### PR TITLE
Default to UTF-8 source encoding (PEP8: python3)

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -398,7 +398,7 @@ def extract_python(fileobj, keywords, comment_tags, options):
     in_def = in_translator_comments = False
     comment_tag = None
 
-    encoding = parse_encoding(fileobj) or options.get('encoding', 'iso-8859-1')
+    encoding = parse_encoding(fileobj) or options.get('encoding', 'UTF-8')
 
     if PY2:
         next_line = fileobj.readline

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -50,6 +50,21 @@ msg10 = dngettext(getDomain(), 'Page', 'Pages', 3)
             (10, 'dngettext', (None, u'Page', u'Pages', None), [])],
             messages)
 
+    def test_extract_default_encoding_ascii(self):
+        buf = BytesIO(b'_("a")')
+        messages = list(extract.extract_python(
+            buf, list(extract.DEFAULT_KEYWORDS), [], {},
+        ))
+        # Should work great in both py2 and py3
+        self.assertEqual([(1, '_', 'a', [])], messages)
+
+    def test_extract_default_encoding_utf8(self):
+        buf = BytesIO(u'_("☃")'.encode('UTF-8'))
+        messages = list(extract.extract_python(
+            buf, list(extract.DEFAULT_KEYWORDS), [], {},
+        ))
+        self.assertEqual([(1, '_', u'☃', [])], messages)
+
     def test_nested_comments(self):
         buf = BytesIO(b"""\
 msg = ngettext('pylon',  # TRANSLATORS: shouldn't be


### PR DESCRIPTION
The following python3 source file:

```python3
print(_('☃'))
```

has UTF-8 encoding (by default without a pragma).  The code I touched (before my change) caused this to be scanned as latin-1 (mojibake)

The section of PEP8 which covers this: http://legacy.python.org/dev/peps/pep-0008/#source-file-encoding