### PR TITLE
Extract CLI: Add `input-dirs` alias for `input-paths`

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -254,6 +254,8 @@ class extract_messages(Command):
         ('input-paths=', None,
          'files or directories that should be scanned for messages. Separate multiple '
          'files or directories with commas(,)'),
+        ('input-dirs=', None,  # TODO (3.x): Remove me.
+         'alias for input-paths (does allow files as well as directories).'),
     ]
     boolean_options = [
         'no-default-keywords', 'no-location', 'omit-header', 'no-wrap',
@@ -271,6 +273,7 @@ class extract_messages(Command):
         self.no_location = False
         self.omit_header = False
         self.output_file = None
+        self.input_dirs = None
         self.input_paths = None
         self.width = None
         self.no_wrap = False
@@ -284,6 +287,14 @@ class extract_messages(Command):
         self.strip_comments = False
 
     def finalize_options(self):
+        if self.input_dirs:
+            if not self.input_paths:
+                self.input_paths = self.input_dirs
+            else:
+                raise DistutilsOptionError(
+                    'input-dirs and input-paths are mutually exclusive'
+                )
+
         if self.no_default_keywords and not self.keywords:
             raise DistutilsOptionError('you must specify new keywords if you '
                                        'disable the default ones')

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -132,6 +132,19 @@ class ExtractMessagesTestCase(unittest.TestCase):
 
         self.assertEqual([this_dir, self.datadir], self.cmd.input_paths)
 
+    def test_input_dirs_is_alias_for_input_paths(self):
+        self.cmd.input_dirs = this_dir
+        self.cmd.output_file = self._pot_file()
+        self.cmd.finalize_options()
+        # Gets listified in `finalize_options`:
+        assert self.cmd.input_paths == [self.cmd.input_dirs]
+
+    def test_input_dirs_is_mutually_exclusive_with_input_paths(self):
+        self.cmd.input_dirs = this_dir
+        self.cmd.input_paths = this_dir
+        self.cmd.output_file = self._pot_file()
+        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+
     def test_extraction_with_default_mapping(self):
         self.cmd.copyright_holder = 'FooBar, Inc.'
         self.cmd.msgid_bugs_address = 'bugs.address@email.tld'


### PR DESCRIPTION
Just in case some script expects to be able to pass `--input-dirs`.

Fixes #330
Augments 19957e21470615d42fb7b6e2c1a580cd679d33c8