### PR TITLE
Added territory-language import from CLDR.

### DIFF
--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -145,6 +145,7 @@ def main():
         territory_currencies = global_data.setdefault('territory_currencies', {})
         parent_exceptions = global_data.setdefault('parent_exceptions', {})
         currency_fractions = global_data.setdefault('currency_fractions', {})
+        territory_languages = global_data.setdefault('territory_languages', {})
 
         # create auxiliary zone->territory map from the windows zones (we don't set
         # the 'zones_territories' map directly here, because there are some zones
@@ -237,6 +238,16 @@ def main():
             cur_cdigits = int(fraction.attrib.get('cashDigits', cur_digits))
             cur_crounding = int(fraction.attrib.get('cashRounding', cur_rounding))
             currency_fractions[cur_code] = (cur_digits, cur_rounding, cur_cdigits, cur_crounding)
+
+        # Languages in territories
+        for territory in sup.findall('.//territoryInfo/territory'):
+            languages = {}
+            for language in territory.findall('./languagePopulation'):
+                languages[language.attrib['type']] = {
+                    'population_percent': float(language.attrib['populationPercent']),
+                    'official_status': language.attrib.get('officialStatus'),
+                }
+            territory_languages[territory.attrib['type']] = languages
 
         outfile = open(global_path, 'wb')
         try:


### PR DESCRIPTION
Available in the global data onder the 'territory_language' key. For example, for NL this looks like:

```
{'en': {'official_status': None, 'population_percent': 74.0},
 'fy': {'official_status': 'official_regional', 'population_percent': 4.3},
 'gos': {'official_status': None, 'population_percent': 3.6},
 'id': {'official_status': None, 'population_percent': 1.8},
 'li': {'official_status': None, 'population_percent': 5.5},
 'nl': {'official_status': 'official', 'population_percent': 100.0},
 'rif': {'official_status': None, 'population_percent': 1.2},
 'tr': {'official_status': None, 'population_percent': 1.2},
 'zea': {'official_status': None, 'population_percent': 1.4}
}
```

Source from the CLDR is: http://www.unicode.org/cldr/charts/latest/supplemental/territory_language_information.html