### PR TITLE
imported and exposed support for character order and measurement units and systems

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -885,6 +885,52 @@ class Locale(object):
         """
         return self._data.get('ordinal_form', _default_plural_rule)
 
+    @property
+    def unit_patterns(self):
+        """Locale patterns for units of measurement.
+
+        >>> locale = Locale('fr', 'FR')
+        >>> val = 12
+        >>> unit_length = 'long'
+        >>> unit = 'length-foot' + ':' + unit_length
+        >>> locale.unit_patterns[unit][locale.plural_form(val)].format(val)
+        u'12 pieds'
+        """
+        return self._data['unit_patterns']
+
+    @property
+    def measurement_systems(self):
+        """Locale names for the measurement systems.
+
+        >>> locale = Locale('fr', 'FR')
+        >>> print locale.measurement_systems['US']
+        américain
+        """
+        return self._data['measurement_systems']
+
+    @property
+    def character_order(self):
+        """this locale text direction . the original form.
+
+        >>> Locale('de', 'DE').character_order
+        u'left-to-right'
+        >>> Locale('ar', 'SA').character_order
+        u'right-to-left'
+        """
+        return self._data['character_order']
+
+    @property
+    def direction(self):
+        """this locale text direction  the css form.
+
+        >>> Locale('de', 'DE').direction
+        u'ltr'
+        >>> Locale('ar', 'SA').direction
+        u'rtl'
+        """
+        order = self.character_order
+        return ''.join([word[0] for word in order.split('-')])
+
 
 def default_locale(category=None, aliases=LOCALE_ALIASES):
     """Returns the system default locale for a given category, based on

--- a/babel/core.py
+++ b/babel/core.py
@@ -903,8 +903,8 @@ class Locale(object):
         """Locale names for the measurement systems.
 
         >>> locale = Locale('fr', 'FR')
-        >>> unicode(locale.measurement_systems['US'])
-        américain
+        >>> locale.measurement_systems['US']
+        u'am\xe9ricain'
         """
         return self._data['measurement_systems']
 

--- a/babel/core.py
+++ b/babel/core.py
@@ -903,14 +903,15 @@ class Locale(object):
         """Locale names for the measurement systems.
 
         >>> locale = Locale('fr', 'FR')
-        >>> print locale.measurement_systems['US']
+        >>> unicode(locale.measurement_systems['US'])
         américain
         """
         return self._data['measurement_systems']
 
     @property
     def character_order(self):
-        """this locale text direction . the original form.
+        """The text direction for the locale 
+        ("left-to-right" or "right-to-left").
 
         >>> Locale('de', 'DE').character_order
         u'left-to-right'
@@ -921,7 +922,7 @@ class Locale(object):
 
     @property
     def direction(self):
-        """this locale text direction  the css form.
+        """The text direction for the locale in CSS form ("ltr" or "rtl").
 
         >>> Locale('de', 'DE').direction
         u'ltr'

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -152,6 +152,31 @@ def get_territory_currencies(territory, start_date=None, end_date=None,
     return result
 
 
+def get_unit_name(measurement_unit, count=None, length='long', locale=LC_NUMERIC):
+    """Return the name used by the locale for the specified measurement unit.
+
+    >>> get_unit_name('length-meter', 12, locale='en_US')
+    u'12 metri'
+
+    .. versionadded:: 2.2.0
+
+    :param measurement_unit: the code, in cldr, for the given measurement unit
+    :param length: long or short
+    :param count: the optional count.  If provided the measurement unit name
+                  will be pluralized to that number if possible.
+    :param locale: the `Locale` object or locale identifier
+    """
+    loc = Locale.parse(locale)
+    if count is not None:
+        unit_length = '%s:%s' % (measurement_unit, length)
+        if unit_length in loc.unit_patterns:
+            unit_patterns = loc.unit_patterns[unit_length]
+            plural_form = loc.plural_form(count)
+            if plural_form in unit_patterns:
+                return unit_patterns[plural_form].format(count)
+    return measurement_unit
+
+
 def get_decimal_symbol(locale=LC_NUMERIC):
     """Return the symbol used by the locale to separate decimal fractions.
 

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -155,7 +155,7 @@ def get_territory_currencies(territory, start_date=None, end_date=None,
 def get_unit_name(measurement_unit, count=None, length='long', locale=LC_NUMERIC):
     """Return the name used by the locale for the specified measurement unit.
 
-    >>> get_unit_name('length-meter', 12, locale='en_US')
+    >>> get_unit_name('length-meter', 12, locale='ro_RO')
     u'12 metri'
 
     .. versionadded:: 2.2.0

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -422,6 +422,9 @@ def _process_local_datas(sup, srcdir, destdir, force=False, dump_json=False):
         parse_unit_patterns(data, tree)
         parse_date_fields(data, tree)
 
+        for elem in tree.findall('.//layout/orientation/characterOrder'):
+            data['character_order'] = elem.text
+
         write_datafile(data_filename, data, dump_json=dump_json)
 
 
@@ -479,6 +482,10 @@ def parse_locale_display_names(data, tree):
             continue
         for listPattern in listType.findall('listPatternPart'):
             list_patterns[listPattern.attrib['type']] = _text(listPattern)
+
+    measurement_systems = data.setdefault('measurement_systems', {})
+    for measurement_system in tree.findall('.//measurementSystemNames/measurementSystemName'):
+        measurement_systems[measurement_system.attrib['type']] = _text(measurement_system)
 
 
 def parse_dates(data, tree, sup, regions, territory):
@@ -763,6 +770,13 @@ def parse_unit_patterns(data, tree):
                 box = unit_type
                 box += ':' + unit_length_type
                 unit_patterns.setdefault(box, {})[pattern.attrib['count']] = text_type(pattern.text)
+
+        for unit in elem.findall('compoundUnit'):
+            unit_type = unit.attrib['type']
+            for pattern in unit.findall('compoundUnitPattern'):
+                box = 'compound:' + unit_type
+                box += ':' + unit_length_type
+                unit_patterns[box] = text_type(pattern.text)
 
 
 def parse_date_fields(data, tree):


### PR DESCRIPTION
imported and exposed support for character order:
	>>> Locale('de', 'DE').character_order
	<<< u'left-to-right'
	>>> Locale('ar', 'SA').direction
	<<< u'rtl'

exposed measurement units and measurement systems translation:
	>>> locale = Locale('fr', 'FR')
	>>> val = 12
	>>> unit_length = 'long'
	>>> unit = 'length-foot' + ':' + unit_length
	>>> locale.unit_patterns[unit][locale.plural_form(val)].format(val)
	<<< u'12 pieds'
	>>> locale = Locale('fr', 'FR')
	>>> print locale.measurement_systems['US']
	<<< américain