### PR TITLE
Respect currency digit settings.

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -278,7 +278,13 @@ def format_currency(number, currency, format=None, locale=LC_NUMERIC):
     locale = Locale.parse(locale)
     if not format:
         format = locale.currency_formats.get(format)
+
+    fractions = get_global('currency_fractions')
+    digits = fractions.get(currency, fractions['DEFAULT'])['digits']
+
     pattern = parse_pattern(format)
+    pattern.frac_prec = (digits, digits)
+
     return pattern.apply(number, locale, currency=currency)
 
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -145,6 +145,7 @@ def main():
         variant_aliases = global_data.setdefault('variant_aliases', {})
         likely_subtags = global_data.setdefault('likely_subtags', {})
         territory_currencies = global_data.setdefault('territory_currencies', {})
+        currency_fractions = global_data.setdefault('currency_fractions', {})
 
         # create auxiliary zone->territory map from the windows zones (we don't set
         # the 'zones_territories' map directly here, because there are some zones
@@ -221,6 +222,13 @@ def main():
                                               'tender', 'true') == 'true'))
             region_currencies.sort(key=_currency_sort_key)
             territory_currencies[region_code] = region_currencies
+
+        # Fractions in currencies
+        for currency in sup.findall('.//currencyData/fractions/info'):
+            currency_code = currency.attrib['iso4217']
+            currency_fractions[currency_code] = {
+                'digits': int(currency.attrib['digits']),
+            }
 
         outfile = open(global_path, 'wb')
         try:

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -251,6 +251,8 @@ def test_format_currency():
             == u'EUR 1,099.98')
     assert (numbers.format_currency(1099.98, 'EUR', locale='nl_NL')
             != numbers.format_currency(-1099.98, 'EUR', locale='nl_NL'))
+    assert (numbers.format_currency(50.00, 'JPY', locale='en_US')
+            == u'\xa550')
 
 
 def test_format_percent():


### PR DESCRIPTION
The supplemental currency data should be respected when
formatting currencies. In particular this means some
currencies should always have a certain number of digits
after the decimal point.

http://www.unicode.org/reports/tr35/tr35-numbers.html#Supplemental_Currency_Data

Conflicts:
	scripts/import_cldr.py
	tests/test_numbers.py

Conflicts:
	scripts/import_cldr.py
	tests/test_numbers.py