### PR TITLE
Support reading multi line obsolete units in po files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ matrix:
       python: 3.4
     - os: linux
       python: 3.5
-    - os: osx
-      language: generic
-      env:
-      - PYTHON_VERSION=3.5.1
-      - PYENV_ROOT=~/.pyenv
-      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
 
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -73,11 +73,16 @@ def denormalize(string):
         return unescape(string)
 
 
-class _PoFileParser(object):
+class PoFileParser(object):
+    """Support class to  read messages from a ``gettext`` PO (portable object) file
+    and add them to a `Catalog`
 
-    def __init__(self, locale=None, domain=None, ignore_obsolete=False, charset=None):
+    See `read_po` for simple cases.
+    """
+
+    def __init__(self, catalog, ignore_obsolete=False):
+        self.catalog = catalog
         self.ignore_obsolete = ignore_obsolete
-        self.catalog = Catalog(locale=locale, domain=domain, charset=charset)
         self.counter = 0
         self.offset = 0
         self.messages = []
@@ -93,6 +98,10 @@ class _PoFileParser(object):
         self.in_msgctxt = False
 
     def _add_message(self):
+        """
+        Add a message to the catalog based on the current parser state and
+        clear the state ready to process the next message.
+        """
         self.translations.sort()
         if len(self.messages) > 1:
             msgid = tuple([denormalize(m) for m in self.messages])
@@ -193,6 +202,10 @@ class _PoFileParser(object):
             self.user_comments.append(line[1:].strip())
 
     def parse(self, fileobj):
+        """
+        Reads from the file-like object `fileobj` and adds any po file
+        units found in it to the `Catalog` supplied to the constructor.
+        """
 
         for lineno, line in enumerate(fileobj.readlines()):
             line = line.strip()
@@ -264,9 +277,10 @@ def read_po(fileobj, locale=None, domain=None, ignore_obsolete=False, charset=No
     :param ignore_obsolete: whether to ignore obsolete messages in the input
     :param charset: the character set of the catalog.
     """
-    parser = _PoFileParser(locale, domain, ignore_obsolete, charset)
+    catalog = Catalog(locale=locale, domain=domain, charset=charset)
+    parser = PoFileParser(catalog, ignore_obsolete)
     parser.parse(fileobj)
-    return parser.catalog
+    return catalog
 
 
 WORD_SEP = re.compile('('

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -164,6 +164,48 @@ msgstr "Bahr"
         self.assertEqual(1, len(catalog))
         self.assertEqual(0, len(catalog.obsolete))
 
+    def test_multi_line_obsolete_message(self):
+        buf = StringIO(r'''# This is an obsolete message
+#~ msgid ""
+#~ "foo"
+#~ "foo"
+#~ msgstr ""
+#~ "Voh"
+#~ "Vooooh"
+
+# This message is not obsolete
+#: main.py:1
+msgid "bar"
+msgstr "Bahr"
+''')
+        catalog = pofile.read_po(buf)
+        self.assertEqual(1, len(catalog.obsolete))
+        message = catalog.obsolete[u'foofoo']
+        self.assertEqual(u'foofoo', message.id)
+        self.assertEqual(u'VohVooooh', message.string)
+        self.assertEqual(['This is an obsolete message'], message.user_comments)
+
+    def test_unit_following_multi_line_obsolete_message(self):
+        buf = StringIO(r'''# This is an obsolete message
+#~ msgid ""
+#~ "foo"
+#~ "fooooooo"
+#~ msgstr ""
+#~ "Voh"
+#~ "Vooooh"
+
+# This message is not obsolete
+#: main.py:1
+msgid "bar"
+msgstr "Bahr"
+''')
+        catalog = pofile.read_po(buf)
+        self.assertEqual(1, len(catalog))
+        message = catalog[u'bar']
+        self.assertEqual(u'bar', message.id)
+        self.assertEqual(u'Bahr', message.string)
+        self.assertEqual(['This message is not obsolete'], message.user_comments)
+
     def test_with_context(self):
         buf = BytesIO(b'''# Some string in the menu
 #: main.py:1


### PR DESCRIPTION
This fixes issue #27. I also found with multi-line obsolete units it would mark the following unit as obsolete. This fixes that also. 

The fixes are entirely confined to the second commit. The first commit refactors read_po so that all the state is stored on a class. This is just because I found it more readable than having to use lists to store a single boolean which we wanted to update from inside the closures.