### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1136,7 +1136,7 @@ def parse_date(string, locale=LC_TIME):
 
     indexes = [(year_idx, 'Y'), (month_idx, 'M'), (day_idx, 'D')]
     indexes.sort()
-    indexes = dict([(item[1], idx) for idx, item in enumerate(indexes)])
+    indexes = {item[1]: idx for idx, item in enumerate(indexes)}
 
     # FIXME: this currently only supports numbers, but should also support month
     #        names, both in the requested locale, and english
@@ -1178,7 +1178,7 @@ def parse_time(string, locale=LC_TIME):
 
     indexes = [(hour_idx, 'H'), (min_idx, 'M'), (sec_idx, 'S')]
     indexes.sort()
-    indexes = dict([(item[1], idx) for idx, item in enumerate(indexes)])
+    indexes = {item[1]: idx for idx, item in enumerate(indexes)}
 
     # FIXME: support 12 hour clock, and 0-based hour specification
     #        and seconds should be optional, maybe minutes too

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -538,7 +538,7 @@ class Catalog(object):
             buf.append('%s: %s' % (name, value))
         flags = set()
         if self.fuzzy:
-            flags |= set(['fuzzy'])
+            flags |= {'fuzzy'}
         yield Message(u'', '\n'.join(buf), flags=flags)
         for key in self._messages:
             yield self._messages[key]
@@ -769,7 +769,7 @@ class Catalog(object):
                 message.string = message.string[0]
             message.flags |= oldmsg.flags
             if fuzzy:
-                message.flags |= set([u'fuzzy'])
+                message.flags |= {u'fuzzy'}
             self[message.id] = message
 
         for message in template:

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -17,9 +17,9 @@ from babel._compat import string_types, izip
 
 #: list of format chars that are compatible to each other
 _string_format_compatibilities = [
-    set(['i', 'd', 'u']),
-    set(['x', 'X']),
-    set(['f', 'F', 'g', 'G'])
+    {'i', 'd', 'u'},
+    {'x', 'X'},
+    {'f', 'F', 'g', 'G'}
 ]
 
 

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 import re
-import sys
 
 from babel._compat import decimal
 
@@ -30,9 +29,6 @@ def extract_operands(source):
         if i == n:
             n = i
         else:
-            # 2.6's Decimal cannot convert from float directly
-            if sys.version_info < (2, 7):
-                n = str(n)
             n = decimal.Decimal(n)
 
     if isinstance(n, decimal.Decimal):
@@ -124,7 +120,7 @@ class PluralRule(object):
         {'one': 'n is 1'}
         """
         _compile = _UnicodeCompiler().compile
-        return dict([(tag, _compile(ast)) for tag, ast in self.abstract])
+        return {tag: _compile(ast) for tag, ast in self.abstract}
 
     tags = property(lambda x: frozenset([i[0] for i in x.abstract]), doc="""
         A set of explicitly defined tags in this rule.  The implicit default
@@ -218,7 +214,7 @@ def to_gettext(rule):
     """
     rule = PluralRule.parse(rule)
 
-    used_tags = rule.tags | set([_fallback_tag])
+    used_tags = rule.tags | {_fallback_tag}
     _compile = _GettextCompiler().compile
     _get_index = [tag for tag in _plural_tags if tag in used_tags].index
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -30,7 +30,6 @@ Python Versions
 
 At the moment the following Python versions should be supported:
 
-*   Python 2.6
 *   Python 2.7
 *   Python 3.3 and up
 *   PyPy tracking 2.7 and 3.2 and up

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -334,7 +334,7 @@ def _process_local_datas(sup, srcdir, destdir, force=False, dump_json=False):
     region_items = sorted(regions.items())
     for group, territory_list in region_items:
         for territory in territory_list:
-            containers = territory_containment.setdefault(territory, set([]))
+            containers = territory_containment.setdefault(territory, set())
             if group in territory_containment:
                 containers |= territory_containment[group]
             containers.add(group)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34, py26-cdecimal, py27-cdecimal
+envlist = py27, pypy, py33, py34, py27-cdecimal
 
 [testenv]
 deps =


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
