### PR TITLE
Add links from changelog entries to their ticket via extlink

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,7 +30,7 @@ Version 1.3
 - Fixed a bug in likely-subtag resolving for some common locales.
   This primarily makes ``zh_CN`` work again which was broken
   due to how it was defined in the likely subtags combined with
-  our broken resolving.  This fixes #37.
+  our broken resolving.  This fixes :gh:`37`.
 - Fixed a bug that caused pybabel to break when writing to stdout
   on Python 3.
 - Removed a stray print that was causing issues when writing to
@@ -65,8 +65,8 @@ Version 1.0
 - use tox for testing on different pythons
 - Added support for the locale plural rules defined by the CLDR.
 - Added `format_timedelta` function to support localized formatting of
-  relative times with strings such as "2 days" or "1 month" (ticket #126).
-- Fixed negative offset handling of Catalog._set_mime_headers (ticket #165).
+  relative times with strings such as "2 days" or "1 month" (:trac:`126`).
+- Fixed negative offset handling of Catalog._set_mime_headers (:trac:`165`).
 - Fixed the case where messages containing square brackets would break with
   an unpack error.
 - updated to CLDR 23
@@ -74,52 +74,56 @@ Version 1.0
 - Fix various typos.
 - Sort output of list-locales.
 - Make the POT-Creation-Date of the catalog being updated equal to
-  POT-Creation-Date of the template used to update (ticket #148).
+  POT-Creation-Date of the template used to update (:trac:`148`).
 - Use a more explicit error message if no option or argument (command) is
-  passed to pybabel (ticket #81).
-- Keep the PO-Revision-Date if it is not the default value (ticket #148).
+  passed to pybabel (:trac:`81`).
+- Keep the PO-Revision-Date if it is not the default value (:trac:`148`).
 - Make --no-wrap work by reworking --width's default and mimic xgettext's
-  behaviour of always wrapping comments (ticket #145).
-- Add --project and --version options for commandline (ticket #173).
+  behaviour of always wrapping comments (:trac:`145`).
+- Add --project and --version options for commandline (:trac:`173`).
 - Add a __ne__() method to the Local class.
 - Explicitly sort instead of using sorted() and don't assume ordering
   (Jython compatibility).
 - Removed ValueError raising for string formatting message checkers if the
-  string does not contain any string formattings (ticket #150).
-- Fix Serbian plural forms (ticket #213).
-- Small speed improvement in format_date() (ticket #216).
+  string does not contain any string formattings (:trac:`150`).
+- Fix Serbian plural forms (:trac:`213`).
+- Small speed improvement in format_date() (:trac:`216`).
 - Fix so frontend.CommandLineInterface.run does not accumulate logging 
-  handlers (#227, reported with initial patch by dfraser)
-- Fix exception if environment contains an invalid locale setting (#200)
-- use cPickle instead of pickle for better performance (#225)
+  handlers (:trac:`227`, reported with initial patch by dfraser)
+- Fix exception if environment contains an invalid locale setting
+  (:trac:`200`)
+- use cPickle instead of pickle for better performance (:trac:`225`)
 - Only use bankers round algorithm as a tie breaker if there are two nearest
-  numbers, round as usual if there is only one nearest number (#267, patch by 
-  Martin)
-- Allow disabling cache behaviour in LazyProxy (#208, initial patch from Pedro 
-  Algarvio)
-- Support for context-aware methods during message extraction (#229, patch
-  from David Rios)
-- "init" and "update" commands support "--no-wrap" option (#289)
+  numbers, round as usual if there is only one nearest number (:trac:`267`,
+  patch by Martin)
+- Allow disabling cache behaviour in LazyProxy (:trac:`208`, initial patch
+  from Pedro Algarvio)
+- Support for context-aware methods during message extraction (:trac:`229`,
+  patch from David Rios)
+- "init" and "update" commands support "--no-wrap" option (:trac:`289`)
 - fix formatting of fraction in format_decimal() if the input value is a float
-  with more than 7 significant digits (#183)
-- fix format_date() with datetime parameter (#282, patch from Xavier Morel)
-- fix format_decimal() with small Decimal values (#214, patch from George Lund)
-- fix handling of messages containing '\\n' (#198)
-- handle irregular multi-line msgstr (no "" as first line) gracefully (#171)
-- parse_decimal() now returns Decimals not floats, API change (#178)
-- no warnings when running setup.py without installed setuptools (#262)
+  with more than 7 significant digits (:trac:`183`)
+- fix format_date() with datetime parameter (:trac:`282`, patch from Xavier
+  Morel)
+- fix format_decimal() with small Decimal values (:trac:`214`, patch from
+  George Lund)
+- fix handling of messages containing '\\n' (:trac:`198`)
+- handle irregular multi-line msgstr (no "" as first line) gracefully
+  (:trac:`171`)
+- parse_decimal() now returns Decimals not floats, API change (:trac:`178`)
+- no warnings when running setup.py without installed setuptools (:trac:`262`)
 - modified Locale.__eq__ method so Locales are only equal if all of their
   attributes (language, territory, script, variant) are equal
-- resort to hard-coded message extractors/checkers if pkg_resources is 
-  installed but no egg-info was found (#230)
-- format_time() and format_datetime() now accept also floats (#242)
+- resort to hard-coded message extractors/checkers if pkg_resources is
+  installed but no egg-info was found (:trac:`230`)
+- format_time() and format_datetime() now accept also floats (:trac:`242`)
 - add babel.support.NullTranslations class similar to gettext.NullTranslations
-  but with all of Babel's new gettext methods (#277)
-- "init" and "update" commands support "--width" option (#284)
-- fix 'input_dirs' option for setuptools integration (#232, initial patch by 
-  Étienne Bersac)
-- ensure .mo file header contains the same information as the source .po file 
-  (#199)
+  but with all of Babel's new gettext methods (:trac:`277`)
+- "init" and "update" commands support "--width" option (:trac:`284`)
+- fix 'input_dirs' option for setuptools integration (:trac:`232`, initial
+  patch by Étienne Bersac)
+- ensure .mo file header contains the same information as the source .po file
+  (:trac:`199`)
 - added support for get_language_name() on the locale objects.
 - added support for get_territory_name() on the locale objects.
 - added support for get_script_name() on the locale objects.
@@ -143,31 +147,32 @@ Version 0.9.6
 - Backport r493-494: documentation typo fixes.
 - Make the CLDR import script work with Python 2.7.
 - Fix various typos.
-- Fixed Python 2.3 compatibility (ticket #146, #233).
+- Fixed Python 2.3 compatibility (:trac:`146`, :trac:`233`).
 - Sort output of list-locales.
 - Make the POT-Creation-Date of the catalog being updated equal to
-  POT-Creation-Date of the template used to update (ticket #148).
+  POT-Creation-Date of the template used to update (:trac:`148`).
 - Use a more explicit error message if no option or argument (command) is
-  passed to pybabel (ticket #81).
-- Keep the PO-Revision-Date if it is not the default value (ticket #148).
+  passed to pybabel (:trac:`81`).
+- Keep the PO-Revision-Date if it is not the default value (:trac:`148`).
 - Make --no-wrap work by reworking --width's default and mimic xgettext's
-  behaviour of always wrapping comments (ticket #145).
-- Fixed negative offset handling of Catalog._set_mime_headers (ticket #165).
-- Add --project and --version options for commandline (ticket #173).
+  behaviour of always wrapping comments (:trac:`145`).
+- Fixed negative offset handling of Catalog._set_mime_headers (:trac:`165`).
+- Add --project and --version options for commandline (:trac:`173`).
 - Add a __ne__() method to the Local class.
 - Explicitly sort instead of using sorted() and don't assume ordering
   (Python 2.3 and Jython compatibility).
 - Removed ValueError raising for string formatting message checkers if the
-  string does not contain any string formattings (ticket #150).
-- Fix Serbian plural forms (ticket #213).
-- Small speed improvement in format_date() (ticket #216).
+  string does not contain any string formattings (:trac:`150`).
+- Fix Serbian plural forms (:trac:`213`).
+- Small speed improvement in format_date() (:trac:`216`).
 - Fix number formatting for locales where CLDR specifies alt or draft 
-  items (ticket #217)
-- Fix bad check in format_time (ticket #257, reported with patch and tests by 
+  items (:trac:`217`)
+- Fix bad check in format_time (:trac:`257`, reported with patch and tests by
   jomae)
 - Fix so frontend.CommandLineInterface.run does not accumulate logging 
-  handlers (#227, reported with initial patch by dfraser)
-- Fix exception if environment contains an invalid locale setting (#200)
+  handlers (:trac:`227`, reported with initial patch by dfraser)
+- Fix exception if environment contains an invalid locale setting
+  (:trac:`200`)
 
 
 Version 0.9.5
@@ -179,7 +184,7 @@ Version 0.9.5
   an unpack error.
 - Backport of r467: Fuzzy matching regarding plurals should *NOT* be checked
   against len(message.id)  because this is always 2, instead, it's should be
-  checked against catalog.num_plurals (ticket #212).
+  checked against catalog.num_plurals (:trac:`212`).
 
 
 Version 0.9.4
@@ -191,17 +196,17 @@ Version 0.9.4
   CLDR data are no longer imported, so the symbol code will be used instead.
 - Fixed quarter support in date formatting.
 - Fixed a serious memory leak that was introduces by the support for CLDR
-  aliases in 0.9.3 (ticket #128).
+  aliases in 0.9.3 (:trac:`128`).
 - Locale modifiers such as "@euro" are now stripped from locale identifiers
-  when parsing (ticket #136).
+  when parsing (:trac:`136`).
 - The system locales "C" and "POSIX" are now treated as aliases for
   "en_US_POSIX", for which the CLDR provides the appropriate data. Thanks to
   Manlio Perillo for the suggestion.
-- Fixed JavaScript extraction for regular expression literals (ticket #138)
+- Fixed JavaScript extraction for regular expression literals (:trac:`138`)
   and concatenated strings.
 - The `Translation` class in `babel.support` can now manage catalogs with
   different message domains, and exposes the family of `d*gettext` functions
-  (ticket #137).
+  (:trac:`137`).
 
 
 Version 0.9.3
@@ -211,11 +216,11 @@ Version 0.9.3
 
 - Fixed invalid message extraction methods causing an UnboundLocalError.
 - Extraction method specification can now use a dot instead of the colon to
-  separate module and function name (ticket #105).
+  separate module and function name (:trac:`105`).
 - Fixed message catalog compilation for locales with more than two plural
-  forms (ticket #95).
+  forms (:trac:`95`).
 - Fixed compilation of message catalogs for locales with more than two plural
-  forms where the translations were empty (ticket #97).
+  forms where the translations were empty (:trac:`97`).
 - The stripping of the comment tags in comments is optional now and
   is done for each line in a comment.
 - Added a JavaScript message extractor.
@@ -225,7 +230,7 @@ Version 0.9.3
   correct plural forms for a locale as tuple.
 - Added support for alias definitions in the CLDR data files, meaning that
   the chance for items missing in certain locales should be greatly reduced
-  (ticket #68).
+  (:trac:`68`).
 
 
 Version 0.9.2
@@ -233,15 +238,15 @@ Version 0.9.2
 
 (released on February 4th 2008)
 
-- Fixed catalogs' charset values not being recognized (ticket #66).
+- Fixed catalogs' charset values not being recognized (:trac:`66`).
 - Numerous improvements to the default plural forms.
-- Fixed fuzzy matching when updating message catalogs (ticket #82).
+- Fixed fuzzy matching when updating message catalogs (:trac:`82`).
 - Fixed bug in catalog updating, that in some cases pulled in translations
   from different catalogs based on the same template.
 - Location lines in PO files do no longer get wrapped at hyphens in file
-  names (ticket #79).
+  names (:trac:`79`).
 - Fixed division by zero error in catalog compilation on empty catalogs
-  (ticket #60).
+  (:trac:`60`).
 
 
 Version 0.9.1
@@ -254,7 +259,7 @@ Version 0.9.1
   `ngettext`, or vice versa.
 - Fixed time formatting for 12 am and 12 pm.
 - Fixed output encoding of the `pybabel --list-locales` command.
-- MO files are now written in binary mode on windows (ticket #61).
+- MO files are now written in binary mode on windows (:trac:`61`).
 
 
 Version 0.9
@@ -264,23 +269,24 @@ Version 0.9
 
 - The `new_catalog` distutils command has been renamed to `init_catalog` for
   consistency with the command-line frontend.
-- Added compilation of message catalogs to MO files (ticket #21).
-- Added updating of message catalogs from POT files (ticket #22).
+- Added compilation of message catalogs to MO files (:trac:`21`).
+- Added updating of message catalogs from POT files (:trac:`22`).
 - Support for significant digits in number formatting.
 - Apply proper "banker's rounding" in number formatting in a cross-platform
   manner.
 - The number formatting functions now also work with numbers represented by
-  Python `Decimal` objects (ticket #53).
+  Python `Decimal` objects (:trac:`53`).
 - Added extensible infrastructure for validating translation catalogs.
 - Fixed the extractor not filtering out messages that didn't validate against
-  the keyword's specification (ticket #39).
+  the keyword's specification (:trac:`39`).
 - Fixed the extractor raising an exception when encountering an empty string
   msgid. It now emits a warning to stderr.
 - Numerous Python message extractor fixes: it now handles nested function
   calls within a gettext function call correctly, uses the correct line number
-  for multi-line function calls, and other small fixes (tickets #38 and #39).
+  for multi-line function calls, and other small fixes (tickets :trac:`38` and
+  :trac:`39`).
 - Improved support for detecting Python string formatting fields in message
-  strings (ticket #57).
+  strings (:trac:`57`).
 - CLDR upgraded to the 1.5 release.
 - Improved timezone formatting.
 - Implemented scientific number formatting.
@@ -302,21 +308,21 @@ Version 0.8.1
   that way.
 - The character set specified in PO template files is now respected when
   creating new catalog files based on that template. This allows the use of
-  characters outside the ASCII range in POT files (ticket #17).
+  characters outside the ASCII range in POT files (:trac:`17`).
 - The default ordering of messages in generated POT files, which is based on
   the order those messages are found when walking the source tree, is no
   longer subject to differences between platforms; directory and file names
   are now always sorted alphabetically.
 - The Python message extractor now respects the special encoding comment to be
-  able to handle files containing non-ASCII characters (ticket #23).
+  able to handle files containing non-ASCII characters (:trac:`23`).
 - Added ``N_`` (gettext noop) to the extractor's default keywords.
 - Made locale string parsing more robust, and also take the script part into
-  account (ticket #27).
+  account (:trac:`27`).
 - Added a function to list all locales for which locale data is available.
 - Added a command-line option to the `pybabel` command which prints out all
-  available locales (ticket #24).
+  available locales (:trac:`24`).
 - The name of the command-line script has been changed from just `babel` to
-  `pybabel` to avoid a conflict with the OpenBabel project (ticket #34).
+  `pybabel` to avoid a conflict with the OpenBabel project (:trac:`34`).
 
 
 Version 0.8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,8 @@ sys.path.append(os.path.abspath('_themes'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.intersphinx']
+              'sphinx.ext.intersphinx',
+              'sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -253,4 +254,9 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     'http://docs.python.org/2': None,
+}
+
+extlinks = {
+    'gh': ('https://github.com/mitsuhiko/babel/issues/%s', '#'),
+    'trac': ('http://babel.edgewall.org/ticket/%s', 'ticket #'),
 }


### PR DESCRIPTION
The changelog currently informally references an entry's ticket/issue.
- Because the changelog is now used in the Sphinx/HTML documentation hyperlinks are possible
- Because issues are now spread over two trackers (old issues in trac and new ones on github) having the same informal style will probably be confusing for readers of the documentation.

Sphinx's extlinks can be used to unambiguously link changelog entries to their issue without being significantly more verbose than the informal version (it's slightly less verbose for historical trac refs, quite a bit more for github refs). The extlink prefixes were configured to keep the final rendering similar to the original.
