### PR TITLE
Add a format_list function

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -743,6 +743,19 @@ class Locale(object):
         """
         return self._data.get('plural_form', _default_plural_rule)
 
+    @property
+    def list_patterns(self):
+        """Patterns for generating lists
+
+        >>> Locale('en').list_patterns['start']
+        u'{0}, {1}'
+        >>> Locale('en').list_patterns['end']
+        u'{0}, and {1}'
+        >>> Locale('en_GB').list_patterns['end']
+        u'{0} and {1}'
+        """
+        return self._data['list_patterns']
+
 
 def default_locale(category=None, aliases=LOCALE_ALIASES):
     """Returns the system default locale for a given category, based on

--- a/babel/lists.py
+++ b/babel/lists.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+    babel.lists
+    ~~~~~~~~~~~
+
+    Locale dependent formatting of lists.
+
+    The default locale for the functions in this module is determined by the
+    following environment variables, in that order:
+
+     * ``LC_ALL``, and
+     * ``LANG``
+
+    :copyright: (c) 2015 by the Babel Team.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from babel.core import Locale, default_locale
+
+DEFAULT_LOCALE = default_locale()
+
+
+def format_list(lst, locale=DEFAULT_LOCALE):
+    """ Formats `lst` as a list
+
+    e.g.
+    >>> format_list(['apples', 'oranges', 'pears'], 'en')
+    u'apples, oranges, and pears'
+    >>> format_list(['apples', 'oranges', 'pears'], 'zh')
+    u'apples\u3001oranges\u548cpears'
+
+    :param lst: a sequence of items to format in to a list
+    :param locale: the locale
+    """
+    locale = Locale.parse(locale)
+    if not lst:
+        return ''
+    if len(lst) == 1:
+        return lst[0]
+    if len(lst) == 2:
+        return locale.list_patterns['2'].format(*lst)
+
+    result = locale.list_patterns['start'].format(lst[0], lst[1])
+    for elem in lst[2:-1]:
+        result = locale.list_patterns['middle'].format(result, elem)
+    result = locale.list_patterns['end'].format(result, lst[-1])
+
+    return result

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -343,6 +343,13 @@ def main():
                 continue
             scripts[elem.attrib['type']] = _text(elem)
 
+        list_patterns = data.setdefault('list_patterns', {})
+        for listType in tree.findall('.//listPatterns/listPattern'):
+            if 'type' in listType.attrib:
+                continue
+            for listPattern in listType.findall('listPatternPart'):
+                list_patterns[listPattern.attrib['type']] = _text(listPattern)
+
         # <dates>
 
         week_data = data.setdefault('week_data', {})

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+from babel import lists
+
+
+def test_format_list():
+    for list, locale, expected in [
+        ([], 'en', ''),
+        ([u'string'], 'en', u'string'),
+        (['string1', 'string2'], 'en', u'string1 and string2'),
+        (['string1', 'string2', 'string3'], 'en', u'string1, string2, and string3'),
+        (['string1', 'string2', 'string3'], 'zh', u'string1、string2和string3'),
+        (['string1', 'string2', 'string3', 'string4'], 'ne', u'string1 र string2, string3 र string4'),
+    ]:
+        assert lists.format_list(list, locale=locale) == expected


### PR DESCRIPTION
Adds a format_list function which formats a python list according to the locale e.g. ['a', 'b', 'c'] will be formatted as "a, b and c" in english or "a、b和c" in chinese. 