### PR TITLE
Use currency fraction information

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Version 2.2
 
 - Upgraded data to CLDR 26
 - Add official support for Python 3.4
+- Use the CLDR recommended amount of decimal digits when formatting
+  currencies (https://github.com/python-babel/babel/issues/139)
 
 Version 2.1
 -----------

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -602,7 +602,8 @@ class NumberPattern(object):
     def __repr__(self):
         return '<%s %r>' % (type(self).__name__, self.pattern)
 
-    def apply(self, value, locale, currency=None):
+    def apply(self, value, locale, currency=None, force_frac=None):
+        frac_prec = force_frac or self.frac_prec
         if isinstance(value, float):
             value = Decimal(str(value))
         value *= self.scale
@@ -632,8 +633,7 @@ class NumberPattern(object):
                 exp_sign = get_plus_sign_symbol(locale)
             exp = abs(exp)
             number = u'%s%s%s%s' % \
-                 (self._format_sigdig(value, self.frac_prec[0],
-                                     self.frac_prec[1]),
+                 (self._format_sigdig(value, frac_prec[0], frac_prec[1]),
                   get_exponential_symbol(locale),  exp_sign,
                   self._format_int(str(exp), self.exp_prec[0],
                                    self.exp_prec[1], locale))
@@ -650,12 +650,11 @@ class NumberPattern(object):
             else:
                 number = self._format_int(text, 0, 1000, locale)
         else: # A normal number pattern
-            a, b = split_number(bankersround(abs(value),
-                                             self.frac_prec[1]))
+            a, b = split_number(bankersround(abs(value), frac_prec[1]))
             b = b or '0'
             a = self._format_int(a, self.int_prec[0],
                                  self.int_prec[1], locale)
-            b = self._format_frac(b, locale)
+            b = self._format_frac(b, locale, force_frac)
             number = a + b
         retval = u'%s%s%s' % (self.prefix[is_negative], number,
                                 self.suffix[is_negative])
@@ -705,8 +704,8 @@ class NumberPattern(object):
             gsize = self.grouping[1]
         return value + ret
 
-    def _format_frac(self, value, locale):
-        min, max = self.frac_prec
+    def _format_frac(self, value, locale, force_frac=None):
+        min, max = force_frac or self.frac_prec
         if len(value) < min:
             value += ('0' * (min - len(value)))
         if max == 0 or (min == 0 and int(value) == 0):

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -144,6 +144,7 @@ def main():
         likely_subtags = global_data.setdefault('likely_subtags', {})
         territory_currencies = global_data.setdefault('territory_currencies', {})
         parent_exceptions = global_data.setdefault('parent_exceptions', {})
+        currency_fractions = global_data.setdefault('currency_fractions', {})
 
         # create auxiliary zone->territory map from the windows zones (we don't set
         # the 'zones_territories' map directly here, because there are some zones
@@ -227,6 +228,15 @@ def main():
             parent = paternity.attrib['parent']
             for child in paternity.attrib['locales'].split():
                 parent_exceptions[child] = parent
+
+        # Currency decimal and rounding digits
+        for fraction in sup.findall('.//currencyData/fractions/info'):
+            cur_code = fraction.attrib['iso4217']
+            cur_digits = int(fraction.attrib['digits'])
+            cur_rounding = int(fraction.attrib['rounding'])
+            cur_cdigits = int(fraction.attrib.get('cashDigits', cur_digits))
+            cur_crounding = int(fraction.attrib.get('cashRounding', cur_rounding))
+            currency_fractions[cur_code] = (cur_digits, cur_rounding, cur_cdigits, cur_crounding)
 
         outfile = open(global_path, 'wb')
         try:

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -252,6 +252,17 @@ def test_format_currency():
     assert (numbers.format_currency(1099.98, 'EUR', locale='nl_NL')
             != numbers.format_currency(-1099.98, 'EUR', locale='nl_NL'))
 
+    assert (numbers.format_currency(1099.98, 'JPY', locale='en_US')
+            == u'\xa51,100')
+    assert (numbers.format_currency(1099.98, 'COP', u'#,##0.00', locale='es_ES')
+            == u'1.100')
+    assert (numbers.format_currency(1099.98, 'JPY', locale='en_US',
+                                    currency_digits=False)
+            == u'\xa51,099.98')
+    assert (numbers.format_currency(1099.98, 'COP', u'#,##0.00', locale='es_ES',
+                                    currency_digits=False)
+            == u'1.099,98')
+
 
 def test_format_percent():
     assert numbers.format_percent(0.34, locale='en_US') == u'34%'


### PR DESCRIPTION
This extends pull request #117 to also load the currency fraction information from CLDR supplemental data. Once loaded, it adds an option to babel.numbers.format_currency so the decimal positions deduced from the format pattern can be ignored and replaced by those of the currency, as indicated by such supplemental information.

The API remains backwards compatible.
