### PR TITLE
Try to fix the broken builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
     - os: linux
       python: 2.6
       env:
-      - CDECIMAL=cdecimal
+      - CDECIMAL=m3-cdecimal
     - os: linux
       python: 2.7
     - os: linux
       python: 2.7
       env:
-      - CDECIMAL=cdecimal
+      - CDECIMAL=m3-cdecimal
     - os: linux
       python: pypy
     - os: linux
@@ -43,7 +43,7 @@ matrix:
       - PYTHON_VERSION=2.6.6
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-      - CDECIMAL=cdecimal
+      - CDECIMAL=m3-cdecimal
     - os: osx
       language: generic
       env:
@@ -56,7 +56,7 @@ matrix:
       - PYTHON_VERSION=2.7.10
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-      - CDECIMAL=cdecimal
+      - CDECIMAL=m3-cdecimal
     - os: osx
       language: generic
       env:
@@ -85,7 +85,7 @@ matrix:
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
-  - pip install --allow-external cdecimal --upgrade pytest==2.8.5 pytest-cov==2.2.0 $CDECIMAL
+  - pip install --upgrade pytest==2.8.5 pytest-cov==2.2.0 $CDECIMAL
   - pip install --editable .
 
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,8 @@
 envlist = py26, py27, pypy, py33, py34, py26-cdecimal, py27-cdecimal
 
 [testenv]
-install_command =
-    pip install --allow-external cdecimal {opts} {packages}
 deps =
     pytest
-    cdecimal: cdecimal
+    cdecimal: m3-cdecimal
 whitelist_externals = make
 commands = make clean-cldr test


### PR DESCRIPTION
The cdecimal extension doesn't seem to install anymore.  It looks like it has been renamed to m3-cdecimal.  However, in my system doesn't install properly either.  Let's try Travis to see if it has better luck.