### PR TITLE
Use pytz.FixedOffset instead of babel.util.FixedOffsetTimezone

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -18,11 +18,13 @@ from difflib import get_close_matches
 from email import message_from_string
 from copy import copy
 
+from pytz import FixedOffset
+
 from babel import __version__ as VERSION
 from babel.core import Locale
 from babel.dates import format_datetime
 from babel.messages.plurals import get_plural
-from babel.util import odict, distinct, LOCALTZ, FixedOffsetTimezone
+from babel.util import odict, distinct, LOCALTZ
 from babel._compat import string_types, number_types, PY2, cmp
 
 __all__ = ['Message', 'Catalog', 'TranslationError']
@@ -64,7 +66,7 @@ def _parse_datetime_header(value):
         net_mins_offset *= plus_minus
 
         # Create an offset object
-        tzoffset = FixedOffsetTimezone(net_mins_offset)
+        tzoffset = FixedOffset(net_mins_offset)
 
         # Store the offset in a datetime object
         dt = dt.replace(tzinfo=tzoffset)

--- a/babel/util.py
+++ b/babel/util.py
@@ -10,7 +10,6 @@
 """
 
 import codecs
-from datetime import timedelta, tzinfo
 import os
 import re
 import textwrap
@@ -259,31 +258,6 @@ class odict(dict):
 
     def itervalues(self):
         return imap(self.get, self._keys)
-
-
-class FixedOffsetTimezone(tzinfo):
-    """Fixed offset in minutes east from UTC."""
-
-    def __init__(self, offset, name=None):
-        self._offset = timedelta(minutes=offset)
-        if name is None:
-            name = 'Etc/GMT%+d' % offset
-        self.zone = name
-
-    def __str__(self):
-        return self.zone
-
-    def __repr__(self):
-        return '<FixedOffset "%s" %s>' % (self.zone, self._offset)
-
-    def utcoffset(self, dt):
-        return self._offset
-
-    def tzname(self, dt):
-        return self.zone
-
-    def dst(self, dt):
-        return ZERO
 
 
 # Export the localtime functionality here because that's

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -15,9 +15,10 @@ import copy
 import datetime
 import unittest
 
+from pytz import FixedOffset
+
 from babel.dates import format_datetime, UTC
 from babel.messages import catalog
-from babel.util import FixedOffsetTimezone
 
 
 class MessageTestCase(unittest.TestCase):
@@ -302,7 +303,7 @@ class CatalogTestCase(unittest.TestCase):
         self.assertEqual('de <de@example.com>', cat.language_team)
         self.assertEqual('de <de@example.com>', mime_headers['Language-Team'])
 
-        dt = datetime.datetime(2009, 3, 9, 15, 47, tzinfo=FixedOffsetTimezone(-7 * 60))
+        dt = datetime.datetime(2009, 3, 9, 15, 47, tzinfo=FixedOffset(-7 * 60))
         self.assertEqual(dt, cat.revision_date)
         formatted_dt = format_datetime(dt, 'yyyy-MM-dd HH:mmZ', locale='en')
         self.assertEqual(formatted_dt, mime_headers['PO-Revision-Date'])
@@ -468,7 +469,7 @@ def test_datetime_parsing():
     assert val1.year == 2006
     assert val1.month == 6
     assert val1.day == 28
-    assert val1.tzinfo.zone == 'Etc/GMT+120'
+    assert val1.tzinfo.utcoffset(val1).seconds == 120 * 60
 
     val2 = catalog._parse_datetime_header('2006-06-28 23:24')
     assert val2.year == 2006

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -14,10 +14,11 @@
 from datetime import datetime
 import unittest
 
+from pytz import FixedOffset
+
 from babel.core import Locale
 from babel.messages.catalog import Catalog, Message
 from babel.messages import pofile
-from babel.util import FixedOffsetTimezone
 from babel._compat import StringIO, BytesIO
 
 
@@ -131,11 +132,8 @@ msgstr ""
         catalog = pofile.read_po(buf)
         self.assertEqual(1, len(list(catalog)))
         self.assertEqual(u'3.15', catalog.version)
-        self.assertEqual(u'Fliegender Zirkus <fliegender@zirkus.de>',
-                         catalog.msgid_bugs_address)
-        self.assertEqual(datetime(2007, 9, 27, 11, 19,
-                                  tzinfo=FixedOffsetTimezone(7 * 60)),
-                         catalog.creation_date)
+        self.assertEqual(u'Fliegender Zirkus <fliegender@zirkus.de>', catalog.msgid_bugs_address)
+        self.assertEqual(datetime(2007, 9, 27, 11, 19, tzinfo=FixedOffset(7 * 60)), catalog.creation_date)
         self.assertEqual(u'John <cleese@bavaria.de>', catalog.last_translator)
         self.assertEqual(Locale('de'), catalog.locale)
         self.assertEqual(u'German Lang <de@babel.org>', catalog.language_team)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,8 +11,6 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
 
-import unittest
-
 from babel import util
 from babel._compat import BytesIO
 
@@ -42,18 +40,6 @@ def test_odict_pop():
         assert False
     except KeyError:
         assert True
-
-
-class FixedOffsetTimezoneTestCase(unittest.TestCase):
-
-    def test_zone_negative_offset(self):
-        self.assertEqual('Etc/GMT-60', util.FixedOffsetTimezone(-60).zone)
-
-    def test_zone_zero_offset(self):
-        self.assertEqual('Etc/GMT+0', util.FixedOffsetTimezone(0).zone)
-
-    def test_zone_positive_offset(self):
-        self.assertEqual('Etc/GMT+330', util.FixedOffsetTimezone(330).zone)
 
 
 parse_encoding = lambda s: util.parse_encoding(BytesIO(s.encode('utf-8')))


### PR DESCRIPTION
Fixes #215
Fixes #217
Fixes #218
