### PR TITLE
Upgrade to CLDR 28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist
 test-env
 **/__pycache__
 babel/global.dat
+babel/global.dat.json
 tests/messages/data/project/i18n/long_messages.pot
 tests/messages/data/project/i18n/temp.pot
 tests/messages/data/project/i18n/en_US

--- a/babel/core.py
+++ b/babel/core.py
@@ -113,10 +113,10 @@ class Locale(object):
     If a locale is requested for which no locale data is available, an
     `UnknownLocaleError` is raised:
 
-    >>> Locale.parse('en_DE')
+    >>> Locale.parse('en_XX')
     Traceback (most recent call last):
         ...
-    UnknownLocaleError: unknown locale 'en_DE'
+    UnknownLocaleError: unknown locale 'en_XX'
 
     For more information see :rfc:`3066`.
     """
@@ -432,8 +432,8 @@ class Locale(object):
     script_name = property(get_script_name, doc="""\
         The localized script name of the locale if available.
 
-        >>> Locale('ms', 'SG', script='Latn').script_name
-        u'Latin'
+        >>> Locale('sr', 'ME', script='Latn').script_name
+        u'latinica'
     """)
 
     @property

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -582,7 +582,7 @@ def format_datetime(datetime=None, format='medium', tzinfo=None,
 
     >>> format_datetime(dt, 'full', tzinfo=get_timezone('Europe/Paris'),
     ...                 locale='fr_FR')
-    u'dimanche 1 avril 2007 17:30:00 heure d\u2019\xe9t\xe9 d\u2019Europe centrale'
+    u'dimanche 1 avril 2007 \xe0 17:30:00 heure d\u2019\xe9t\xe9 d\u2019Europe centrale'
     >>> format_datetime(dt, "yyyy.MM.dd G 'at' HH:mm:ss zzz",
     ...                 tzinfo=get_timezone('US/Eastern'), locale='en')
     u'2007.04.01 AD at 11:30:00 EDT'
@@ -742,7 +742,7 @@ def format_timedelta(delta, granularity='second', threshold=.85,
     The format parameter controls how compact or wide the presentation is:
 
     >>> format_timedelta(timedelta(hours=3), format='short', locale='en')
-    u'3 hrs'
+    u'3 hr'
     >>> format_timedelta(timedelta(hours=3), format='narrow', locale='en')
     u'3h'
 

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -265,7 +265,7 @@ def format_currency(number, currency, format=None, locale=LC_NUMERIC,
     >>> format_currency(1099.98, 'USD', locale='en_US')
     u'$1,099.98'
     >>> format_currency(1099.98, 'USD', locale='es_CO')
-    u'US$1.099,98'
+    u'US$\\xa01.099,98'
     >>> format_currency(1099.98, 'EUR', locale='de_DE')
     u'1.099,98\\xa0\\u20ac'
 

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -71,8 +71,9 @@ def is_good_file(filename):
 def main():
     scripts_path = os.path.dirname(os.path.abspath(__file__))
     repo = os.path.dirname(scripts_path)
-    cldr_path = os.path.join(repo, 'cldr')
-    zip_path = os.path.join(cldr_path, FILENAME)
+    cldr_dl_path = os.path.join(repo, 'cldr')
+    cldr_path = os.path.join(repo, 'cldr', os.path.splitext(FILENAME)[0])
+    zip_path = os.path.join(cldr_dl_path, FILENAME)
     changed = False
 
     while not is_good_file(zip_path):

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -5,7 +5,6 @@ import sys
 import shutil
 import hashlib
 import zipfile
-import urllib
 import subprocess
 try:
     from urllib.request import urlretrieve
@@ -13,9 +12,9 @@ except ImportError:
     from urllib import urlretrieve
 
 
-URL = 'http://unicode.org/Public/cldr/26/core.zip'
-FILENAME = 'core-26.zip'
-FILESUM = '46220170238b092685fd24221f895e3d'
+URL = 'http://unicode.org/Public/cldr/28/core.zip'
+FILENAME = 'core-28.zip'
+FILESUM = 'bc545b4c831e1987ea931b04094d7b9fc59ec3d8'
 BLKSIZE = 131072
 
 
@@ -53,7 +52,7 @@ def is_good_file(filename):
     if not os.path.isfile(filename):
         log('Local copy \'%s\' not found', filename)
         return False
-    h = hashlib.md5()
+    h = hashlib.sha1()
     with open(filename, 'rb') as f:
         while 1:
             blk = f.read(BLKSIZE)

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -124,10 +124,14 @@ def _extract_plural_rules(file_path):
 
 def main():
     parser = OptionParser(usage='%prog path/to/cldr')
+    parser.add_option(
+        '-f', '--force', dest='force', action='store_true', default=False,
+        help='force import even if destination file seems up to date'
+    )
     options, args = parser.parse_args()
     if len(args) != 1:
         parser.error('incorrect number of arguments')
-
+    force = bool(options.force)
     srcdir = args[0]
     destdir = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),
                            '..', 'babel')
@@ -145,7 +149,7 @@ def main():
     # Import global data from the supplemental files
     global_path = os.path.join(destdir, 'global.dat')
     global_data = {}
-    if need_conversion(global_path, global_data, sup_filename):
+    if force or need_conversion(global_path, global_data, sup_filename):
         territory_zones = global_data.setdefault('territory_zones', {})
         zone_aliases = global_data.setdefault('zone_aliases', {})
         zone_territories = global_data.setdefault('zone_territories', {})
@@ -290,7 +294,7 @@ def main():
         data_filename = os.path.join(destdir, 'locale-data', stem + '.dat')
 
         data = {}
-        if not need_conversion(data_filename, data, full_filename):
+        if not (force or need_conversion(data_filename, data, full_filename)):
             continue
 
         tree = parse(full_filename)

--- a/tests/messages/test_plurals.py
+++ b/tests/messages/test_plurals.py
@@ -34,7 +34,7 @@ def test_get_plural_accpets_strings():
 
 
 def test_get_plural_falls_back_to_default():
-    assert plurals.get_plural('aa') == (2, '(n != 1)')
+    assert plurals.get_plural('ii') == (2, '(n != 1)')
 
 
 def test_plural_tuple_attributes():

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -282,14 +282,14 @@ class FormatTimedeltaTestCase(unittest.TestCase):
         self.assertEqual('0 seconds', string)
         string = dates.format_timedelta(timedelta(seconds=0), locale='en',
                                         format='short')
-        self.assertEqual('0 secs', string)
+        self.assertEqual('0 sec', string)
         string = dates.format_timedelta(timedelta(seconds=0),
                                         granularity='hour', locale='en')
         self.assertEqual('0 hours', string)
         string = dates.format_timedelta(timedelta(seconds=0),
                                         granularity='hour', locale='en',
                                         format='short')
-        self.assertEqual('0 hrs', string)
+        self.assertEqual('0 hr', string)
 
     def test_small_value_with_granularity(self):
         string = dates.format_timedelta(timedelta(seconds=42),
@@ -465,7 +465,7 @@ def test_format_datetime():
 
     full = dates.format_datetime(dt, 'full', tzinfo=timezone('Europe/Paris'),
                                  locale='fr_FR')
-    assert full == (u'dimanche 1 avril 2007 17:30:00 heure '
+    assert full == (u'dimanche 1 avril 2007 à 17:30:00 heure '
                     u'd\u2019\xe9t\xe9 d\u2019Europe centrale')
     custom = dates.format_datetime(dt, "yyyy.MM.dd G 'at' HH:mm:ss zzz",
                                    tzinfo=timezone('US/Eastern'), locale='en')

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -230,7 +230,7 @@ def test_format_currency():
     assert (numbers.format_currency(1099.98, 'USD', locale='en_US')
             == u'$1,099.98')
     assert (numbers.format_currency(1099.98, 'USD', locale='es_CO')
-            == u'US$1.099,98')
+            == u'US$\xa01.099,98')
     assert (numbers.format_currency(1099.98, 'EUR', locale='de_DE')
             == u'1.099,98\xa0\u20ac')
     assert (numbers.format_currency(1099.98, 'EUR', u'\xa4\xa4 #,##0.00',

--- a/tests/test_plural.py
+++ b/tests/test_plural.py
@@ -133,10 +133,10 @@ def test_plural_within_rules():
 
 def test_locales_with_no_plural_rules_have_default():
     from babel import Locale
-    aa_plural = Locale.parse('aa').plural_form
-    assert aa_plural(1) == 'other'
-    assert aa_plural(2) == 'other'
-    assert aa_plural(15) == 'other'
+    pf = Locale.parse('ii').plural_form
+    assert pf(1) == 'other'
+    assert pf(2) == 'other'
+    assert pf(15) == 'other'
 
 
 WELL_FORMED_TOKEN_TESTS = (


### PR DESCRIPTION
This PR:

* Updates Babel to use CLDR 28, including some fixes for new CLDR features.
* Includes some development convenience switches for the CLDR import scripts

I'd love to have more behavioral tests that ensure there aren't serious regressions in behavior (for example by way of mis-parsing the XML files), but I'm not quite sure where to source the data for that for several languages. For the time, the current tests will have to do.

It would also be a great idea to compare and contrast the parser behavior to the actual spec (http://www.unicode.org/reports/tr35/tr35-39/tr35.html#Modifications and previous versions as linked therein).