### PR TITLE
Make catalog header updating an option

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -673,7 +673,7 @@ class Catalog(object):
         if key in self._messages:
             del self._messages[key]
 
-    def update(self, template, no_fuzzy_matching=False):
+    def update(self, template, no_fuzzy_matching=False, update_header_comment=False):
         """Update the catalog based on the given template catalog.
 
         >>> from babel.messages import Catalog
@@ -798,9 +798,10 @@ class Catalog(object):
             if no_fuzzy_matching or msgid not in fuzzy_matches:
                 self.obsolete[msgid] = remaining[msgid]
 
-        # Allow the updated catalog's header to be rewritten based on the
-        # template's header
-        self.header_comment = template.header_comment
+        if update_header_comment:
+            # Allow the updated catalog's header to be rewritten based on the
+            # template's header
+            self.header_comment = template.header_comment
 
         # Make updated catalog's POT-Creation-Date equal to the template
         # used to update the catalog

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -545,10 +545,12 @@ class update_catalog(Command):
          'whether to omit obsolete messages from the output'),
         ('no-fuzzy-matching', 'N',
          'do not use fuzzy matching'),
+        ('update-header-comment', None,
+         'update target header comment'),
         ('previous', None,
          'keep previous msgids of translated messages')
     ]
-    boolean_options = ['ignore_obsolete', 'no_fuzzy_matching', 'previous']
+    boolean_options = ['ignore_obsolete', 'no_fuzzy_matching', 'previous', 'update_header_comment']
 
     def initialize_options(self):
         self.domain = 'messages'
@@ -560,6 +562,7 @@ class update_catalog(Command):
         self.no_wrap = False
         self.ignore_obsolete = False
         self.no_fuzzy_matching = False
+        self.update_header_comment = False
         self.previous = False
 
     def finalize_options(self):
@@ -619,7 +622,10 @@ class update_catalog(Command):
             finally:
                 infile.close()
 
-            catalog.update(template, self.no_fuzzy_matching)
+            catalog.update(
+                template, self.no_fuzzy_matching,
+                update_header_comment=self.update_header_comment
+            )
 
             tmpname = os.path.join(os.path.dirname(filename),
                                    tempfile.gettempprefix() +

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -440,7 +440,6 @@ def test_catalog_update():
 
     cat.update(template)
     assert len(cat) == 3
-    assert cat.header_comment == template.header_comment  # Header comment also gets updated
 
     msg1 = cat['green']
     msg1.string
@@ -456,6 +455,9 @@ def test_catalog_update():
 
     assert not 'head' in cat
     assert list(cat.obsolete.values())[0].id == 'head'
+
+    cat.update(template, update_header_comment=True)
+    assert cat.header_comment == template.header_comment  # Header comment also gets updated
 
 
 def test_datetime_parsing():


### PR DESCRIPTION
The change in e0e7ef168856bb had an unexpected and likely undesired effect
when updating catalogs with, e.g. translator names in the header comment.

It's better to make the updating an option and revert back to the pre-2.2
behavior by default.

Fixes https://github.com/python-babel/babel/issues/318