### PR TITLE
Fix the way a local time is constructed in tests

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -624,8 +624,9 @@ def test_get_timezone_name():
     assert dates.get_timezone_name(tz, locale='en', width='long',
                                    zone_variant='daylight') == u'Pacific Daylight Time'
 
+    localnow = datetime.utcnow().replace(tzinfo=timezone('UTC')).astimezone(dates.LOCALTZ)
     assert (dates.get_timezone_name(None, locale='en_US') ==
-            dates.get_timezone_name(datetime.now().replace(tzinfo=dates.LOCALTZ), locale='en_US'))
+            dates.get_timezone_name(localnow, locale='en_US'))
 
     assert (dates.get_timezone_name('Europe/Berlin', locale='en_US') == "Central European Time")
 


### PR DESCRIPTION
When running the test suite from my computer, I had the following failure:

```
====================================================== FAILURES =======================================================
_______________________________________________ test_get_timezone_name ________________________________________________

    def test_get_timezone_name():
        dt = time(15, 30, tzinfo=timezone('America/Los_Angeles'))
        assert (dates.get_timezone_name(dt, locale='en_US') ==
                u'Pacific Standard Time')
        assert (dates.get_timezone_name(dt, locale='en_US', return_zone=True) ==
                u'America/Los_Angeles')
        assert dates.get_timezone_name(dt, width='short', locale='en_US') == u'PST'
    
        tz = timezone('America/Los_Angeles')
        assert dates.get_timezone_name(tz, locale='en_US') == u'Pacific Time'
        assert dates.get_timezone_name(tz, 'short', locale='en_US') == u'PT'
    
        tz = timezone('Europe/Berlin')
        assert (dates.get_timezone_name(tz, locale='de_DE') ==
                u'Mitteleurop\xe4ische Zeit')
        assert (dates.get_timezone_name(tz, locale='pt_BR') ==
                u'Hor\xe1rio da Europa Central')
    
        tz = timezone('America/St_Johns')
        assert dates.get_timezone_name(tz, locale='de_DE') == u'Neufundland-Zeit'
    
        tz = timezone('America/Los_Angeles')
        assert dates.get_timezone_name(tz, locale='en', width='short',
                                       zone_variant='generic') == u'PT'
        assert dates.get_timezone_name(tz, locale='en', width='short',
                                       zone_variant='standard') == u'PST'
        assert dates.get_timezone_name(tz, locale='en', width='short',
                                       zone_variant='daylight') == u'PDT'
        assert dates.get_timezone_name(tz, locale='en', width='long',
                                       zone_variant='generic') == u'Pacific Time'
        assert dates.get_timezone_name(tz, locale='en', width='long',
                                       zone_variant='standard') == u'Pacific Standard Time'
        assert dates.get_timezone_name(tz, locale='en', width='long',
                                       zone_variant='daylight') == u'Pacific Daylight Time'
    
>       assert (dates.get_timezone_name(None, locale='en_US') ==
                dates.get_timezone_name(datetime.now().replace(tzinfo=dates.LOCALTZ), locale='en_US'))
E       assert 'Central European Summer Time' == 'Central Europ...Standard Time'
E         - Central European Summer Time
E         ?                   ^^^^
E         + Central European Standard Time
E         ?                   ^^^^^ +

tests/test_dates.py:627: AssertionError
======================================== 1 failed, 2015 passed in 9.73 seconds ========================================
```

This is due to the way the local time is constructed for the test.  The current mechanism used is:

```python
datetime.now().replace(tzinfo=dates.LOCALTZ)
```

But it has de inconvenience of not dealing properly with DST offsets.  As [recommended by pytz][1]:

> The preferred way of dealing with times is to always work in UTC, converting to localtime only when generating output to be read by humans.

Therefore, the proper way to obtain a current local time would be:

```python
datetime.utcnow().replace(tzinfo=timezone('UTC')).astimezone(dates.LOCALTZ)
```

[1]: http://pytz.sourceforge.net/#localized-times-and-date-arithmetic