### PR TITLE
Fix bug of unsuitable type in Python 3.

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -385,7 +385,11 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
     def _write(text):
         if isinstance(text, text_type):
             text = text.encode(catalog.charset, 'backslashreplace')
-        fileobj.write(text)
+        try:
+            fileobj.write(text)
+        except TypeError:
+            text = text.decode()
+            fileobj.write(text)
 
     def _write_comment(comment, prefix=''):
         # xgettext always wraps comments even if --no-wrap is passed;


### PR DESCRIPTION
Hi mitsuhiko

This is my fix for a bug I found.

This is the log of that bug (with 3 lines of my additional `print`)

```
b <class 'str'>
a <class 'bytes'>
fileobj <_io.TextIOWrapper name='puppysplash/translations/fr/LC_MESSAGES/tmpmessages.po' mode='w' encoding='UTF-8'>
Traceback (most recent call last):
  File "/home/hongquan/Works/Envs/puppy3/bin/pybabel", line 9, in <module>
    load_entry_point('Babel==1.3', 'console_scripts', 'pybabel')()
  File "/home/hongquan/Works/Envs/puppy3/lib/python3.3/site-packages/babel/messages/frontend.py", line 1151, in main
    return CommandLineInterface().run(sys.argv)
  File "/home/hongquan/Works/Envs/puppy3/lib/python3.3/site-packages/babel/messages/frontend.py", line 665, in run
    return getattr(self, cmdname)(args[1:])
  File "/home/hongquan/Works/Envs/puppy3/lib/python3.3/site-packages/babel/messages/frontend.py", line 1130, in update
    width=options.width)
  File "/home/hongquan/Works/Envs/puppy3/lib/python3.3/site-packages/babel/messages/pofile.py", line 447, in write_po
    _write(comment_header + u'\n')
  File "/home/hongquan/Works/Envs/puppy3/lib/python3.3/site-packages/babel/messages/pofile.py", line 391, in _write
    fileobj.write(text)
TypeError: must be str, not bytes

```
