### PR TITLE
Fix zh plural selection

### DIFF
--- a/babel/messages/plurals.py
+++ b/babel/messages/plurals.py
@@ -192,10 +192,8 @@ PLURALS = {
     'vi': (1, '0'),
     # Xhosa - From Pootle's PO's
     'xh': (2, '(n != 1)'),
-    # Chinese - From Pootle's PO's
-    'zh_CN': (1, '0'),
-    'zh_HK': (1, '0'),
-    'zh_TW': (1, '0'),
+    # Chinese - From Pootle's PO's (modified)
+    'zh': (1, '0'),
 }
 
 

--- a/tests/messages/test_plurals.py
+++ b/tests/messages/test_plurals.py
@@ -10,17 +10,34 @@
 # This software consists of voluntary contributions made by many
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
+import pytest
 
-import doctest
-import unittest
-
+from babel import Locale
 from babel.messages import plurals
 
 
-def test_get_plural():
-    assert plurals.get_plural(locale='en') == (2, '(n != 1)')
+@pytest.mark.parametrize(('locale', 'num_plurals', 'plural_expr'), [
+    (Locale('en'), 2, '(n != 1)'),
+    (Locale('en', 'US'), 2, '(n != 1)'),
+    (Locale('zh'), 1, '0'),
+    (Locale('zh', script='Hans'), 1, '0'),
+    (Locale('zh', script='Hant'), 1, '0'),
+    (Locale('zh', 'CN', 'Hans'), 1, '0'),
+    (Locale('zh', 'TW', 'Hant'), 1, '0'),
+])
+def test_get_plural_selection(locale, num_plurals, plural_expr):
+    assert plurals.get_plural(locale) == (num_plurals, plural_expr)
+
+
+def test_get_plural_accpets_strings():
     assert plurals.get_plural(locale='ga') == (3, '(n==1 ? 0 : n==2 ? 1 : 2)')
 
+
+def test_get_plural_falls_back_to_default():
+    assert plurals.get_plural('aa') == (2, '(n != 1)')
+
+
+def test_plural_tuple_attributes():
     tup = plurals.get_plural("ja")
     assert tup.num_plurals == 1
     assert tup.plural_expr == '0'


### PR DESCRIPTION
Provide only one option for chinese in the plural data. The 3 previous options were all the same and I've checked with a chinese colleague she thinks that applies to all variants on the chinese language. 

Before this change things like ```get_plurals('zh_CN')``` would return the default plural rules because that string would get expanded out to ```Locale('zh', 'CN', 'Hans')``` with string representation ```"zh_Hans_CH"```, which isn't in the table. 

I feel like this is side stepping the underlying issue that the way that this table is searched isn't very flexible, but I thought it might be a pragmatic improvement.