### PR TITLE
Fix the loading of the currency format types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,8 @@ Contributors:
 - Nick Retallack <nick@bitcasa.com>
 - Thomas Waldmann <tw@waldmann-edv.de>
 - Lennart Regebro <regebro@gmail.com>
+- Isaac Jurado <diptongo@gmail.com>
+- Craig Loftus <craig@regulusweb.com>
 
 Babel was previously developed under the Copyright of Edgewall Software.  The
 following copyright notice holds true for releases before 2013: "Copyright (c)

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ Version 2.2
 - Add official support for Python 3.4
 - Use the CLDR recommended amount of decimal digits when formatting
   currencies (https://github.com/python-babel/babel/issues/139)
+- Properly load and use currency format types
+  (https://github.com/python-babel/babel/issues/201)
 
 Version 2.1
 -----------

--- a/babel/core.py
+++ b/babel/core.py
@@ -544,7 +544,9 @@ class Locale(object):
     def currency_formats(self):
         """Locale patterns for currency number formatting.
 
-        >>> print Locale('en', 'US').currency_formats[None]
+        >>> print Locale('en', 'US').currency_formats['standard']
+        <NumberPattern u'\\xa4#,##0.00'>
+        >>> print Locale('en', 'US').currency_formats['accounting']
         <NumberPattern u'\\xa4#,##0.00'>
         """
         return self._data['currency_formats']

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -256,7 +256,7 @@ def format_decimal(number, format=None, locale=LC_NUMERIC):
     return pattern.apply(number, locale)
 
 
-def format_currency(number, currency, format=None, locale=LC_NUMERIC, currency_digits=True):
+def format_currency(number, currency, format='standard', locale=LC_NUMERIC, currency_digits=True):
     u"""Return formatted currency value.
 
     >>> format_currency(1099.98, 'USD', locale='en_US')
@@ -298,9 +298,7 @@ def format_currency(number, currency, format=None, locale=LC_NUMERIC, currency_d
     :param currency_digits: use the currency's number of decimal digits
     """
     locale = Locale.parse(locale)
-    if not format:
-        format = locale.currency_formats.get(format)
-    pattern = parse_pattern(format)
+    pattern = parse_pattern(locale.currency_formats.get(format, format))
     if currency_digits:
         fractions = get_global('currency_fractions')
         try:

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -256,7 +256,12 @@ def format_decimal(number, format=None, locale=LC_NUMERIC):
     return pattern.apply(number, locale)
 
 
-def format_currency(number, currency, format='standard', locale=LC_NUMERIC, currency_digits=True):
+class UnknownCurrencyFormatError(KeyError):
+    """Exception raised when an unknown currency format is requested."""
+
+
+def format_currency(number, currency, format=None, locale=LC_NUMERIC,
+                    currency_digits=True, format_type='standard'):
     u"""Return formatted currency value.
 
     >>> format_currency(1099.98, 'USD', locale='en_US')
@@ -266,7 +271,7 @@ def format_currency(number, currency, format='standard', locale=LC_NUMERIC, curr
     >>> format_currency(1099.98, 'EUR', locale='de_DE')
     u'1.099,98\\xa0\\u20ac'
 
-    The pattern can also be specified explicitly.  The currency is
+    The format can also be specified explicitly.  The currency is
     placed with the '¤' sign.  As the sign gets repeated the format
     expands (¤ being the symbol, ¤¤ is the currency abbreviation and
     ¤¤¤ is the full name of the currency):
@@ -292,13 +297,36 @@ def format_currency(number, currency, format='standard', locale=LC_NUMERIC, curr
     >>> format_currency(1099.98, 'COP', u'#,##0.00', locale='es_ES', currency_digits=False)
     u'1.099,98'
 
+    If a format is not specified the type of currency format to use
+    from the locale can be specified:
+
+    >>> format_currency(1099.98, 'EUR', locale='en_US', format_type='standard')
+    u'\\u20ac1,099.98'
+
+    When the given currency format type is not available, an exception is
+    raised:
+
+    >>> format_currency('1099.98', 'EUR', locale='root', format_type='unknown')
+    Traceback (most recent call last):
+        ...
+    UnknownCurrencyFormatError: "'unknown' is not a known currency format type"
+
     :param number: the number to format
     :param currency: the currency code
+    :param format: the format string to use
     :param locale: the `Locale` object or locale identifier
     :param currency_digits: use the currency's number of decimal digits
+    :param format_type: the currency format type to use
     """
     locale = Locale.parse(locale)
-    pattern = parse_pattern(locale.currency_formats.get(format, format))
+    if format:
+        pattern = parse_pattern(format)
+    else:
+        try:
+            pattern = locale.currency_formats[format_type]
+        except KeyError:
+            raise UnknownCurrencyFormatError("%r is not a known currency format"
+                                             " type" % format_type)
     if currency_digits:
         fractions = get_global('currency_fractions')
         try:

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -586,13 +586,20 @@ def main():
                 numbers.parse_pattern(pattern)
 
         currency_formats = data.setdefault('currency_formats', {})
-        for elem in tree.findall('.//currencyFormats/currencyFormatLength'):
+        for elem in tree.findall('.//currencyFormats/currencyFormatLength/currencyFormat'):
             if ('draft' in elem.attrib or 'alt' in elem.attrib) \
                     and elem.attrib.get('type') in currency_formats:
                 continue
-            pattern = text_type(elem.findtext('currencyFormat/pattern'))
-            currency_formats[elem.attrib.get('type')] = \
-                numbers.parse_pattern(pattern)
+            for child in elem.getiterator():
+                if child.tag == 'alias':
+                    currency_formats[elem.attrib.get('type')] = Alias(
+                        _translate_alias(['currency_formats', elem.attrib['type']],
+                                         child.attrib['path'])
+                    )
+                elif child.tag == 'pattern':
+                    pattern = text_type(child.text)
+                    currency_formats[elem.attrib.get('type')] = \
+                        numbers.parse_pattern(pattern)
 
         percent_formats = data.setdefault('percent_formats', {})
         for elem in tree.findall('.//percentFormats/percentFormatLength'):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -157,7 +157,9 @@ class TestLocaleClass:
         assert Locale('en', 'US').decimal_formats[None].pattern == '#,##0.###'
 
     def test_currency_formats_property(self):
-        assert (Locale('en', 'US').currency_formats[None].pattern ==
+        assert (Locale('en', 'US').currency_formats['standard'].pattern ==
+                u'\xa4#,##0.00')
+        assert (Locale('en', 'US').currency_formats['accounting'].pattern ==
                 u'\xa4#,##0.00')
 
     def test_percent_formats_property(self):

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -251,6 +251,24 @@ def test_format_currency():
             == u'EUR 1,099.98')
     assert (numbers.format_currency(1099.98, 'EUR', locale='nl_NL')
             != numbers.format_currency(-1099.98, 'EUR', locale='nl_NL'))
+    assert (numbers.format_currency(1099.98, 'USD', format=None,
+                                    locale='en_US')
+            == u'$1,099.98')
+
+
+def test_format_currency_format_type():
+    assert (numbers.format_currency(1099.98, 'USD', locale='en_US',
+                                    format_type="standard")
+            == u'$1,099.98')
+
+    assert (numbers.format_currency(1099.98, 'USD', locale='en_US',
+                                    format_type="accounting")
+            == u'$1,099.98')
+
+    with pytest.raises(numbers.UnknownCurrencyFormatError) as excinfo:
+        numbers.format_currency(1099.98, 'USD', locale='en_US',
+                                    format_type='unknown')
+    assert excinfo.value.args[0] == "'unknown' is not a known currency format type"
 
     assert (numbers.format_currency(1099.98, 'JPY', locale='en_US')
             == u'\xa51,100')


### PR DESCRIPTION
In order to fix #201, it was necessary to properly interpret the `type` attribute of the `currencyFormat` elements in CLDR data.  It apparently changed between version 23 and 26.