### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,5 @@ shall be amended so the history is not cluttered by "fixup commits".
 ## Writing Good Commits
 
 Please see
-http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Good_Commits.html
+https://coala.readthedocs.io/en/latest/Getting_Involved/Writing_Good_Commits.html
 for guidelines on how to write good commits and proper commit messages.

--- a/tests/messages/test_plurals.py
+++ b/tests/messages/test_plurals.py
@@ -38,7 +38,7 @@ def test_get_plural_falls_back_to_default():
 
 
 def test_get_plural():
-    # See http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html for more details.
+    # See https://localization-guide.readthedocs.io/en/latest/l10n/pluralforms.html for more details.
     assert plurals.get_plural(locale='en') == (2, '(n != 1)')
     assert plurals.get_plural(locale='ga') == (3, '(n==1 ? 0 : n==2 ? 1 : 2)')
 


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.