### PR TITLE
BACKPORT: docs: Change repository adress

### DIFF
--- a/README
+++ b/README
@@ -10,3 +10,5 @@ Details can be found in the HTML files in the `docs` folder.
 For more information please visit the Babel web site:
 
   <http://babel.pocoo.org/>
+
+Join the chat at https://gitter.im/python-babel/babel

--- a/docs/_templates/sidebar-links.html
+++ b/docs/_templates/sidebar-links.html
@@ -10,6 +10,6 @@
 <ul>
   <li><a href="http://babel.pocoo.org/">Babel Website</a></li>
   <li><a href="http://pypi.python.org/pypi/Babel">Babel @ PyPI</a></li>
-  <li><a href="http://github.com/mitsuhiko/babel">Babel @ github</a></li>
-  <li><a href="http://github.com/mitsuhiko/babel/issues">Issue Tracker</a></li>
+  <li><a href="http://github.com/python-babel/babel">Babel @ github</a></li>
+  <li><a href="http://github.com/python-babel/babel/issues">Issue Tracker</a></li>
 </ul>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,6 +257,6 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'gh': ('https://github.com/mitsuhiko/babel/issues/%s', '#'),
+    'gh': ('https://github.com/python-babel/babel/issues/%s', '#'),
     'trac': ('http://babel.edgewall.org/ticket/%s', 'ticket #'),
 }

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,7 +80,7 @@ use a git checkout.
 
 Get the git checkout in a new virtualenv and run in development mode::
 
-    $ git clone http://github.com/mitsuhiko/babel.git
+    $ git clone http://github.com/python-babel/babel.git
     Initialized empty Git repository in ~/dev/babel/.git/
     $ cd babel
     $ virtualenv venv


### PR DESCRIPTION
The repository moved.

Backport version of https://github.com/python-babel/babel/pull/231