### PR TITLE
Correctly parse number pattern with '-' on the end

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -389,7 +389,7 @@ def parse_decimal(string, locale=LC_NUMERIC):
 
 
 PREFIX_END = r'[^0-9@#.,]'
-NUMBER_TOKEN = r'[0-9@#.\-,E+]'
+NUMBER_TOKEN = r'[0-9@#.,E+]'
 
 PREFIX_PATTERN = r"(?P<prefix>(?:'[^']*'|%s)*)" % PREFIX_END
 NUMBER_PATTERN = r"(?P<number>%s+)" % NUMBER_TOKEN

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -213,6 +213,7 @@ def test_get_plus_sign_symbol():
 
 def test_get_minus_sign_symbol():
     assert numbers.get_minus_sign_symbol('en_US') == u'-'
+    assert numbers.get_minus_sign_symbol('nl_NL') == u'-'
 
 
 def test_get_exponential_symbol():
@@ -247,6 +248,8 @@ def test_format_currency():
     assert (numbers.format_currency(1099.98, 'EUR', u'\xa4\xa4 #,##0.00',
                                     locale='en_US')
             == u'EUR 1,099.98')
+    assert (numbers.format_currency(1099.98, 'EUR', locale='nl_NL')
+            != numbers.format_currency(-1099.98, 'EUR', locale='nl_NL'))
 
 
 def test_format_percent():
@@ -298,3 +301,8 @@ def test_parse_grouping():
     assert numbers.parse_grouping('##') == (1000, 1000)
     assert numbers.parse_grouping('#,###') == (3, 3)
     assert numbers.parse_grouping('#,####,###') == (3, 4)
+
+
+def test_parse_pattern():
+    assert numbers.parse_pattern(u'¤#,##0.00;(¤#,##0.00)').suffix == (u'', u')')
+    assert numbers.parse_pattern(u'¤ #,##0.00;¤ #,##0.00-').suffix == (u'', u'-')


### PR DESCRIPTION
For the nl_NL locale, negative numbers would be formatted just like
positive numbers by format_currency. By changing NUMBER_TOKEN to
no longer have a minus sign in it, the minus sign on the end
of the negative pattern for nl_NL is correctly parsed.
