### PR TITLE
Increase coverage of JSX extraction tests

### DIFF
--- a/tests/messages/test_js_extract.py
+++ b/tests/messages/test_js_extract.py
@@ -108,10 +108,12 @@ class Foo {
             <option value="val1">{ i18n._('String1') }</option>
             <option value="val2">{ i18n._('String 2') }</option>
             <option value="val3">{ i18n._('String 3') }</option>
+            <option value="val4">{ _('String 4') }</option>
+            <option>{ _('String 5') }</option>
         );
     }
 """
-EXPECTED_JSX_MESSAGES = ["hello", "String1", "String 2", "String 3"]
+EXPECTED_JSX_MESSAGES = ["hello", "String1", "String 2", "String 3", "String 4", "String 5"]
 
 
 @pytest.mark.parametrize("jsx_enabled", (False, True))


### PR DESCRIPTION
b5e0ad8 fixed a few bugs with jsx parsing but only added
tests for the lexer. This commit adds a test for the extraction
which did not work before:

```
<tag>{ _"Text" }</tag>
```

This test case is not present yet in the suite, only tags with
attributes (`<tag attr="value">`) are, but they get extracted correctly
already.
