### PR TITLE
Day period API

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -628,6 +628,12 @@ class Locale(object):
         return self._data['day_periods']
 
     @property
+    def day_period_rules(self):
+        """Day period rules for the locale.  Used by `get_period_id`.
+        """
+        return self._data.get('day_period_rules', {})
+
+    @property
     def days(self):
         """Locale display names for weekdays.
 

--- a/babel/core.py
+++ b/babel/core.py
@@ -614,7 +614,10 @@ class Locale(object):
         >>> Locale('en', 'US').periods['am']
         u'AM'
         """
-        return self._data['periods']
+        try:
+            return self._data['day_periods']['stand-alone']['wide']
+        except KeyError:
+            return {}
 
     @property
     def days(self):

--- a/babel/core.py
+++ b/babel/core.py
@@ -620,6 +620,14 @@ class Locale(object):
             return {}
 
     @property
+    def day_periods(self):
+        """Locale display names for various day periods (not necessarily only AM/PM).
+
+        These are not meant to be used without the relevant `day_period_rules`.
+        """
+        return self._data['day_periods']
+
+    @property
     def days(self):
         """Locale display names for weekdays.
 

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -138,6 +138,32 @@ def _ensure_datetime_tzinfo(datetime, tzinfo=None):
     return datetime
 
 
+def _get_time(time, tzinfo=None):
+    """
+    Get a timezoned time from a given instant.
+
+    .. warning:: The return values of this function may depend on the system clock.
+
+    :param time: time, datetime or None
+    :rtype: time
+    """
+    if time is None:
+        time = datetime.utcnow()
+    elif isinstance(time, number_types):
+        time = datetime.utcfromtimestamp(time)
+    if time.tzinfo is None:
+        time = time.replace(tzinfo=UTC)
+    if isinstance(time, datetime):
+        if tzinfo is not None:
+            time = time.astimezone(tzinfo)
+            if hasattr(tzinfo, 'normalize'):  # pytz
+                time = tzinfo.normalize(time)
+        time = time.timetz()
+    elif tzinfo is not None:
+        time = time.replace(tzinfo=tzinfo)
+    return time
+
+
 def get_timezone(zone=None):
     """Looks up a timezone by name and returns it.  The timezone object
     returned comes from ``pytz`` and corresponds to the `tzinfo` interface and
@@ -753,20 +779,7 @@ def format_time(time=None, format='medium', tzinfo=None, locale=LC_TIME):
     :param tzinfo: the time-zone to apply to the time for display
     :param locale: a `Locale` object or a locale identifier
     """
-    if time is None:
-        time = datetime.utcnow()
-    elif isinstance(time, number_types):
-        time = datetime.utcfromtimestamp(time)
-    if time.tzinfo is None:
-        time = time.replace(tzinfo=UTC)
-    if isinstance(time, datetime):
-        if tzinfo is not None:
-            time = time.astimezone(tzinfo)
-            if hasattr(tzinfo, 'normalize'):  # pytz
-                time = tzinfo.normalize(time)
-        time = time.timetz()
-    elif tzinfo is not None:
-        time = time.replace(tzinfo=tzinfo)
+    time = _get_time(time, tzinfo)
 
     locale = Locale.parse(locale)
     if format in ('full', 'long', 'medium', 'short'):

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -247,15 +247,17 @@ class TimezoneTransition(object):
         )
 
 
-def get_period_names(locale=LC_TIME):
+def get_period_names(width='wide', context='stand-alone', locale=LC_TIME):
     """Return the names for day periods (AM/PM) used by the locale.
 
     >>> get_period_names(locale='en_US')['am']
     u'AM'
 
+    :param width: the width to use, one of "abbreviated", "narrow", or "wide"
+    :param context: the context, either "format" or "stand-alone"
     :param locale: the `Locale` object, or a locale string
     """
-    return Locale.parse(locale).periods
+    return Locale.parse(locale).day_periods[context][width]
 
 
 def get_day_names(width='wide', context='format', locale=LC_TIME):

--- a/tests/test_day_periods.py
+++ b/tests/test_day_periods.py
@@ -1,0 +1,18 @@
+# -- encoding: UTF-8 --
+from datetime import time
+
+import babel.dates as dates
+import pytest
+
+
+@pytest.mark.parametrize("locale, time, expected_period_id", [
+    ("de", time(7, 42), "morning1"),  # (from, before)
+    ("de", time(3, 11), "night1"),  # (after, before)
+    ("fi", time(0), "midnight"),  # (at)
+    ("en_US", time(12), "noon"),  # (at)
+    ("agq", time(10), "am"),  # no periods defined
+    ("agq", time(22), "pm"),  # no periods defined
+    ("am", time(14), "afternoon1"),  # (before, after)
+])
+def test_day_period_rules(locale, time, expected_period_id):
+    assert dates.get_period_id(time, locale=locale) == expected_period_id


### PR DESCRIPTION
This PR adds full support for day periods other than am/pm.

Requested by @sachinpali146 for additional time format character support. :)

See: http://unicode.org/reports/tr35/tr35-dates.html#Day_Period_Rules