### PR TITLE
Add `flake8` pre-commit hook and applied fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,19 @@
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: 97b88d9610bcc03982ddac33caba98bb2b751f5f
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
     -   id: autopep8-wrapper
         exclude: (docs/conf.py|tests/messages/data/)
+    -   id: check-added-large-files
     -   id: check-docstring-first
         exclude: (docs/conf.py)
     -   id: check-json
-    -   id: check-added-large-files
     -   id: check-yaml
     -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: flake8
+        exclude: (docs/conf.py|babel/messages/__init__.py|babel/__init__.py|babel/_compat.py|tests/messages/data|scripts/import_cldr.py)
     -   id: name-tests-test
         args: ['--django']
         exclude: (tests/messages/data/)
     -   id: requirements-txt-fixer
+    -   id: trailing-whitespace

--- a/babel/core.py
+++ b/babel/core.py
@@ -469,7 +469,7 @@ class Locale(object):
         :type: `unicode`"""
         return self.get_display_name(Locale('en'))
 
-    #{ General Locale Display Names
+    # { General Locale Display Names
 
     @property
     def languages(self):
@@ -516,7 +516,7 @@ class Locale(object):
         """
         return self._data['variants']
 
-    #{ Number Formatting
+    # { Number Formatting
 
     @property
     def currencies(self):
@@ -605,7 +605,7 @@ class Locale(object):
         """
         return self._data['scientific_formats']
 
-    #{ Calendar Information and Date Formatting
+    # { Calendar Information and Date Formatting
 
     @property
     def periods(self):

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -339,7 +339,7 @@ def normalize(string, prefix='', width=76):
     if lines and not lines[-1]:
         del lines[-1]
         lines[-1] += '\n'
-    return u'""\n' + u'\n'.join([(prefix + escape(l)) for l in lines])
+    return u'""\n' + u'\n'.join([(prefix + escape(line)) for line in lines])
 
 
 def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -676,7 +676,6 @@ class NumberPattern(object):
             value += ('0' * (min - len(value)))
         if max == 0 or (min == 0 and int(value) == 0):
             return ''
-        width = len(value)
         while len(value) > min and value[-1] == '0':
             value = value[:-1]
         return get_decimal_symbol(locale) + value

--- a/babel/util.py
+++ b/babel/util.py
@@ -15,6 +15,8 @@ import os
 import re
 import textwrap
 from babel._compat import izip, imap
+import pytz as _pytz
+from babel import localtime
 
 missing = object()
 
@@ -260,9 +262,6 @@ class FixedOffsetTimezone(tzinfo):
     def dst(self, dt):
         return ZERO
 
-
-import pytz as _pytz
-from babel import localtime
 
 # Export the localtime functionality here because that's
 # where it was in the past.

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -26,7 +26,6 @@ def parse_changelog():
             match = re.search('^Version\s+(.*)', line.strip())
             if match is None:
                 continue
-            length = len(match.group(1))
             version = match.group(1).strip()
             if lineiter.next().count('-') != len(match.group(0)):
                 continue

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -456,7 +456,7 @@ def test_catalog_update():
     assert msg3.string == (u'Salat', u'Salate')
     assert msg3.locations == [('util.py', 42)]
 
-    assert not 'head' in cat
+    assert 'head' not in cat
     assert list(cat.obsolete.values())[0].id == 'head'
 
     cat.update(template, update_header_comment=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,11 +11,9 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
 
-import doctest
-import unittest
 import pytest
 
-from babel import core, Locale
+from babel import core
 from babel.core import default_locale, Locale
 
 
@@ -41,7 +39,7 @@ def test_locale_comparison():
     assert en_US == en_US_2
     assert en_US != fi_FI
     assert not (en_US != en_US_2)
-    assert None != en_US
+    assert en_US is not None
     assert en_US != bad_en_US
     assert fi_FI != bad_en_US
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -13,7 +13,6 @@
 
 import calendar
 from datetime import date, datetime, time, timedelta
-import types
 import unittest
 
 from pytz import timezone
@@ -161,7 +160,7 @@ class DateTimeFormatTestCase(unittest.TestCase):
         self.assertEqual('4', fmt['c'])  # friday is first day of week
 
     def test_pattern_day_of_week(self):
-        dt = datetime(2016,2,6)
+        dt = datetime(2016, 2, 6)
         fmt = dates.DateTimeFormat(dt, locale='en_US')
         self.assertEqual('7', fmt['c'])
         self.assertEqual('Sat', fmt['ccc'])
@@ -184,7 +183,6 @@ class DateTimeFormatTestCase(unittest.TestCase):
         self.assertEqual('6', fmt['c'])
         self.assertEqual('6', fmt['e'])
         self.assertEqual('06', fmt['ee'])
-
 
     def test_fractional_seconds(self):
         t = time(8, 3, 9, 799)

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -11,7 +11,6 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
 
-import doctest
 import unittest
 import random
 from operator import methodcaller

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals = make
 commands = make clean-cldr test
 
 [pep8]
-ignore = E501,E731
+ignore = E501,E731,W503
 
 [flake8]
-ignore = E501,E731
+ignore = E501,E731,W503


### PR DESCRIPTION
Added `flake8` and `reorder-python-imports` [pre-commit](https://github.com/pre-commit/pre-commit) [hooks](https://github.com/pre-commit/pre-commit-hooks) and applied fixes.