### PR TITLE
Faster rounding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,15 @@ matrix:
     - os: linux
       python: 2.6
     - os: linux
+      python: 2.6
+      env:
+      - CDECIMAL=cdecimal
+    - os: linux
       python: 2.7
+    - os: linux
+      python: 2.7
+      env:
+      - CDECIMAL=cdecimal
     - os: linux
       python: pypy
     - os: linux
@@ -28,9 +36,23 @@ matrix:
     - os: osx
       language: generic
       env:
+      - PYTHON_VERSION=2.6.6
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+      - CDECIMAL=cdecimal
+    - os: osx
+      language: generic
+      env:
       - PYTHON_VERSION=2.7.10
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+    - os: osx
+      language: generic
+      env:
+      - PYTHON_VERSION=2.7.10
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+      - CDECIMAL=cdecimal
     - os: osx
       language: generic
       env:
@@ -53,7 +75,7 @@ matrix:
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
-  - pip install pytest pytest-cov
+  - pip install --allow-external cdecimal pytest pytest-cov $CDECIMAL
   - pip install --editable .
 
 script:

--- a/babel/_compat.py
+++ b/babel/_compat.py
@@ -54,3 +54,22 @@ else:
 
 
 number_types = integer_types + (float,)
+
+
+#
+# Use cdecimal when available
+#
+from decimal import (Decimal as _dec,
+                     InvalidOperation as _invop,
+                     ROUND_HALF_EVEN as _RHE)
+try:
+    from cdecimal import (Decimal as _cdec,
+                          InvalidOperation as _cinvop,
+                          ROUND_HALF_EVEN as _CRHE)
+    Decimal = _cdec
+    InvalidOperation = (_invop, _cinvop)
+    ROUND_HALF_EVEN = _CRHE
+except ImportError:
+    Decimal = _dec
+    InvalidOperation = _invop
+    ROUND_HALF_EVEN = _RHE

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -20,10 +20,9 @@
 #  - http://www.unicode.org/reports/tr35/ (Appendix G.6)
 import re
 from datetime import date as date_, datetime as datetime_
-from decimal import Decimal, InvalidOperation, ROUND_HALF_EVEN
 
 from babel.core import default_locale, Locale, get_global
