### PR TITLE
docs/dates.rst: Correct line length

### DIFF
--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -85,8 +85,8 @@ inherited from C and POSIX. The patterns used in Babel are based on the
 follows:
 
     A date/time pattern is a string of characters, where specific strings of
-    characters are replaced with date and time data from a calendar when formatting
-    or used to generate data for a calendar when parsing. […]
+    characters are replaced with date and time data from a calendar when
+    formatting or used to generate data for a calendar when parsing. […]
 
     Characters may be used multiple times. For example, if ``y`` is used for the
     year, ``yy`` might produce "99", whereas ``yyyy`` produces "1999". For most
@@ -123,7 +123,8 @@ The syntax for custom datetime format patterns is described in detail in the
 the `Locale Data Markup Language specification`_. The following table is just a
 relatively brief overview.
 
- .. _`Locale Data Markup Language specification`: http://unicode.org/reports/tr35/#Date_Format_Patterns
+ .. _`Locale Data Markup Language specification`:
+    http://unicode.org/reports/tr35/#Date_Format_Patterns
 
 Date Fields
 -----------


### PR DESCRIPTION
Fixes https://github.com/python-babel/babel/issues/356