### PR TITLE
Embetter pofile sorting

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -453,7 +453,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
 
         if not no_location:
             locs = []
-            for filename, lineno in message.locations:
+            for filename, lineno in sorted(message.locations):
                 if lineno:
                     locs.append(u'%s:%d' % (filename.replace(os.sep, '/'), lineno))
                 else:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -431,7 +431,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
     if sort_output:
         messages.sort()
     elif sort_by_file:
-        messages.sort(lambda x,y: cmp(x.locations, y.locations))
+        messages.sort(key=lambda m: m.locations)
 
     for message in messages:
         if not message.id: # This is the header "message"

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -427,13 +427,13 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                 prefix, _normalize(message.string or '', prefix)
             ))
 
-    messages = list(catalog)
+    sort_by = None
     if sort_output:
-        messages.sort()
+        sort_by = "message"
     elif sort_by_file:
-        messages.sort(key=lambda m: m.locations)
+        sort_by = "location"
 
-    for message in messages:
+    for message in _sort_messages(catalog, sort_by=sort_by):
         if not message.id: # This is the header "message"
             if omit_header:
                 continue
@@ -474,14 +474,29 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
         _write('\n')
 
     if not ignore_obsolete:
-        obsolete = list(catalog.obsolete.values())
-        if sort_output:
-            obsolete.sort()
-        elif sort_by_file:
-            obsolete.sort(key=lambda m: m.locations)
-
-        for message in obsolete:
+        for message in _sort_messages(
+            catalog.obsolete.values(),
+            sort_by=sort_by
+        ):
             for comment in message.user_comments:
                 _write_comment(comment)
             _write_message(message, prefix='#~ ')
             _write('\n')
+
+
+def _sort_messages(messages, sort_by):
+    """
+    Sort the given message iterable by the given criteria.
+
+    Always returns a list.
+
+    :param messages: An iterable of Messages.
+    :param sort_by: Sort by which criteria? Options are `message` and `location`.
+    :return: list[Message]
+    """
+    messages = list(messages)
+    if sort_by == "message":
+        messages.sort()
+    elif sort_by == "location":
+        messages.sort(key=lambda m: m.locations)
+    return messages

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -474,7 +474,13 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
         _write('\n')
 
     if not ignore_obsolete:
-        for message in catalog.obsolete.values():
+        obsolete = list(catalog.obsolete.values())
+        if sort_output:
+            obsolete.sort()
+        elif sort_by_file:
+            obsolete.sort(key=lambda m: m.locations)
+
+        for message in obsolete:
             for comment in message.user_comments:
                 _write_comment(comment)
             _write_message(message, prefix='#~ ')

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -513,6 +513,15 @@ msgstr[0] "Voh"
 msgstr[1] "Voeh"''' in value
         assert value.find(b'msgid ""') < value.find(b'msgid "bar"') < value.find(b'msgid "foo"')
 
+    def test_file_sorted_po(self):
+        catalog = Catalog()
+        catalog.add(u'bar', locations=[('utils.py', 3)])
+        catalog.add((u'foo', u'foos'), (u'Voh', u'Voeh'), locations=[('main.py', 1)])
+        buf = BytesIO()
+        pofile.write_po(buf, catalog, sort_by_file=True)
+        value = buf.getvalue().strip()
+        assert value.find(b'main.py') < value.find(b'utils.py')
+
     def test_file_with_no_lineno(self):
         catalog = Catalog()
         catalog.add(u'bar', locations=[('utils.py', None)],


### PR DESCRIPTION
I think sorting message locations irrespective of the sort flags is alright.

The only UC I can think of where that wouldn't be desired might be trying to read a .po and emitting an identical copy of it, but I don't think Babel does that as it is anyway?