### PR TITLE
Python3 support [update]

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1121,7 +1121,7 @@ class CommandLineInterface(object):
             tmpname = os.path.join(os.path.dirname(filename),
                                    tempfile.gettempprefix() +
                                    os.path.basename(filename))
-            tmpfile = open(tmpname, 'w')
+            tmpfile = open(tmpname, 'wb')
             try:
                 try:
                     write_po(tmpfile, catalog,


### PR DESCRIPTION
Without 'b' option, using python3 everybody will get this during update:

bash-3.2$ pybabel update -i messages.pot -d translations
updating catalog 'translations/en/LC_MESSAGES/messages.po' based on 'messages.pot'
Traceback (most recent call last):
  File "/home/user/.pyenv/versions/3.3.2/bin/pybabel", line 9, in <module>
    load_entry_point('Babel==1.3', 'console_scripts', 'pybabel')()
  File "/home/user/.pyenv/versions/3.3.2/lib/python3.3/site-packages/babel/messages/frontend.py", line 1151, in main
    return CommandLineInterface().run(sys.argv)
  File "/home/user/.pyenv/versions/3.3.2/lib/python3.3/site-packages/babel/messages/frontend.py", line 665, in run
    return getattr(self, cmdname)(args[1:])
  File "/home/user/.pyenv/versions/3.3.2/lib/python3.3/site-packages/babel/messages/frontend.py", line 1130, in update
    width=options.width)
  File "/home/user/.pyenv/versions/3.3.2/lib/python3.3/site-packages/babel/messages/pofile.py", line 444, in write_po
    _write(comment_header + u'\n')
  File "/home/user/.pyenv/versions/3.3.2/lib/python3.3/site-packages/babel/messages/pofile.py", line 388, in _write
    fileobj.write(text)
TypeError: must be str, not bytes
