### PR TITLE
Prevent update_catalog from stomping over comments in existing po files

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -753,6 +753,7 @@ class Catalog(object):
             else:
                 oldmsg = remaining.pop(oldkey, None)
             message.string = oldmsg.string
+            message.user_comments = list(distinct(oldmsg.user_comments))
             if isinstance(message.id, (list, tuple)):
                 if not isinstance(message.string, (list, tuple)):
                     fuzzy = True


### PR DESCRIPTION
`pybabel update` will ignore existing comments in a po file. This issue is outlined in greater detail here (https://babel.edgewall.org/ticket/170) and this is the suggested fix. Auto comments are not copied over here as they will work when extractor runs, but user comments are stored in the .po file, therefore will be overwritten unless they are merged in.
