### PR TITLE
Extract: Add npgettext to default keywords map

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -39,7 +39,7 @@ DEFAULT_KEYWORDS = {
     'dngettext': (2, 3),
     'N_': None,
     'pgettext': ((1, 'c'), 2),
-    'npgettext': ((1, 'c', 2, 3))
+    'npgettext': ((1, 'c'), 2, 3)
 }
 
 DEFAULT_MAPPING = [('**.py', 'python')]

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -38,7 +38,8 @@ DEFAULT_KEYWORDS = {
     'dgettext': (2,),
     'dngettext': (2, 3),
     'N_': None,
-    'pgettext': ((1, 'c'), 2)
+    'pgettext': ((1, 'c'), 2),
+    'npgettext': ((1, 'c', 2, 3))
 }
 
 DEFAULT_MAPPING = [('**.py', 'python')]

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -60,6 +60,15 @@ msg = ngettext('pylon',  # TRANSLATORS: shouldn't be
                                                ['TRANSLATORS:'], {}))
         self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), [])],
                          messages)
+        buf = BytesIO(b"""\
+msg = npgettext('Strings', 'pylon',  # TRANSLATORS: shouldn't be
+                'pylons', # TRANSLATORS: seeing this
+                count)
+""")
+        messages = list(extract.extract_python(buf, ('npgettext',),
+                                               ['TRANSLATORS:'], {}))
+        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), [])],
+                         messages)
 
     def test_comments_with_calls_that_spawn_multiple_lines(self):
         buf = BytesIO(b"""\
@@ -131,6 +140,17 @@ msg2 = ngettext('elvis',
         self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), []),
                           (3, 'ngettext', (u'elvis', u'elvises', None), [])],
                          messages)
+        buf = BytesIO(b"""\
+msg1 = npgettext('Strings','pylon',
+                'pylons', count)
+msg2 = npgettext('Strings','elvis',
+                'elvises',
+                 count)
+""")
+        messages = list(extract.extract_python(buf, ('npgettext',), [], {}))
+        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), []),
+                          (3, 'npgettext', (u'Strings', u'elvis', u'elvises', None), [])],
+                          messages)
 
     def test_triple_quoted_strings(self):
         buf = BytesIO(b"""\

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -60,15 +60,6 @@ msg = ngettext('pylon',  # TRANSLATORS: shouldn't be
                                                ['TRANSLATORS:'], {}))
         self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), [])],
                          messages)
-        buf = BytesIO(b"""\
-msg = npgettext('Strings', 'pylon',  # TRANSLATORS: shouldn't be
-                'pylons', # TRANSLATORS: seeing this
-                count)
-""")
-        messages = list(extract.extract_python(buf, ('npgettext',),
-                                               ['TRANSLATORS:'], {}))
-        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), [])],
-                         messages)
 
     def test_comments_with_calls_that_spawn_multiple_lines(self):
         buf = BytesIO(b"""\
@@ -140,6 +131,8 @@ msg2 = ngettext('elvis',
         self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), []),
                           (3, 'ngettext', (u'elvis', u'elvises', None), [])],
                          messages)
+
+    def test_npgettext(self):
         buf = BytesIO(b"""\
 msg1 = npgettext('Strings','pylon',
                 'pylons', count)
@@ -151,6 +144,15 @@ msg2 = npgettext('Strings','elvis',
         self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), []),
                           (3, 'npgettext', (u'Strings', u'elvis', u'elvises', None), [])],
                           messages)
+        buf = BytesIO(b"""\
+msg = npgettext('Strings', 'pylon',  # TRANSLATORS: shouldn't be
+                'pylons', # TRANSLATORS: seeing this
+                count)
+""")
+        messages = list(extract.extract_python(buf, ('npgettext',),
+                                               ['TRANSLATORS:'], {}))
+        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), [])],
+                         messages)
 
     def test_triple_quoted_strings(self):
         buf = BytesIO(b"""\


### PR DESCRIPTION
Add the npgettext as a default keyword in the keywords map.
Create test_npgettext in test_extract showing the passing tests.

Fixes https://github.com/python-babel/babel/issues/281
Fixes https://github.com/python-babel/babel/issues/328