### PR TITLE
Don't set tag_date by default, to avoid the date ending up in the version number

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[egg_info]
-tag_date = true
-
 [aliases]
 release = egg_info -RDb ''
 


### PR DESCRIPTION
I want to be able to build and install Babel with bit-for-bit reproducibility, as part of [the Baserock project's](http://wiki.baserock.org/projects/deterministic-builds/) work on the subject. Including the build date in the version number was preventing Babel from being bit-for-bit reproducible.