### PR TITLE
Updates a catalog's header to from the template

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -794,6 +794,11 @@ class Catalog(object):
         for msgid in remaining:
             if no_fuzzy_matching or msgid not in fuzzy_matches:
                 self.obsolete[msgid] = remaining[msgid]
+
+        # Allow the updated catalog's header to be rewritten based on the
+        # template's header
+        self.header_comment = template.header_comment
+
         # Make updated catalog's POT-Creation-Date equal to the template
         # used to update the catalog
         self.creation_date = template.creation_date


### PR DESCRIPTION
A language specific catalog's initial header is based on the template
when it is created.  Updates to the template's header were previously
not getting into the catalog during the update_catalog process.

This came from trying to update the copyright holder in the 
[Keystone project](https://git.openstack.org/cgit/openstack/keystone).  I had to edit the generated .po files by hand since the headers were not being updated.