### PR TITLE
Pull flags out of regular expressions

### DIFF
--- a/babel/localtime/_unix.py
+++ b/babel/localtime/_unix.py
@@ -5,7 +5,7 @@ import sys
 import pytz
 import subprocess
 
-_systemconfig_tz = re.compile(r'^Time Zone: (.*)$(?m)')
+_systemconfig_tz = re.compile(r'^Time Zone: (.*)$', re.MULTILINE)
 
 
 def _tz_from_env(tzenv):

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -28,7 +28,7 @@ from babel._compat import string_types, number_types, PY2, cmp
 __all__ = ['Message', 'Catalog', 'TranslationError']
 
 
-PYTHON_FORMAT = re.compile(r'''(?x)
+PYTHON_FORMAT = re.compile(r'''
     \%
         (?:\(([\w]*)\))?
         (
@@ -37,7 +37,7 @@ PYTHON_FORMAT = re.compile(r'''(?x)
             [hlL]?
         )
         ([diouxXeEfFgGcrs%])
-''')
+''', re.VERBOSE)
 
 
 def _parse_datetime_header(value):

--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -25,7 +25,7 @@ escapes = {'b': '\b', 'f': '\f', 'n': '\n', 'r': '\r', 't': '\t'}
 name_re = re.compile(r'[\w$_][\w\d$_]*', re.UNICODE)
 dotted_name_re = re.compile(r'[\w$_][\w\d$_.]*[\w\d$_.]', re.UNICODE)
 division_re = re.compile(r'/=?')
-regex_re = re.compile(r'/(?:[^/\\]*(?:\\.[^/\\]*)*)/[a-zA-Z]*(?s)')
+regex_re = re.compile(r'/(?:[^/\\]*(?:\\.[^/\\]*)*)/[a-zA-Z]*', re.DOTALL)
 line_re = re.compile(r'(\r\n|\n|\r)')
 line_join_re = re.compile(r'\\' + line_re.pattern)
 uni_escape_re = re.compile(r'[a-fA-F0-9]{1,4}')
@@ -33,25 +33,25 @@ uni_escape_re = re.compile(r'[a-fA-F0-9]{1,4}')
 Token = namedtuple('Token', 'type value lineno')
 
 _rules = [
-    (None, re.compile(r'\s+(?u)')),
+    (None, re.compile(r'\s+', re.UNICODE)),
     (None, re.compile(r'<!--.*')),
     ('linecomment', re.compile(r'//.*')),
-    ('multilinecomment', re.compile(r'/\*.*?\*/(?us)')),
+    ('multilinecomment', re.compile(r'/\*.*?\*/', re.UNICODE | re.DOTALL)),
     ('dotted_name', dotted_name_re),
     ('name', name_re),
-    ('number', re.compile(r'''(?x)(
+    ('number', re.compile(r'''(
         (?:0|[1-9]\d*)
         (\.\d+)?
         ([eE][-+]?\d+)? |
         (0x[a-fA-F0-9]+)
-    )''')),
+    )''', re.VERBOSE)),
     ('jsx_tag', re.compile(r'(?:</?[^>\s]+|/>)', re.I)),  # May be mangled in `get_rules`
     ('operator', re.compile(r'(%s)' % '|'.join(map(re.escape, operators)))),
     ('template_string', re.compile(r'''`(?:[^`\\]*(?:\\.[^`\\]*)*)`''', re.UNICODE)),
-    ('string', re.compile(r'''(?xs)(
+    ('string', re.compile(r'''(
         '(?:[^'\\]*(?:\\.[^'\\]*)*)'  |
         "(?:[^"\\]*(?:\\.[^"\\]*)*)"
-    )'''))
+    )''', re.VERBOSE | re.DOTALL))
 ]
 
 

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -321,7 +321,7 @@ class RuleError(Exception):
 _VARS = 'nivwft'
 
 _RULES = [
-    (None, re.compile(r'\s+(?u)')),
+    (None, re.compile(r'\s+', re.UNICODE)),
     ('word', re.compile(r'\b(and|or|is|(?:with)?in|not|mod|[{0}])\b'
                         .format(_VARS))),
     ('value', re.compile(r'\d+')),

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -35,7 +35,8 @@ def parse_changelog():
                     break
 
             match = re.search(r'released on (\w+\s+\d+\w+\s+\d+)'
-                              r'(?:, codename (.*))?(?i)', change_info)
+                              r'(?:, codename (.*))?', change_info,
+                              flags=re.IGNORECASE)
             if match is None:
                 continue
 
@@ -68,8 +69,9 @@ def set_filename_version(filename, version_number, pattern):
         changed.append(True)
         return before + version_number + after
     with open(filename) as f:
-        contents = re.sub(r"^(\s*%s\s*=\s*')(.+?)(')(?sm)" % pattern,
-                          inject_version, f.read())
+        contents = re.sub(r"^(\s*%s\s*=\s*')(.+?)(')" % pattern,
+                          inject_version, f.read(),
+                          flags=re.DOTALL | re.MULTILINE)
 
     if not changed:
         fail('Could not find %s in %s', pattern, filename)


### PR DESCRIPTION
In Python, you can pass flags to regular expressions. There are two ways to do so: by passing the flag as a `flag` argument to whatever regex function you're using, or by embedding the flag in the regex itself. If the flag is embedded in the regex, it is ambiguous unless it is at the start of the expression, and in Python 3.6 this is now deprecated.

This pull request pulls all flags out of regexes and passes them via the `flag` argument, instead. This is clearer and more consistent.