-from babel._compat import range_type
+from babel._compat import range_type, Decimal, InvalidOperation, ROUND_HALF_EVEN
 
 
 LC_NUMERIC = default_locale('LC_NUMERIC')

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -8,9 +8,10 @@
     :copyright: (c) 2013 by the Babel Team.
     :license: BSD, see LICENSE for more details.
 """
-import decimal
 import re
 import sys
+
+from babel._compat import Decimal
 
 
 _plural_tags = ('zero', 'one', 'two', 'few', 'many', 'other')
@@ -32,9 +33,9 @@ def extract_operands(source):
             # 2.6's Decimal cannot convert from float directly
             if sys.version_info < (2, 7):
                 n = str(n)
-            n = decimal.Decimal(n)
+            n = Decimal(n)
 
-    if isinstance(n, decimal.Decimal):
+    if isinstance(n, Decimal):
         dec_tuple = n.as_tuple()
         exp = dec_tuple.exponent
         fraction_digits = dec_tuple.digits[exp:] if exp < 0 else ()

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -11,13 +11,13 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
 
-from decimal import Decimal
 import unittest
 import pytest
 
 from datetime import date
 
 from babel import numbers
+from babel._compat import Decimal
 
 
 class FormatDecimalTestCase(unittest.TestCase):

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -151,19 +151,6 @@ class FormatDecimalTestCase(unittest.TestCase):
         self.assertEqual('0.000000700', fmt)
 
 
-class BankersRoundTestCase(unittest.TestCase):
-    def test_round_to_nearest_integer(self):
-        self.assertEqual(1, numbers.bankersround(Decimal('0.5001')))
-
-    def test_round_to_even_for_two_nearest_integers(self):
-        self.assertEqual(0, numbers.bankersround(Decimal('0.5')))
-        self.assertEqual(2, numbers.bankersround(Decimal('1.5')))
-        self.assertEqual(-2, numbers.bankersround(Decimal('-2.5')))
-
-        self.assertEqual(0, numbers.bankersround(Decimal('0.05'), ndigits=1))
-        self.assertEqual(Decimal('0.2'), numbers.bankersround(Decimal('0.15'), ndigits=1))
-
-
 class NumberParsingTestCase(unittest.TestCase):
     def test_can_parse_decimals(self):
         self.assertEqual(Decimal('1099.98'),
@@ -318,13 +305,6 @@ def test_parse_decimal():
     with pytest.raises(numbers.NumberFormatError) as excinfo:
         numbers.parse_decimal('2,109,998', locale='de')
     assert excinfo.value.args[0] == "'2,109,998' is not a valid decimal number"
-
-
-def test_bankersround():
-    assert numbers.bankersround(5.5, 0) == 6.0
-    assert numbers.bankersround(6.5, 0) == 6.0
-    assert numbers.bankersround(-6.5, 0) == -6.0
-    assert numbers.bankersround(1234.0, -2) == 1200.0
 
 
 def test_parse_grouping():

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -271,6 +271,8 @@ def test_format_currency_format_type():
 
 def test_format_percent():
     assert numbers.format_percent(0.34, locale='en_US') == u'34%'
+    assert numbers.format_percent(0.34, u'##0%', locale='en_US') == u'34%'
+    assert numbers.format_percent(34, u'##0', locale='en_US') == u'34'
     assert numbers.format_percent(25.1234, locale='en_US') == u'2,512%'
     assert (numbers.format_percent(25.1234, locale='sv_SE')
             == u'2\xa0512\xa0%')

--- a/tests/test_plural.py
+++ b/tests/test_plural.py
@@ -10,10 +10,11 @@
 # This software consists of voluntary contributions made by many
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
-import decimal
 import unittest
 import pytest
+
 from babel import plural
+from babel._compat import Decimal
 
 
 def test_plural_rule():
@@ -33,29 +34,29 @@ def test_plural_rule_operands_i():
 
 def test_plural_rule_operands_v():
     rule = plural.PluralRule({'one': 'v is 2'})
-    assert rule(decimal.Decimal('1.20')) == 'one'
-    assert rule(decimal.Decimal('1.2')) == 'other'
+    assert rule(Decimal('1.20')) == 'one'
+    assert rule(Decimal('1.2')) == 'other'
     assert rule(2) == 'other'
 
 
 def test_plural_rule_operands_w():
     rule = plural.PluralRule({'one': 'w is 2'})
-    assert rule(decimal.Decimal('1.23')) == 'one'
-    assert rule(decimal.Decimal('1.20')) == 'other'
+    assert rule(Decimal('1.23')) == 'one'
+    assert rule(Decimal('1.20')) == 'other'
     assert rule(1.2) == 'other'
 
 
 def test_plural_rule_operands_f():
     rule = plural.PluralRule({'one': 'f is 20'})
-    assert rule(decimal.Decimal('1.23')) == 'other'
-    assert rule(decimal.Decimal('1.20')) == 'one'
+    assert rule(Decimal('1.23')) == 'other'
+    assert rule(Decimal('1.20')) == 'one'
     assert rule(1.2) == 'other'
 
 
 def test_plural_rule_operands_t():
     rule = plural.PluralRule({'one': 't = 5'})
-    assert rule(decimal.Decimal('1.53')) == 'other'
-    assert rule(decimal.Decimal('1.50')) == 'one'
+    assert rule(Decimal('1.53')) == 'other'
+    assert rule(Decimal('1.50')) == 'one'
     assert rule(1.5) == 'one'
 
 
@@ -250,6 +251,6 @@ EXTRACT_OPERANDS_TESTS = (
 
 @pytest.mark.parametrize('source,n,i,v,w,f,t', EXTRACT_OPERANDS_TESTS)
 def test_extract_operands(source, n, i, v, w, f, t):
-    source = decimal.Decimal(source) if isinstance(source, str) else source
+    source = Decimal(source) if isinstance(source, str) else source
     assert (plural.extract_operands(source) ==
-            decimal.Decimal(n), i, v, w, f, t)
+            Decimal(n), i, v, w, f, t)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34
+envlist = py26, py27, pypy, py33, py34, py26-cdecimal, py27-cdecimal
 
 [testenv]
+install_command =
+    pip install --allow-external cdecimal {opts} {packages}
 deps =
     pytest
+    cdecimal: cdecimal
 whitelist_externals = make
 commands = make clean-cldr test


### PR DESCRIPTION
At work, we had some performance issues when trying to format almost 100,000 prices in a single report.  Some profiling revelaed inefficiencies in the number rounding functions.  Such number rounding operations can be implemented making use of the `decimal` standard Python module.  Which probably means that the number rounding code in Babel was meant to support Python versions below 2.4.

Since the oldest supported version now is 2.6, it is probably time to remove the rust and make more use of the standard library (when compatibility is not an issue).

Moreover, this pull request also contains some additional code to make use of the `cdecimal` implementation when available (already shipped with Python since 3.3).  Which speeds up some operations considerably.  Here are some dumb microbenchmarks taken with CPython 2.7.

Original rounding implementation:

```
In [4]: %timeit format_currency(1234.5678, 'USD', locale='en_US')
1000 loops, best of 3: 284 µs per loop
```

New rounding implementation based on `decimal`:

```
In [4]: %timeit format_currency(1234.5678, 'USD', locale='en_US')
1000 loops, best of 3: 229 µs per loop
```

New rounding implementation based on `cdecimal`:

```
In [4]: %timeit format_currency(1234.5678, 'USD', locale='en_US')
10000 loops, best of 3: 100 µs per loop
```

This will also make it easier to provide a solution to #90.  However, the API design for that will have to be discussed a bit.
