### PR TITLE
Make `windows_zone_mapping`lossless. Fixes #464

### DIFF
--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -231,7 +231,7 @@ def parse_global(srcdir, sup):
     _zone_territory_map = {}
     for map_zone in sup_windows_zones.findall('.//windowsZones/mapTimezones/mapZone'):
         if map_zone.attrib.get('territory') == '001':
-            win_mapping[map_zone.attrib['other']] = map_zone.attrib['type'].split()[0]
+            win_mapping[map_zone.attrib['other']] = map_zone.attrib['type'].split()
         for tzid in text_type(map_zone.attrib['type']).split():
             _zone_territory_map[tzid] = text_type(map_zone.attrib['territory'])
     for key_elem in bcp47_timezone.findall('.//keyword/key'):


### PR DESCRIPTION
Changes  `get_global('windows_zone_mapping')` to return tuple values. This preserves all input data and makes it possible to easily make a reverse map without losing keys.