### PR TITLE
Add __hash__ to Locale.

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -326,6 +326,9 @@ class Locale(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash((self.language, self.territory, self.script, self.variant))
+
     def __repr__(self):
         parameters = ['']
         for key in ('territory', 'script', 'variant'):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,6 +57,11 @@ def test_get_global():
 
 class TestLocaleClass:
 
+    def test_hash(self):
+        locale_a = Locale('en', 'US')
+        locale_b = Locale('en', 'US')
+        assert hash(locale_a) == hash(locale_b)
+
     def test_repr(self):
         assert repr(Locale('en', 'US')) == "Locale('en', territory='US')"
 


### PR DESCRIPTION
The `Locale` class has `__eq__`, but not `__hash__`. The absence of `__hash__` results in some rather maddening results when trying to use it as a key to `dict`s, and there's no reason not to `__hash__`…