### PR TITLE
fix typos in messages frontend

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -592,7 +592,7 @@ class update_catalog(Command):
         ('previous', None,
          'keep previous msgids of translated messages')
     ]
-    boolean_options = ['ignore_obsolete', 'no_fuzzy_matching', 'previous', 'update_header_comment']
+    boolean_options = ['no-wrap', 'ignore-obsolete', 'no-fuzzy-matching', 'previous', 'update-header-comment']
 
     def initialize_options(self):
         self.domain = 'messages'


### PR DESCRIPTION
The 'no-wrap', 'ignore-obsolete', 'no-fuzzy-matching', 'previous' and
'update-header-comment' were not correctly parsed in the update_catalog
command.