### PR TITLE
Documented all valid keys for get_global()

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -43,6 +43,11 @@ def get_global(key):
     >>> get_global('zone_territories')['Europe/Berlin']
     u'DE'
 
+    The keys available are ``currency_fractions``, ``language_aliases``, ``likely_subtags``,
+    ``parent_exceptions``, ``script_aliases``, ``territory_aliases``, ``territory_currencies``,
+    ``territory_languages``, ``territory_zones``, ``variant_aliases``, ``win_mapping``,
+    ``zone_aliases`` and ``zone_territories``.
+
     .. versionadded:: 0.9
 
     :param key: the data key


### PR DESCRIPTION
This adds a simple list of all valid keys for `get_global()` to the documentation. I've already included the `territory_languages` key, which is introduced in PR #122.