### PR TITLE
merge method fails on Python 3

### DIFF
--- a/babel/support.py
+++ b/babel/support.py
@@ -587,6 +587,6 @@ class Translations(NullTranslations, gettext.GNUTranslations):
         if isinstance(translations, gettext.GNUTranslations):
             self._catalog.update(translations._catalog)
             if isinstance(translations, Translations):
-                self.files.extend(translations.files)
-
+                lst = (list(self.files)).extend(list(translations.files))
+                self.files = filter(None, lst)
         return self


### PR DESCRIPTION
Could you please apply this merge or correct this problem, i'm having the following error on Python 3.3

File "XXXXXX/lib/python3.3/site-packages/Babel-1.3-py3.3.egg/babel/support.py", line 590, in merge
    self.files.extend(translations.files)
AttributeError: 'filter' object has no attribute 'extend'

Filter in python 3 return iterators, so there is no extend method.

Thanks!