### PR TITLE
documentation: Correct timezone in example.

### DIFF
--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -352,7 +352,7 @@ functions in the ``babel.dates`` module, most importantly the
 
     >>> tz = get_timezone('Europe/Berlin')
     >>> get_timezone_name(tz, locale=Locale.parse('pt_PT'))
-    u'Hor\xe1rio Alemanha'
+    u'Hora da Europa Central'
 
 You can pass the function either a ``datetime.tzinfo`` object, or a
 ``datetime.date`` or ``datetime.datetime`` object. If you pass an actual date,


### PR DESCRIPTION
Update example in Date and Time documentation to reflect metazone translation.

Fixes https://github.com/python-babel/babel/issues/108