### PR TITLE
read in text mode, not binary

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -128,7 +128,7 @@ class compile_catalog(Command):
 
         for idx, (locale, po_file) in enumerate(po_files):
             mo_file = mo_files[idx]
-            infile = open(po_file, 'rb')
+            infile = open(po_file, 'r')
             try:
                 catalog = read_po(infile, locale)
             finally:
@@ -439,7 +439,7 @@ class init_catalog(Command):
         log.info('creating catalog %r based on %r', self.output_file,
                  self.input_file)
 
-        infile = open(self.input_file, 'rb')
+        infile = open(self.input_file, 'r')
         try:
             # Although reading from the catalog template, read_po must be fed
             # the locale in order to correctly calculate plurals
@@ -554,7 +554,7 @@ class update_catalog(Command):
         if not domain:
             domain = os.path.splitext(os.path.basename(self.input_file))[0]
 
-        infile = open(self.input_file, 'rb')
+        infile = open(self.input_file, 'r')
         try:
             template = read_po(infile)
         finally:
@@ -566,7 +566,7 @@ class update_catalog(Command):
         for locale, filename in po_files:
             log.info('updating catalog %r based on %r', filename,
                      self.input_file)
-            infile = open(filename, 'rb')
+            infile = open(filename, 'r')
             try:
                 catalog = read_po(infile, locale=locale, domain=domain)
             finally:
@@ -760,7 +760,7 @@ class CommandLineInterface(object):
 
         for idx, (locale, po_file) in enumerate(po_files):
             mo_file = mo_files[idx]
-            infile = open(po_file, 'rb')
+            infile = open(po_file, 'r')
             try:
                 catalog = read_po(infile, locale)
             finally:


### PR DESCRIPTION
Read text files as binary it generally bad idea (and write too, but now using wb is shortest way for avoid problems while writing encoded text in python3). For example it affects regular expr. matching in third-party extractors for whitespace in windows platform.
