### PR TITLE
Fix incorrect test_fractional_seconds

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -158,7 +158,7 @@ class DateTimeFormatTestCase(unittest.TestCase):
     def test_fractional_seconds(self):
         t = time(15, 30, 12, 34567)
         fmt = dates.DateTimeFormat(t, locale='en_US')
-        self.assertEqual('3457', fmt['SSSS'])
+        self.assertEqual('0346', fmt['SSSS'])
 
     def test_fractional_seconds_zero(self):
         t = time(15, 30, 0)


### PR DESCRIPTION
Reopened from https://github.com/mitsuhiko/babel/pull/103
Yes, this is broken on master.
There are two problems:
1. Bug in DateTimeFormat.format_frac_seconds() (https://github.com/mitsuhiko/babel/pull/102)
2. Bug in test_fractional_seconds, which checks format_frac_seconds()
Therefore, the master builds. This pull request fix only test
