### PR TITLE
Fix of losses of significant zeros in DateTimeFormat.format_frac_seconds()

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1029,8 +1029,7 @@ class DateTimeFormat(object):
         return get_period_names(locale=self.locale)[period]
 
     def format_frac_seconds(self, num):
-        value = str(self.value.microsecond)
-        return self.format(round(float('.%s' % value), num) * 10**num, num)
+        return self.format(self.value.microsecond // 10**(6-num), num)
 
     def format_milliseconds_in_day(self, num):
         msecs = self.value.microsecond // 1000 + self.value.second * 1000 + \


### PR DESCRIPTION
Reopened from https://github.com/mitsuhiko/babel/pull/102
Yes, this is broken on master.
There are two problems:
1. Bug in DateTimeFormat.format_frac_seconds()
2. Bug in test_fractional_seconds, which checks format_frac_seconds() (https://github.com/mitsuhiko/babel/pull/103)
This pull request is my option of fix format_frac_seconds() function
