### PR TITLE
Revert "import_cldr: if lxml is installed, use it"

### DIFF
--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -18,12 +18,9 @@ import re
 import sys
 
 try:
-    import lxml.etree as ElementTree
+    from xml.etree import cElementTree as ElementTree
 except ImportError:
-    try:
-        from xml.etree import cElementTree as ElementTree
-    except ImportError:
-        from xml.etree import ElementTree
+    from xml.etree import ElementTree
 
 # Make sure we're using Babel source, and not some previously installed version
 CHECKOUT_ROOT = os.path.abspath(os.path.join(


### PR DESCRIPTION
This reverts commit 9b5c7f3678167f03ec39fd1c25f98d0e0d41621f.

Addresses https://github.com/python-babel/babel/issues/391, not much else to say. :) FYI @aronbierbaum