### PR TITLE
format_datetime: using 'S...S' format is incorrect

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1287,8 +1287,13 @@ class DateTimeFormat(object):
         return get_period_names(locale=self.locale)[period]
 
     def format_frac_seconds(self, num):
-        value = str(self.value.microsecond)
-        return self.format(round(float('.%s' % value), num) * 10**num, num)
+        """ Return fractional seconds.
+
+        Rounds the time's microseconds to the precision given by the number \
+        of digits passed in.
+        """
+        value = self.value.microsecond / 1000000
+        return self.format(round(value, num) * 10**num, num)
 
     def format_milliseconds_in_day(self, num):
         msecs = self.value.microsecond // 1000 + self.value.second * 1000 + \

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -156,9 +156,21 @@ class DateTimeFormatTestCase(unittest.TestCase):
         self.assertEqual('4', fmt['c']) # friday is first day of week
 
     def test_fractional_seconds(self):
-        t = time(15, 30, 12, 34567)
+        t = time(8, 3, 9, 799)
         fmt = dates.DateTimeFormat(t, locale='en_US')
-        self.assertEqual('3457', fmt['SSSS'])
+        self.assertEqual('0', fmt['S'])
+        t = time(8, 3, 1, 799)
+        fmt = dates.DateTimeFormat(t, locale='en_US')
+        self.assertEqual('0008', fmt['SSSS'])
+        t = time(8, 3, 1, 34567)
+        fmt = dates.DateTimeFormat(t, locale='en_US')
+        self.assertEqual('0346', fmt['SSSS'])
+        t = time(8, 3, 1, 345678)
+        fmt = dates.DateTimeFormat(t, locale='en_US')
+        self.assertEqual('345678', fmt['SSSSSS'])
+        t = time(8, 3, 1, 799)
+        fmt = dates.DateTimeFormat(t, locale='en_US')
+        self.assertEqual('00080', fmt['SSSSS'])
 
     def test_fractional_seconds_zero(self):
         t = time(15, 30, 0)


### PR DESCRIPTION
Fixes https://github.com/python-babel/babel/issues/350