### PR TITLE
Add option 'add_location' for location line formatting

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -371,7 +371,7 @@ def normalize(string, prefix='', width=76):
 
 def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
              sort_output=False, sort_by_file=False, ignore_obsolete=False,
-             include_previous=False):
+             include_previous=False, include_lineno=True):
     r"""Write a ``gettext`` PO (portable object) template file for a given
     message catalog to the provided file-like object.
 
@@ -413,6 +413,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                             comments
     :param include_previous: include the old msgid as a comment when
                              updating the catalog
+    :param include_lineno: include line number in the location comment
     """
     def _normalize(key, prefix=''):
         return normalize(key, prefix=prefix, width=width)
@@ -486,7 +487,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
         if not no_location:
             locs = []
             for filename, lineno in sorted(message.locations):
-                if lineno:
+                if lineno and include_lineno:
                     locs.append(u'%s:%d' % (filename.replace(os.sep, '/'), lineno))
                 else:
                     locs.append(u'%s' % filename.replace(os.sep, '/'))

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -315,6 +315,37 @@ msgstr[1] ""
             actual_content = f.read()
         self.assertEqual(expected_content, actual_content)
 
+    def test_extraction_add_location_file(self):
+        self.dist.message_extractors = {
+            'project': [
+                ('**/ignored/**.*', 'ignore', None),
+                ('**.py', 'python', None),
+            ]
+        }
+        self.cmd.output_file = 'project/i18n/temp.pot'
+        self.cmd.add_location = 'file'
+        self.cmd.omit_header = True
+
+        self.cmd.finalize_options()
+        self.cmd.run()
+
+        self.assert_pot_file_exists()
+
+        expected_content = r"""#: project/file1.py
+msgid "bar"
+msgstr ""
+
+#: project/file2.py
+msgid "foobar"
+msgid_plural "foobars"
+msgstr[0] ""
+msgstr[1] ""
+
+"""
+        with open(self._pot_file(), 'U') as f:
+            actual_content = f.read()
+        self.assertEqual(expected_content, actual_content)
+
 
 class InitCatalogTestCase(unittest.TestCase):
 
@@ -1354,3 +1385,22 @@ def test_extract_cli_knows_dash_s():
     cmdinst = configure_cli_command("extract -s -o foo babel")
     assert isinstance(cmdinst, extract_messages)
     assert cmdinst.strip_comments
+
+
+def test_extract_add_location():
+    cmdinst = configure_cli_command("extract -o foo babel --add-location full")
+    assert isinstance(cmdinst, extract_messages)
+    assert cmdinst.add_location == 'full'
+    assert not cmdinst.no_location
+    assert cmdinst.include_lineno
+
+    cmdinst = configure_cli_command("extract -o foo babel --add-location file")
+    assert isinstance(cmdinst, extract_messages)
+    assert cmdinst.add_location == 'file'
+    assert not cmdinst.no_location
+    assert not cmdinst.include_lineno
+
+    cmdinst = configure_cli_command("extract -o foo babel --add-location never")
+    assert isinstance(cmdinst, extract_messages)
+    assert cmdinst.add_location == 'never'
+    assert cmdinst.no_location

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -602,6 +602,26 @@ msgstr ""''')
         self.assertEqual(catalog['missing line number'].locations, [(u'broken_file.py', None)])
         self.assertEqual(catalog['broken line number'].locations, [])
 
+    def test_include_lineno(self):
+        catalog = Catalog()
+        catalog.add(u'foo', locations=[('main.py', 1)])
+        catalog.add(u'foo', locations=[('utils.py', 3)])
+        buf = BytesIO()
+        pofile.write_po(buf, catalog, omit_header=True, include_lineno=True)
+        self.assertEqual(b'''#: main.py:1 utils.py:3
+msgid "foo"
+msgstr ""''', buf.getvalue().strip())
+
+    def test_no_include_lineno(self):
+        catalog = Catalog()
+        catalog.add(u'foo', locations=[('main.py', 1)])
+        catalog.add(u'foo', locations=[('utils.py', 3)])
+        buf = BytesIO()
+        pofile.write_po(buf, catalog, omit_header=True, include_lineno=False)
+        self.assertEqual(b'''#: main.py utils.py
+msgid "foo"
+msgstr ""''', buf.getvalue().strip())
+
 
 class PofileFunctionsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Support of add_location option added, can be either 'full', 'file'
or 'never'. 'full' includes both file and line number; 'file' includes
only the file name without line number; 'never' doesn't include the
location comment at all (same as --no-location).

Python babel implementation lacks of this option. We would like to use it to avoid merge conflicts while merging po files.

Option `add_location` is implemented in the GNU xgettext, quote from the manual:

> ‘--add-location=type’
> 
> ```
> Generate ‘#: filename:line’ lines (default).
> 
> The optional type can be either ‘full’, ‘file’, or ‘never’. If it is not given or ‘full’, it generates the lines with both file name and line number. If it is ‘file’, the line number part is omitted. If it is ‘never’, it completely suppresses the lines (same as --no-location).
> ```

https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html
