### PR TITLE
Python message extractor respects unicode_literals in __future__

### DIFF
--- a/babel/util.py
+++ b/babel/util.py
@@ -95,6 +95,29 @@ def parse_encoding(fp):
         fp.seek(pos)
 
 
+PYTHON_FUTURE_IMPORT_re = re.compile(
+    r'from\s+__future__\s+import\s+\(*(.+)\)*')
+
+
+def parse_future_flags(fp, encoding='latin-1'):
+    """Parse the compiler flags by :mod:`__future__` from the given Python
+    code.
+    """
+    import __future__
+    pos = fp.tell()
+    fp.seek(0)
+    flags = 0
+    try:
+        body = fp.read().decode(encoding)
+        for m in PYTHON_FUTURE_IMPORT_re.finditer(body):
+            names = [x.strip() for x in m.group(1).split(',')]
+            for name in names:
+                flags |= getattr(__future__, name).compiler_flag
+    finally:
+        fp.seek(pos)
+    return flags
+
+
 def pathmatch(pattern, filename):
     """Extended pathname pattern matching.
 

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -498,3 +498,13 @@ msg = _('')
             return [(1, None, (), ())]
         for x in extract.extract(arbitrary_extractor, BytesIO(b"")):
             assert x[0] == 1
+
+    def test_future(self):
+        buf = BytesIO(br"""
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+nbsp = _('\xa0')
+""")
+        messages = list(extract.extract('python', buf,
+                                        extract.DEFAULT_KEYWORDS, [], {}))
+        assert messages[0][1] == u'\xa0'


### PR DESCRIPTION
This patch fixes #426.