### PR TITLE
Compile noninteger TR35 operands to zeroes when emitting Gettext

### DIFF
--- a/babel/plural.py
+++ b/babel/plural.py
@@ -485,6 +485,9 @@ def _unary_compiler(tmpl):
     return lambda self, x: tmpl % self.compile(x)
 
 
+compile_zero = lambda x: '0'
+
+
 class _Compiler(object):
     """The compilers are able to transform the expressions into multiple
     output formats.
@@ -557,10 +560,10 @@ class _JavaScriptCompiler(_GettextCompiler):
     # XXX: presently javascript does not support any of the
     # fraction support and basically only deals with integers.
     compile_i = lambda x: 'parseInt(n, 10)'
-    compile_v = lambda x: '0'
-    compile_w = lambda x: '0'
-    compile_f = lambda x: '0'
-    compile_t = lambda x: '0'
+    compile_v = compile_zero
+    compile_w = compile_zero
+    compile_f = compile_zero
+    compile_t = compile_zero
 
     def compile_relation(self, method, expr, range_list):
         code = _GettextCompiler.compile_relation(

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -303,7 +303,7 @@ _RULES = [
                         .format(_VARS))),
     ('value', re.compile(r'\d+')),
     ('symbol', re.compile(r'%|,|!=|=')),
-    ('ellipsis', re.compile(r'\.\.'))
+    ('ellipsis', re.compile(r'\.{2,3}|\u2026', re.UNICODE))  # U+2026: ELLIPSIS
 ]
 
 

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -86,14 +86,14 @@ class PluralRule(object):
         found = set()
         self.abstract = []
         for key, expr in sorted(list(rules)):
-            if key == 'other':
-                continue
             if key not in _plural_tags:
                 raise ValueError('unknown tag %r' % key)
             elif key in found:
                 raise ValueError('tag %r defined twice' % key)
             found.add(key)
-            self.abstract.append((key, _Parser(expr).ast))
+            ast = _Parser(expr).ast
+            if ast:
+                self.abstract.append((key, ast))
 
     def __repr__(self):
         rules = self.rules
@@ -388,6 +388,11 @@ class _Parser(object):
 
     def __init__(self, string):
         self.tokens = tokenize_rule(string)
+        if not self.tokens:
+            # If the pattern is only samples, it's entirely possible
+            # no stream of tokens whatsoever is generated.
+            self.ast = None
+            return
         self.ast = self.condition()
         if self.tokens:
             raise RuleError('Expected end of rule, got %r' %

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -534,6 +534,12 @@ class _PythonCompiler(_Compiler):
 class _GettextCompiler(_Compiler):
     """Compile into a gettext plural expression."""
 
+    compile_i = _Compiler.compile_n
+    compile_v = compile_zero
+    compile_w = compile_zero
+    compile_f = compile_zero
+    compile_t = compile_zero
+
     def compile_relation(self, method, expr, range_list):
         rv = []
         expr = self.compile(expr)


### PR DESCRIPTION
See http://www.unicode.org/reports/tr35/tr35-numbers.html#Operands
See https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html

Fixes #287