### PR TITLE
Extract a format_date_with_time helper function

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -569,6 +569,23 @@ def format_date(date=None, format='medium', locale=LC_TIME):
     return pattern.apply(date, locale)
 
 
+def format_date_with_time(date, time, format='medium', locale=LC_TIME):
+    r"""Combines a pre-formatted date and time in to a single string
+
+    >>> format_date_with_time("20/8/15", "14:40", locale='en')
+    u'20/8/15, 14:40'
+    >>> format_date_with_time("20/8/15", "14:40", 'long', 'en')
+    u'20/8/15 at 14:40'
+    >>> format_date_with_time("20/8/15", "14:40", 'long', 'de')
+    u'20/8/15 um 14:40'
+
+    """
+    return get_datetime_format(format, locale=locale) \
+        .replace("'", "") \
+        .replace('{0}', time) \
+        .replace('{1}', date)
+
+
 def format_datetime(datetime=None, format='medium', tzinfo=None,
                     locale=LC_TIME):
     r"""Return a date formatted according to the given pattern.
@@ -609,11 +626,12 @@ def format_datetime(datetime=None, format='medium', tzinfo=None,
 
     locale = Locale.parse(locale)
     if format in ('full', 'long', 'medium', 'short'):
-        return get_datetime_format(format, locale=locale) \
-            .replace("'", "") \
-            .replace('{0}', format_time(datetime, format, tzinfo=None,
-                                        locale=locale)) \
-            .replace('{1}', format_date(datetime, format, locale=locale))
+        return format_date_with_time(
+            format_date(datetime, format, locale=locale),
+            format_time(datetime, format, tzinfo=None, locale=locale),
+            format,
+            locale,
+        )
     else:
         return parse_pattern(format).apply(datetime, locale)
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -458,6 +458,12 @@ def test_format_date():
             u"Sun, Apr 1, '07")
 
 
+def test_format_date_with_time():
+    assert dates.format_date_with_time("20/8/15", "14:40", locale='en') == u'20/8/15, 14:40'
+    assert dates.format_date_with_time("20/8/15", "14:40", 'long', 'en') == u'20/8/15 at 14:40'
+    assert dates.format_date_with_time("20/8/15", "14:40", 'long', 'de') == u'20/8/15 um 14:40'
+
+
 def test_format_datetime():
     dt = datetime(2007, 4, 1, 15, 30)
     assert (dates.format_datetime(dt, locale='en_US') ==


### PR DESCRIPTION
The exposes some of the behaviour of format_datetime which might be useful
on it's own as it's own function.

Although this doesn't require the changes I proposed in #265 it is complementary to them. 

It allows you to format the date and time using different or explicit formats and then combine them in a locale aware way.