### PR TITLE
Read locale from .po if it has Language header

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -402,6 +402,8 @@ class Catalog(object):
                 self.msgid_bugs_address = value
             elif name == 'last-translator':
                 self.last_translator = value
+            elif name == 'language':
+                self.locale = Locale.parse(value)
             elif name == 'language-team':
                 self.language_team = value
             elif name == 'content-type':

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -29,6 +29,14 @@ msgstr "Voh"''')
         catalog = pofile.read_po(buf, locale='en_US')
         self.assertEqual(Locale('en', 'US'), catalog.locale)
 
+    def test_locale_gets_overridden_by_file(self):
+        buf = StringIO(r'''
+msgid ""
+msgstr ""
+"Language: en_US\n"''')
+        catalog = pofile.read_po(buf, locale='de')
+        self.assertEqual(Locale('en', 'US'), catalog.locale)
+
     def test_preserve_domain(self):
         buf = StringIO(r'''msgid "foo"
 msgstr "Voh"''')
@@ -112,6 +120,7 @@ msgstr ""
 "POT-Creation-Date: 2007-09-27 11:19+0700\n"
 "PO-Revision-Date: 2007-09-27 21:42-0700\n"
 "Last-Translator: John <cleese@bavaria.de>\n"
+"Language: de\n"
 "Language-Team: German Lang <de@babel.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
@@ -128,6 +137,7 @@ msgstr ""
                                   tzinfo=FixedOffsetTimezone(7 * 60)),
                          catalog.creation_date)
         self.assertEqual(u'John <cleese@bavaria.de>', catalog.last_translator)
+        self.assertEqual(Locale('de'), catalog.locale)
         self.assertEqual(u'German Lang <de@babel.org>', catalog.language_team)
         self.assertEqual(u'iso-8859-2', catalog.charset)
         self.assertEqual(True, list(catalog)[0].fuzzy)


### PR DESCRIPTION
When a .po file was written out it would write the "Language"
header, but it wouldn't subsequently read that header back in. This
change makes that symmetric so you can write out a file and get back the
same Catalog by reading it in again.

Additionally other values like charset get overridden when the header is
read, so codify the behavior that the read "Language" header gets set as
the locale of the Catalog object.

Fixes #422 