### PR TITLE
Add an ordinal_form property to Locale

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -756,6 +756,23 @@ class Locale(object):
         """
         return self._data['list_patterns']
 
+    @property
+    def ordinal_form(self):
+        """Plural rules for the locale.
+
+        >>> Locale('en').ordinal_form(1)
+        'one'
+        >>> Locale('en').ordinal_form(2)
+        'two'
+        >>> Locale('en').ordinal_form(3)
+        'few'
+        >>> Locale('fr').ordinal_form(2)
+        'other'
+        >>> Locale('ru').ordinal_form(100)
+        'other'
+        """
+        return self._data.get('ordinal_form', _default_plural_rule)
+
 
 def default_locale(category=None, aliases=LOCALE_ALIASES):
     """Returns the system default locale for a given category, based on


### PR DESCRIPTION
This exposes the rules for selecting ordinal forms in a similar way to the rules for selecting plural forms. In general a languages plural forms and ordinal forms might not be related. 

I was hoping to provide a format_ordinal function to do conversions like 1->1st, 2->2nd, 11->11th, 23->23rd etc. unfortunately the CLDR doesn't have any convenient data for this. It does have some in the rbnf data but the language coverage at least in CLDR 26 seems patchy and pretty hard to interpret.

But I think this is useful on it's own because it provides access to the ordinal rules so that you could construct a simplified solution to a reduced problem based on these rules. Indeed that is what I'm doing for the small set of locales that I need to support.