### PR TITLE
Do not override built-in Python function

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -363,7 +363,7 @@ def get_era_names(width='wide', locale=LC_TIME):
     return Locale.parse(locale).eras[width]
 
 
-def get_date_format(format='medium', locale=LC_TIME):
+def get_date_format(pattern='medium', locale=LC_TIME):
     """Return the date formatting patterns used by the locale for the specified
     format.
 
@@ -372,31 +372,31 @@ def get_date_format(format='medium', locale=LC_TIME):
     >>> get_date_format('full', locale='de_DE')
     <DateTimePattern u'EEEE, d. MMMM y'>
 
-    :param format: the format to use, one of "full", "long", "medium", or
+    :param pattern: the format to use, one of "full", "long", "medium", or
                    "short"
     :param locale: the `Locale` object, or a locale string
     """
-    return Locale.parse(locale).date_formats[format]
+    return Locale.parse(locale).date_formats[pattern]
 
 
-def get_datetime_format(format='medium', locale=LC_TIME):
+def get_datetime_format(pattern='medium', locale=LC_TIME):
     """Return the datetime formatting patterns used by the locale for the
     specified format.
 
     >>> get_datetime_format(locale='en_US')
     u'{1}, {0}'
 
-    :param format: the format to use, one of "full", "long", "medium", or
+    :param pattern: the format to use, one of "full", "long", "medium", or
                    "short"
     :param locale: the `Locale` object, or a locale string
     """
     patterns = Locale.parse(locale).datetime_formats
-    if format not in patterns:
-        format = None
-    return patterns[format]
+    if pattern not in patterns:
+        pattern = None
+    return patterns[pattern]
 
 
-def get_time_format(format='medium', locale=LC_TIME):
+def get_time_format(pattern='medium', locale=LC_TIME):
     """Return the time formatting patterns used by the locale for the specified
     format.
 
@@ -405,11 +405,11 @@ def get_time_format(format='medium', locale=LC_TIME):
     >>> get_time_format('full', locale='de_DE')
     <DateTimePattern u'HH:mm:ss zzzz'>
 
-    :param format: the format to use, one of "full", "long", "medium", or
+    :param pattern: the format to use, one of "full", "long", "medium", or
                    "short"
     :param locale: the `Locale` object, or a locale string
     """
-    return Locale.parse(locale).time_formats[format]
+    return Locale.parse(locale).time_formats[pattern]
 
 
 def get_timezone_gmt(datetime=None, width='long', locale=LC_TIME, return_z=False):
@@ -668,13 +668,13 @@ def get_timezone_name(dt_or_tzinfo=None, width='long', uncommon=False,
     return get_timezone_location(dt_or_tzinfo, locale=locale)
 
 
-def format_date(date=None, format='medium', locale=LC_TIME):
+def format_date(date=None, pattern='medium', locale=LC_TIME):
     """Return a date formatted according to the given pattern.
 
     >>> d = date(2007, 4, 1)
     >>> format_date(d, locale='en_US')
     u'Apr 1, 2007'
-    >>> format_date(d, format='full', locale='de_DE')
+    >>> format_date(d, pattern='full', locale='de_DE')
     u'Sonntag, 1. April 2007'
 
     If you don't want to use the locale default formats, you can specify a
@@ -685,7 +685,7 @@ def format_date(date=None, format='medium', locale=LC_TIME):
 
     :param date: the ``date`` or ``datetime`` object; if `None`, the current
                  date is used
-    :param format: one of "full", "long", "medium", or "short", or a custom
+    :param pattern: one of "full", "long", "medium", or "short", or a custom
                    date/time pattern
     :param locale: a `Locale` object or a locale identifier
     """
@@ -695,13 +695,13 @@ def format_date(date=None, format='medium', locale=LC_TIME):
         date = date.date()
 
     locale = Locale.parse(locale)
-    if format in ('full', 'long', 'medium', 'short'):
-        format = get_date_format(format, locale=locale)
-    pattern = parse_pattern(format)
+    if pattern in ('full', 'long', 'medium', 'short'):
+        pattern = get_date_format(pattern, locale=locale)
+    pattern = parse_pattern(pattern)
     return pattern.apply(date, locale)
 
 
-def format_datetime(datetime=None, format='medium', tzinfo=None,
+def format_datetime(datetime=None, pattern='medium', tzinfo=None,
                     locale=LC_TIME):
     r"""Return a date formatted according to the given pattern.
 
@@ -721,7 +721,7 @@ def format_datetime(datetime=None, format='medium', tzinfo=None,
 
     :param datetime: the `datetime` object; if `None`, the current date and
                      time is used
-    :param format: one of "full", "long", "medium", or "short", or a custom
+    :param pattern: one of "full", "long", "medium", or "short", or a custom
                    date/time pattern
     :param tzinfo: the timezone to apply to the time for display
     :param locale: a `Locale` object or a locale identifier
@@ -729,23 +729,23 @@ def format_datetime(datetime=None, format='medium', tzinfo=None,
     datetime = _ensure_datetime_tzinfo(_get_datetime(datetime), tzinfo)
 
     locale = Locale.parse(locale)
-    if format in ('full', 'long', 'medium', 'short'):
-        return get_datetime_format(format, locale=locale) \
+    if pattern in ('full', 'long', 'medium', 'short'):
+        return get_datetime_format(pattern, locale=locale) \
             .replace("'", "") \
-            .replace('{0}', format_time(datetime, format, tzinfo=None,
+            .replace('{0}', format_time(datetime, pattern, tzinfo=None,
                                         locale=locale)) \
-            .replace('{1}', format_date(datetime, format, locale=locale))
+            .replace('{1}', format_date(datetime, pattern, locale=locale))
     else:
-        return parse_pattern(format).apply(datetime, locale)
+        return parse_pattern(pattern).apply(datetime, locale)
 
 
-def format_time(time=None, format='medium', tzinfo=None, locale=LC_TIME):
+def format_time(time=None, pattern='medium', tzinfo=None, locale=LC_TIME):
     r"""Return a time formatted according to the given pattern.
 
     >>> t = time(15, 30)
     >>> format_time(t, locale='en_US')
     u'3:30:00 PM'
-    >>> format_time(t, format='short', locale='de_DE')
+    >>> format_time(t, pattern='short', locale='de_DE')
     u'15:30'
 
     If you don't want to use the locale default formats, you can specify a
@@ -760,7 +760,7 @@ def format_time(time=None, format='medium', tzinfo=None, locale=LC_TIME):
     >>> t = datetime(2007, 4, 1, 15, 30)
     >>> tzinfo = get_timezone('Europe/Paris')
     >>> t = tzinfo.localize(t)
-    >>> format_time(t, format='full', tzinfo=tzinfo, locale='fr_FR')
+    >>> format_time(t, pattern='full', tzinfo=tzinfo, locale='fr_FR')
     u'15:30:00 heure d\u2019\xe9t\xe9 d\u2019Europe centrale'
     >>> format_time(t, "hh 'o''clock' a, zzzz", tzinfo=get_timezone('US/Eastern'),
     ...             locale='en')
@@ -780,16 +780,16 @@ def format_time(time=None, format='medium', tzinfo=None, locale=LC_TIME):
     parameter is only used to display the timezone name if needed:
 
     >>> t = time(15, 30)
-    >>> format_time(t, format='full', tzinfo=get_timezone('Europe/Paris'),
+    >>> format_time(t, pattern='full', tzinfo=get_timezone('Europe/Paris'),
     ...             locale='fr_FR')
     u'15:30:00 heure normale d\u2019Europe centrale'
-    >>> format_time(t, format='full', tzinfo=get_timezone('US/Eastern'),
+    >>> format_time(t, pattern='full', tzinfo=get_timezone('US/Eastern'),
     ...             locale='en_US')
     u'3:30:00 PM Eastern Standard Time'
 
     :param time: the ``time`` or ``datetime`` object; if `None`, the current
                  time in UTC is used
-    :param format: one of "full", "long", "medium", or "short", or a custom
+    :param pattern: one of "full", "long", "medium", or "short", or a custom
                    date/time pattern
     :param tzinfo: the time-zone to apply to the time for display
     :param locale: a `Locale` object or a locale identifier
@@ -797,9 +797,9 @@ def format_time(time=None, format='medium', tzinfo=None, locale=LC_TIME):
     time = _get_time(time, tzinfo)
 
     locale = Locale.parse(locale)
-    if format in ('full', 'long', 'medium', 'short'):
-        format = get_time_format(format, locale=locale)
-    return parse_pattern(format).apply(time, locale)
+    if pattern in ('full', 'long', 'medium', 'short'):
+        pattern = get_time_format(pattern, locale=locale)
+    return parse_pattern(pattern).apply(time, locale)
 
 
 def format_skeleton(skeleton, datetime=None, tzinfo=None, fuzzy=True, locale=LC_TIME):
@@ -836,8 +836,8 @@ def format_skeleton(skeleton, datetime=None, tzinfo=None, fuzzy=True, locale=LC_
     locale = Locale.parse(locale)
     if fuzzy and skeleton not in locale.datetime_skeletons:
         skeleton = match_skeleton(skeleton, locale.datetime_skeletons)
-    format = locale.datetime_skeletons[skeleton]
-    return format_datetime(datetime, format, tzinfo, locale)
+    pattern = locale.datetime_skeletons[skeleton]
+    return format_datetime(datetime, pattern, tzinfo, locale)
 
 
 TIMEDELTA_UNITS = (
@@ -852,7 +852,7 @@ TIMEDELTA_UNITS = (
 
 
 def format_timedelta(delta, granularity='second', threshold=.85,
-                     add_direction=False, format='long',
+                     add_direction=False, pattern='long',
                      locale=LC_TIME):
     """Return a time delta according to the rules of the given locale.
 
@@ -887,9 +887,9 @@ def format_timedelta(delta, granularity='second', threshold=.85,
 
     The format parameter controls how compact or wide the presentation is:
 
-    >>> format_timedelta(timedelta(hours=3), format='short', locale='en')
+    >>> format_timedelta(timedelta(hours=3), pattern='short', locale='en')
     u'3 hr'
-    >>> format_timedelta(timedelta(hours=3), format='narrow', locale='en')
+    >>> format_timedelta(timedelta(hours=3), pattern='narrow', locale='en')
     u'3h'
 
     :param delta: a ``timedelta`` object representing the time difference to
@@ -904,18 +904,18 @@ def format_timedelta(delta, granularity='second', threshold=.85,
                           positive timedelta will include the information about
                           it being in the future, a negative will be information
                           about the value being in the past.
-    :param format: the format, can be "narrow", "short" or "long". (
+    :param pattern: the format, can be "narrow", "short" or "long". (
                    "medium" is deprecated, currently converted to "long" to
                    maintain compatibility)
     :param locale: a `Locale` object or a locale identifier
     """
-    if format not in ('narrow', 'short', 'medium', 'long'):
+    if pattern not in ('narrow', 'short', 'medium', 'long'):
         raise TypeError('Format must be one of "narrow", "short" or "long"')
-    if format == 'medium':
+    if pattern == 'medium':
         warnings.warn('"medium" value for format param of format_timedelta'
                       ' is deprecated. Use "long" instead',
                       category=DeprecationWarning)
-        format = 'long'
+        pattern = 'long'
     if isinstance(delta, timedelta):
         seconds = int((delta.days * 86400) + delta.seconds)
     else:
@@ -930,7 +930,7 @@ def format_timedelta(delta, granularity='second', threshold=.85,
             else:
                 yield unit_rel_patterns['past']
         a_unit = 'duration-' + a_unit
-        yield locale._data['unit_patterns'].get(a_unit, {}).get(format)
+        yield locale._data['unit_patterns'].get(a_unit, {}).get(pattern)
 
     for unit, secs_per_unit in TIMEDELTA_UNITS:
         value = abs(seconds) / secs_per_unit
@@ -954,16 +954,16 @@ def format_timedelta(delta, granularity='second', threshold=.85,
 
 def _format_fallback_interval(start, end, skeleton, tzinfo, locale):
     if skeleton in locale.datetime_skeletons:  # Use the given skeleton
-        format = lambda dt: format_skeleton(skeleton, dt, tzinfo, locale=locale)
+        pattern = lambda dt: format_skeleton(skeleton, dt, tzinfo, locale=locale)
     elif all((isinstance(d, date) and not isinstance(d, datetime)) for d in (start, end)):  # Both are just dates
-        format = lambda dt: format_date(dt, locale=locale)
+        pattern = lambda dt: format_date(dt, locale=locale)
     elif all((isinstance(d, time) and not isinstance(d, date)) for d in (start, end)):  # Both are times
-        format = lambda dt: format_time(dt, tzinfo=tzinfo, locale=locale)
+        pattern = lambda dt: format_time(dt, tzinfo=tzinfo, locale=locale)
     else:
-        format = lambda dt: format_datetime(dt, tzinfo=tzinfo, locale=locale)
+        pattern = lambda dt: format_datetime(dt, tzinfo=tzinfo, locale=locale)
 
-    formatted_start = format(start)
-    formatted_end = format(end)
+    formatted_start = pattern(start)
+    formatted_end = pattern(end)
 
     if formatted_start == formatted_end:
         return format(start)
@@ -1142,12 +1142,12 @@ def parse_date(string, locale=LC_TIME):
     :param locale: a `Locale` object or a locale identifier
     """
     # TODO: try ISO format first?
-    format = get_date_format(locale=locale).pattern.lower()
-    year_idx = format.index('y')
-    month_idx = format.index('m')
+    pattern = get_date_format(locale=locale).pattern.lower()
+    year_idx = pattern.index('y')
+    month_idx = pattern.index('m')
     if month_idx < 0:
-        month_idx = format.index('l')
-    day_idx = format.index('d')
+        month_idx = pattern.index('l')
+    day_idx = pattern.index('d')
 
     indexes = [(year_idx, 'Y'), (month_idx, 'M'), (day_idx, 'D')]
     indexes.sort()
@@ -1184,12 +1184,12 @@ def parse_time(string, locale=LC_TIME):
     :rtype: `time`
     """
     # TODO: try ISO format first?
-    format = get_time_format(locale=locale).pattern.lower()
-    hour_idx = format.index('h')
+    pattern = get_time_format(locale=locale).pattern.lower()
+    hour_idx = pattern.index('h')
     if hour_idx < 0:
-        hour_idx = format.index('k')
-    min_idx = format.index('m')
-    sec_idx = format.index('s')
+        hour_idx = pattern.index('k')
+    min_idx = pattern.index('m')
+    sec_idx = pattern.index('s')
 
     indexes = [(hour_idx, 'H'), (min_idx, 'M'), (sec_idx, 'S')]
     indexes.sort()
@@ -1357,23 +1357,23 @@ class DateTimeFormat(object):
         """
         Return weekday from parsed datetime according to format pattern.
 
-        >>> format = DateTimeFormat(date(2016, 2, 28), Locale.parse('en_US'))
-        >>> format.format_weekday()
+        >>> pattern = DateTimeFormat(date(2016, 2, 28), Locale.parse('en_US'))
+        >>> pattern.format_weekday()
         u'Sunday'
 
         'E': Day of week - Use one through three letters for the abbreviated day name, four for the full (wide) name,
              five for the narrow name, or six for the short name.
-        >>> format.format_weekday('E',2)
+        >>> pattern.format_weekday('E',2)
         u'Sun'
 
         'e': Local day of week. Same as E except adds a numeric value that will depend on the local starting day of the
              week, using one or two letters. For this example, Monday is the first day of the week.
-        >>> format.format_weekday('e',2)
+        >>> pattern.format_weekday('e',2)
         '01'
 
         'c': Stand-Alone local day of week - Use one letter for the local numeric value (same as 'e'), three for the
              abbreviated day name, four for the full (wide) name, five for the narrow name, or six for the short name.
-        >>> format.format_weekday('c',1)
+        >>> pattern.format_weekday('c',1)
         '1'
 
         :param char: pattern format character ('e','E','c')
@@ -1480,12 +1480,12 @@ class DateTimeFormat(object):
         first week of the period is so short that it actually counts as the last
         week of the previous period, this function will return 0.
 
-        >>> format = DateTimeFormat(date(2006, 1, 8), Locale.parse('de_DE'))
-        >>> format.get_week_number(6)
+        >>> pattern = DateTimeFormat(date(2006, 1, 8), Locale.parse('de_DE'))
+        >>> pattern.get_week_number(6)
         1
 
-        >>> format = DateTimeFormat(date(2006, 1, 8), Locale.parse('en_US'))
-        >>> format.get_week_number(6)
+        >>> pattern = DateTimeFormat(date(2006, 1, 8), Locale.parse('en_US'))
+        >>> pattern.get_week_number(6)
         2
 
         :param day_of_period: the number of the day in the period (usually

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -59,16 +59,16 @@ def python_format(catalog, message):
             _validate_format(msgid, msgstr)
 
 
-def _validate_format(format, alternative):
-    """Test format string `alternative` against `format`.  `format` can be the
+def _validate_format(pattern, alternative):
+    """Test format string `alternative` against `pattern`.  `pattern` can be the
     msgid of a message and `alternative` one of the `msgstr`\s.  The two
     arguments are not interchangeable as `alternative` may contain less
-    placeholders if `format` uses named placeholders.
+    placeholders if `pattern` uses named placeholders.
 
     The behavior of this function is undefined if the string does not use
     string formattings.
 
-    If the string formatting of `alternative` is compatible to `format` the
+    If the string formatting of `alternative` is compatible to `pattern` the
     function returns `None`, otherwise a `TranslationError` is raised.
 
     Examples for compatible format strings:
@@ -85,7 +85,7 @@ def _validate_format(format, alternative):
 
     This function is used by the `python_format` checker.
 
-    :param format: The original format string
+    :param pattern: The original format string
     :param alternative: The alternative format string that should be checked
                         against format
     :raises TranslationError: on formatting errors
@@ -94,7 +94,7 @@ def _validate_format(format, alternative):
     def _parse(string):
         result = []
         for match in PYTHON_FORMAT.finditer(string):
-            name, format, typechar = match.groups()
+            name, pattern, typechar = match.groups()
             if typechar == '%' and name is None:
                 continue
             result.append((name, str(typechar)))
@@ -119,7 +119,7 @@ def _validate_format(format, alternative):
                                            'and named placeholders')
         return bool(positional)
 
-    a, b = map(_parse, (format, alternative))
+    a, b = map(_parse, (pattern, alternative))
 
     # now check if both strings are positional or named
     a_positional, b_positional = map(_check_positional, (a, b))

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -811,10 +811,10 @@ class CommandLineInterface(object):
             identifiers = localedata.locale_identifiers()
             longest = max([len(identifier) for identifier in identifiers])
             identifiers.sort()
-            format = u'%%-%ds %%s' % (longest + 1)
+            pattern = u'%%-%ds %%s' % (longest + 1)
             for identifier in identifiers:
                 locale = Locale.parse(identifier)
-                output = format % (identifier, locale.english_name)
+                output = pattern % (identifier, locale.english_name)
                 print(output.encode(sys.stdout.encoding or
                                     getpreferredencoding() or
                                     'ascii', 'replace'))
@@ -850,10 +850,10 @@ class CommandLineInterface(object):
         print(self.parser.format_help())
         print("commands:")
         longest = max([len(command) for command in self.commands])
-        format = "  %%-%ds %%s" % max(8, longest + 1)
+        pattern = "  %%-%ds %%s" % max(8, longest + 1)
         commands = sorted(self.commands.items())
         for name, description in commands:
-            print(format % (name, description))
+            print(pattern % (name, description))
 
     def _configure_command(self, cmdname, argv):
         """

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -223,7 +223,7 @@ def format_number(number, locale=LC_NUMERIC):
     return format_decimal(number, locale=locale)
 
 
-def format_decimal(number, format=None, locale=LC_NUMERIC):
+def format_decimal(number, pattern=None, locale=LC_NUMERIC):
     u"""Return the given decimal number formatted for a specific locale.
 
     >>> format_decimal(1.2345, locale='en_US')
@@ -244,13 +244,13 @@ def format_decimal(number, format=None, locale=LC_NUMERIC):
     u'12,345.5'
 
     :param number: the number to format
-    :param format:
+    :param pattern:
     :param locale: the `Locale` object or locale identifier
     """
     locale = Locale.parse(locale)
-    if not format:
-        format = locale.decimal_formats.get(format)
-    pattern = parse_pattern(format)
+    if not pattern:
+        pattern = locale.decimal_formats.get(pattern)
+    pattern = parse_pattern(pattern)
     return pattern.apply(number, locale)
 
 
@@ -258,7 +258,7 @@ class UnknownCurrencyFormatError(KeyError):
     """Exception raised when an unknown currency format is requested."""
 
 
-def format_currency(number, currency, format=None, locale=LC_NUMERIC,
+def format_currency(number, currency, pattern=None, locale=LC_NUMERIC,
                     currency_digits=True, format_type='standard'):
     u"""Return formatted currency value.
 
@@ -311,14 +311,14 @@ def format_currency(number, currency, format=None, locale=LC_NUMERIC,
 
     :param number: the number to format
     :param currency: the currency code
-    :param format: the format string to use
+    :param pattern: the format string to use
     :param locale: the `Locale` object or locale identifier
     :param currency_digits: use the currency's number of decimal digits
     :param format_type: the currency format type to use
     """
     locale = Locale.parse(locale)
-    if format:
-        pattern = parse_pattern(format)
+    if pattern:
+        pattern = parse_pattern(pattern)
     else:
         try:
             pattern = locale.currency_formats[format_type]
@@ -337,7 +337,7 @@ def format_currency(number, currency, format=None, locale=LC_NUMERIC,
     return pattern.apply(number, locale, currency=currency, force_frac=frac)
 
 
-def format_percent(number, format=None, locale=LC_NUMERIC):
+def format_percent(number, pattern=None, locale=LC_NUMERIC):
     """Return formatted percent value for a specific locale.
 
     >>> format_percent(0.34, locale='en_US')
@@ -353,17 +353,17 @@ def format_percent(number, format=None, locale=LC_NUMERIC):
     u'25,123\u2030'
 
     :param number: the percent number to format
-    :param format:
+    :param pattern:
     :param locale: the `Locale` object or locale identifier
     """
     locale = Locale.parse(locale)
-    if not format:
-        format = locale.percent_formats.get(format)
-    pattern = parse_pattern(format)
+    if not pattern:
+        pattern = locale.percent_formats.get(pattern)
+    pattern = parse_pattern(pattern)
     return pattern.apply(number, locale)
 
 
-def format_scientific(number, format=None, locale=LC_NUMERIC):
+def format_scientific(number, pattern=None, locale=LC_NUMERIC):
     """Return value formatted in scientific notation for a specific locale.
 
     >>> format_scientific(10000, locale='en_US')
@@ -375,13 +375,13 @@ def format_scientific(number, format=None, locale=LC_NUMERIC):
     u'1.23E06'
 
     :param number: the number to format
-    :param format:
+    :param pattern:
     :param locale: the `Locale` object or locale identifier
     """
     locale = Locale.parse(locale)
-    if not format:
-        format = locale.scientific_formats.get(format)
-    pattern = parse_pattern(format)
+    if not pattern:
+        pattern = locale.scientific_formats.get(pattern)
+    pattern = parse_pattern(pattern)
     return pattern.apply(number, locale)
 
 

--- a/babel/support.py
+++ b/babel/support.py
@@ -45,7 +45,7 @@ class Format(object):
         self.locale = Locale.parse(locale)
         self.tzinfo = tzinfo
 
-    def date(self, date=None, format='medium'):
+    def date(self, date=None, pattern='medium'):
         """Return a date formatted according to the given pattern.
 
         >>> from datetime import date
@@ -53,9 +53,9 @@ class Format(object):
         >>> fmt.date(date(2007, 4, 1))
         u'Apr 1, 2007'
         """
-        return format_date(date, format, locale=self.locale)
+        return format_date(date, pattern, locale=self.locale)
 
-    def datetime(self, datetime=None, format='medium'):
+    def datetime(self, datetime=None, pattern='medium'):
         """Return a date and time formatted according to the given pattern.
 
         >>> from datetime import datetime
@@ -64,10 +64,10 @@ class Format(object):
         >>> fmt.datetime(datetime(2007, 4, 1, 15, 30))
         u'Apr 1, 2007, 11:30:00 AM'
         """
-        return format_datetime(datetime, format, tzinfo=self.tzinfo,
+        return format_datetime(datetime, pattern, tzinfo=self.tzinfo,
                                locale=self.locale)
 
-    def time(self, time=None, format='medium'):
+    def time(self, time=None, pattern='medium'):
         """Return a time formatted according to the given pattern.
 
         >>> from datetime import datetime
@@ -76,10 +76,10 @@ class Format(object):
         >>> fmt.time(datetime(2007, 4, 1, 15, 30))
         u'11:30:00 AM'
         """
-        return format_time(time, format, tzinfo=self.tzinfo, locale=self.locale)
+        return format_time(time, pattern, tzinfo=self.tzinfo, locale=self.locale)
 
     def timedelta(self, delta, granularity='second', threshold=.85,
-                  format='medium', add_direction=False):
+                  pattern='medium', add_direction=False):
         """Return a time delta according to the rules of the given locale.
 
         >>> from datetime import timedelta
@@ -89,7 +89,7 @@ class Format(object):
         """
         return format_timedelta(delta, granularity=granularity,
                                 threshold=threshold,
-                                format=format, add_direction=add_direction,
+                                pattern=pattern, add_direction=add_direction,
                                 locale=self.locale)
 
     def number(self, number):
@@ -101,28 +101,28 @@ class Format(object):
         """
         return format_number(number, locale=self.locale)
 
-    def decimal(self, number, format=None):
+    def decimal(self, number, pattern=None):
         """Return a decimal number formatted for the locale.
 
         >>> fmt = Format('en_US')
         >>> fmt.decimal(1.2345)
         u'1.234'
         """
-        return format_decimal(number, format, locale=self.locale)
+        return format_decimal(number, pattern, locale=self.locale)
 
     def currency(self, number, currency):
         """Return a number in the given currency formatted for the locale.
         """
         return format_currency(number, currency, locale=self.locale)
 
-    def percent(self, number, format=None):
+    def percent(self, number, pattern=None):
         """Return a number formatted as percentage for the locale.
 
         >>> fmt = Format('en_US')
         >>> fmt.percent(0.34)
         u'34%'
         """
-        return format_percent(number, format, locale=self.locale)
+        return format_percent(number, pattern, locale=self.locale)
 
     def scientific(self, number):
         """Return a number formatted using scientific notation for the locale.

--- a/babel/units.py
+++ b/babel/units.py
@@ -65,7 +65,7 @@ def _find_unit_pattern(unit_id, locale=LC_NUMERIC):
             return unit_pattern
 
 
-def format_unit(value, measurement_unit, length='long', format=None, locale=LC_NUMERIC):
+def format_unit(value, measurement_unit, length='long', pattern=None, locale=LC_NUMERIC):
     """Format a value of a given unit.
 
     Values are formatted according to the locale's usual pluralization rules
@@ -78,10 +78,10 @@ def format_unit(value, measurement_unit, length='long', format=None, locale=LC_N
     >>> format_unit(1200, 'pressure-inch-hg', locale='nb')
     u'1\\xa0200 tommer kvikks\\xf8lv'
 
-    Number formats may be overridden with the ``format`` parameter.
+    Number formats may be overridden with the ``pattern`` parameter.
 
     >>> from babel._compat import decimal
-    >>> format_unit(decimal.Decimal("-42.774"), 'temperature-celsius', 'short', format='#.0', locale='fr')
+    >>> format_unit(decimal.Decimal("-42.774"), 'temperature-celsius', 'short', pattern='#.0', locale='fr')
     u'-42,8 \\xb0C'
 
     The locale's usual pluralization rules are respected.
@@ -107,7 +107,7 @@ def format_unit(value, measurement_unit, length='long', format=None, locale=LC_N
                              Known units can be found in the CLDR Unit Validity XML file:
                              http://unicode.org/repos/cldr/tags/latest/common/validity/unit.xml
     :param length: "short", "long" or "narrow"
-    :param format: An optional format, as accepted by `format_decimal`.
+    :param pattern: An optional format, as accepted by `format_decimal`.
     :param locale: the `Locale` object or locale identifier
     """
     locale = Locale.parse(locale)
@@ -121,7 +121,7 @@ def format_unit(value, measurement_unit, length='long', format=None, locale=LC_N
         formatted_value = value
         plural_form = "one"
     else:
-        formatted_value = format_decimal(value, format, locale)
+        formatted_value = format_decimal(value, pattern, locale)
         plural_form = locale.plural_form(value)
 
     if plural_form in unit_patterns:
@@ -186,7 +186,7 @@ def _find_compound_unit(numerator_unit, denominator_unit, locale=LC_NUMERIC):
 def format_compound_unit(
     numerator_value, numerator_unit=None,
     denominator_value=1, denominator_unit=None,
-    length='long', format=None, locale=LC_NUMERIC
+    length='long', pattern=None, locale=LC_NUMERIC
 ):
     """
     Format a compound number value, i.e. "kilometers per hour" or similar.
@@ -228,7 +228,7 @@ def format_compound_unit(
                               in which case it is considered preformatted and the unit is ignored.
     :param denominator_unit: The denominator unit. See `format_unit`.
     :param length: The formatting length. "short", "long" or "narrow"
-    :param format: An optional format, as accepted by `format_decimal`.
+    :param pattern: An optional format, as accepted by `format_decimal`.
     :param locale: the `Locale` object or locale identifier
     :return: A formatted compound value.
     """
@@ -239,7 +239,7 @@ def format_compound_unit(
     if numerator_unit and denominator_unit and denominator_value == 1:
         compound_unit = _find_compound_unit(numerator_unit, denominator_unit, locale=locale)
         if compound_unit:
-            return format_unit(numerator_value, compound_unit, length=length, format=format, locale=locale)
+            return format_unit(numerator_value, compound_unit, length=length, pattern=pattern, locale=locale)
 
     # ... failing that, construct one "by hand".
 
@@ -247,10 +247,10 @@ def format_compound_unit(
         formatted_numerator = numerator_value
     elif numerator_unit:  # Numerator has unit
         formatted_numerator = format_unit(
-            numerator_value, numerator_unit, length=length, format=format, locale=locale
+            numerator_value, numerator_unit, length=length, pattern=pattern, locale=locale
         )
     else:  # Unitless numerator
-        formatted_numerator = format_decimal(numerator_value, format=format, locale=locale)
+        formatted_numerator = format_decimal(numerator_value, pattern=pattern, locale=locale)
 
     if isinstance(denominator_value, string_types):  # Denominator is preformatted
         formatted_denominator = denominator_value
@@ -266,10 +266,10 @@ def format_compound_unit(
             denominator_value = ""
 
         formatted_denominator = format_unit(
-            denominator_value, denominator_unit, length=length, format=format, locale=locale
+            denominator_value, denominator_unit, length=length, pattern=pattern, locale=locale
         ).strip()
     else:  # Bare denominator
-        formatted_denominator = format_decimal(denominator_value, format=format, locale=locale)
+        formatted_denominator = format_decimal(denominator_value, pattern=pattern, locale=locale)
 
     per_pattern = locale._data["compound_unit_patterns"].get("per", {}).get(length, "{0}/{1}")
 

--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -26,7 +26,7 @@ Babel provides functions for locale-specific formatting of those objects in its
 As this example demonstrates, Babel will automatically choose a date format
 that is appropriate for the requested locale.
 
-The ``format_*()`` functions also accept an optional ``format`` argument, which
+The ``format_*()`` functions also accept an optional ``pattern`` argument, which
 allows you to choose between one of four format variations:
 
  * ``short``,
@@ -38,11 +38,11 @@ For example:
 
 .. code-block:: pycon
 
-    >>> format_date(d, format='short', locale='en')
+    >>> format_date(d, pattern='short', locale='en')
     u'4/1/07'
-    >>> format_date(d, format='long', locale='en')
+    >>> format_date(d, pattern='long', locale='en')
     u'April 1, 2007'
-    >>> format_date(d, format='full', locale='en')
+    >>> format_date(d, pattern='full', locale='en')
     u'Sunday, April 1, 2007'
 
 Core Time Concepts

--- a/docs/numbers.rst
+++ b/docs/numbers.rst
@@ -38,9 +38,9 @@ Examples:
 
 .. code-block:: pycon
 
-    >>> format_decimal(-1.2345, format='#,##0.##;-#', locale='en')
+    >>> format_decimal(-1.2345, pattern='#,##0.##;-#', locale='en')
     u'-1.23'
-    >>> format_decimal(-1.2345, format='#,##0.##;(#)', locale='en')
+    >>> format_decimal(-1.2345, pattern='#,##0.##;(#)', locale='en')
     u'(1.23)'
 
 The syntax for custom number format patterns is described in detail in the
@@ -101,7 +101,7 @@ current context before formatting a number or currency:
 
     >>> from babel.numbers import decimal, format_decimal
     >>> with decimal.localcontext(decimal.Context(rounding=decimal.ROUND_DOWN)):
-    >>>    txt = format_decimal(123.99, format='#', locale='en_US')
+    >>>    txt = format_decimal(123.99, pattern='#', locale='en_US')
     >>> txt
     u'123'
 
@@ -124,7 +124,7 @@ unexpected results on Python 2.7, with the `cdecimal`_ module installed:
     >>> from decimal import localcontext, Context, ROUND_DOWN
     >>> from babel.numbers import format_decimal
     >>> with localcontext(Context(rounding=ROUND_DOWN)):
-    >>>    txt = format_decimal(123.99, format='#', locale='en_US')
+    >>>    txt = format_decimal(123.99, pattern='#', locale='en_US')
     >>> txt
     u'124'
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -629,8 +629,8 @@ def parse_calendar_periods(data, calendar):
 
 def parse_calendar_date_formats(data, calendar):
     date_formats = data.setdefault('date_formats', {})
-    for format in calendar.findall('dateFormats'):
-        for elem in format.getiterator():
+    for pattern in calendar.findall('dateFormats'):
+        for elem in pattern.getiterator():
             if elem.tag == 'dateFormatLength':
                 type = elem.attrib.get('type')
                 if _should_skip_elem(elem, type, date_formats):
@@ -649,8 +649,8 @@ def parse_calendar_date_formats(data, calendar):
 
 def parse_calendar_time_formats(data, calendar):
     time_formats = data.setdefault('time_formats', {})
-    for format in calendar.findall('timeFormats'):
-        for elem in format.getiterator():
+    for pattern in calendar.findall('timeFormats'):
+        for elem in pattern.getiterator():
             if elem.tag == 'timeFormatLength':
                 type = elem.attrib.get('type')
                 if _should_skip_elem(elem, type, time_formats):
@@ -670,8 +670,8 @@ def parse_calendar_time_formats(data, calendar):
 def parse_calendar_datetime_skeletons(data, calendar):
     datetime_formats = data.setdefault('datetime_formats', {})
     datetime_skeletons = data.setdefault('datetime_skeletons', {})
-    for format in calendar.findall('dateTimeFormats'):
-        for elem in format.getiterator():
+    for pattern in calendar.findall('dateTimeFormats'):
+        for elem in pattern.getiterator():
             if elem.tag == 'dateTimeFormatLength':
                 type = elem.attrib.get('type')
                 if _should_skip_elem(elem, type, datetime_formats):

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -291,7 +291,7 @@ class FormatDatetimeTestCase(unittest.TestCase):
     def test_with_float(self):
         d = datetime(2012, 4, 1, 15, 30, 29, tzinfo=timezone('UTC'))
         epoch = float(calendar.timegm(d.timetuple()))
-        formatted_string = dates.format_datetime(epoch, format='long', locale='en_US')
+        formatted_string = dates.format_datetime(epoch, pattern='long', locale='en_US')
         self.assertEqual(u'April 1, 2012 at 3:30:29 PM +0000', formatted_string)
 
     def test_timezone_formats(self):
@@ -429,7 +429,7 @@ class FormatTimeTestCase(unittest.TestCase):
     def test_with_float(self):
         d = datetime(2012, 4, 1, 15, 30, 29, tzinfo=timezone('UTC'))
         epoch = float(calendar.timegm(d.timetuple()))
-        formatted_time = dates.format_time(epoch, format='long', locale='en_US')
+        formatted_time = dates.format_time(epoch, pattern='long', locale='en_US')
         self.assertEqual(u'3:30:29 PM +0000', formatted_time)
 
     def test_with_date_fields_in_pattern(self):
@@ -448,14 +448,14 @@ class FormatTimedeltaTestCase(unittest.TestCase):
         string = dates.format_timedelta(timedelta(seconds=0), locale='en')
         self.assertEqual('0 seconds', string)
         string = dates.format_timedelta(timedelta(seconds=0), locale='en',
-                                        format='short')
+                                        pattern='short')
         self.assertEqual('0 sec', string)
         string = dates.format_timedelta(timedelta(seconds=0),
                                         granularity='hour', locale='en')
         self.assertEqual('0 hours', string)
         string = dates.format_timedelta(timedelta(seconds=0),
                                         granularity='hour', locale='en',
-                                        format='short')
+                                        pattern='short')
         self.assertEqual('0 hr', string)
 
     def test_small_value_with_granularity(self):
@@ -464,7 +464,7 @@ class FormatTimedeltaTestCase(unittest.TestCase):
         self.assertEqual('1 hour', string)
         string = dates.format_timedelta(timedelta(seconds=42),
                                         granularity='hour', locale='en',
-                                        format='short')
+                                        pattern='short')
         self.assertEqual('1 hr', string)
 
     def test_direction_adding(self):
@@ -479,19 +479,19 @@ class FormatTimedeltaTestCase(unittest.TestCase):
 
     def test_format_narrow(self):
         string = dates.format_timedelta(timedelta(hours=1),
-                                        locale='en', format='narrow')
+                                        locale='en', pattern='narrow')
         self.assertEqual('1h', string)
         string = dates.format_timedelta(timedelta(hours=-2),
-                                        locale='en', format='narrow')
+                                        locale='en', pattern='narrow')
         self.assertEqual('2h', string)
 
     def test_format_invalid(self):
         self.assertRaises(TypeError, dates.format_timedelta,
-                          timedelta(hours=1), format='')
+                          timedelta(hours=1), pattern='')
         self.assertRaises(TypeError, dates.format_timedelta,
-                          timedelta(hours=1), format='bold italic')
+                          timedelta(hours=1), pattern='bold italic')
         self.assertRaises(TypeError, dates.format_timedelta,
-                          timedelta(hours=1), format=None)
+                          timedelta(hours=1), pattern=None)
 
 
 class TimeZoneAdjustTestCase(unittest.TestCase):
@@ -640,7 +640,7 @@ def test_get_timezone_name():
 def test_format_date():
     d = date(2007, 4, 1)
     assert dates.format_date(d, locale='en_US') == u'Apr 1, 2007'
-    assert (dates.format_date(d, format='full', locale='de_DE') ==
+    assert (dates.format_date(d, pattern='full', locale='de_DE') ==
             u'Sonntag, 1. April 2007')
     assert (dates.format_date(d, "EEE, MMM d, ''yy", locale='en') ==
             u"Sun, Apr 1, '07")
@@ -663,7 +663,7 @@ def test_format_datetime():
 def test_format_time():
     t = time(15, 30)
     assert dates.format_time(t, locale='en_US') == u'3:30:00 PM'
-    assert dates.format_time(t, format='short', locale='de_DE') == u'15:30'
+    assert dates.format_time(t, pattern='short', locale='de_DE') == u'15:30'
 
     assert (dates.format_time(t, "hh 'o''clock' a", locale='en') ==
             u"03 o'clock PM")
@@ -671,17 +671,17 @@ def test_format_time():
     t = datetime(2007, 4, 1, 15, 30)
     tzinfo = timezone('Europe/Paris')
     t = tzinfo.localize(t)
-    fr = dates.format_time(t, format='full', tzinfo=tzinfo, locale='fr_FR')
+    fr = dates.format_time(t, pattern='full', tzinfo=tzinfo, locale='fr_FR')
     assert fr == u'15:30:00 heure d\u2019\xe9t\xe9 d\u2019Europe centrale'
     custom = dates.format_time(t, "hh 'o''clock' a, zzzz",
                                tzinfo=timezone('US/Eastern'), locale='en')
     assert custom == u"09 o'clock AM, Eastern Daylight Time"
 
     t = time(15, 30)
-    paris = dates.format_time(t, format='full',
+    paris = dates.format_time(t, pattern='full',
                               tzinfo=timezone('Europe/Paris'), locale='fr_FR')
     assert paris == u'15:30:00 heure normale d\u2019Europe centrale'
-    us_east = dates.format_time(t, format='full',
+    us_east = dates.format_time(t, pattern='full',
                                 tzinfo=timezone('US/Eastern'), locale='en_US')
     assert us_east == u'3:30:00 PM Eastern Standard Time'
 
@@ -723,11 +723,11 @@ def test_parse_time():
 
 
 def test_datetime_format_get_week_number():
-    format = dates.DateTimeFormat(date(2006, 1, 8), Locale.parse('de_DE'))
-    assert format.get_week_number(6) == 1
+    pattern = dates.DateTimeFormat(date(2006, 1, 8), Locale.parse('de_DE'))
+    assert pattern.get_week_number(6) == 1
 
-    format = dates.DateTimeFormat(date(2006, 1, 8), Locale.parse('en_US'))
-    assert format.get_week_number(6) == 2
+    pattern = dates.DateTimeFormat(date(2006, 1, 8), Locale.parse('en_US'))
+    assert pattern.get_week_number(6) == 2
 
 
 def test_parse_pattern():
@@ -741,7 +741,7 @@ def test_parse_pattern():
 
 def test_lithuanian_long_format():
     assert (
-        dates.format_date(date(2015, 12, 10), locale='lt_LT', format='long') ==
+        dates.format_date(date(2015, 12, 10), locale='lt_LT', pattern='long') ==
         u'2015 m. gruodžio 10 d.'
     )
 
@@ -771,7 +771,7 @@ def test_no_inherit_metazone_marker_never_in_output(locale):
     # See: https://github.com/python-babel/babel/issues/428
     tz = pytz.timezone('America/Los_Angeles')
     t = tz.localize(datetime(2016, 1, 6, 7))
-    assert NO_INHERITANCE_MARKER not in dates.format_time(t, format='long', locale=locale)
+    assert NO_INHERITANCE_MARKER not in dates.format_time(t, pattern='long', locale=locale)
     assert NO_INHERITANCE_MARKER not in dates.get_timezone_name(t, width='short', locale=locale)
 
 
@@ -779,7 +779,7 @@ def test_no_inherit_metazone_formatting():
     # See: https://github.com/python-babel/babel/issues/428
     tz = pytz.timezone('America/Los_Angeles')
     t = tz.localize(datetime(2016, 1, 6, 7))
-    assert dates.format_time(t, format='long', locale='en_US') == "7:00:00 AM PST"
-    assert dates.format_time(t, format='long', locale='en_GB') == "07:00:00 Pacific Standard Time"
+    assert dates.format_time(t, pattern='long', locale='en_US') == "7:00:00 AM PST"
+    assert dates.format_time(t, pattern='long', locale='en_GB') == "07:00:00 Pacific Standard Time"
     assert dates.get_timezone_name(t, width='short', locale='en_US') == "PST"
     assert dates.get_timezone_name(t, width='short', locale='en_GB') == "Pacific Standard Time"

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -147,7 +147,7 @@ class FormatDecimalTestCase(unittest.TestCase):
         # previously formatting very small decimals could lead to a type error
         # because the Decimal->string conversion was too simple (see #214)
         number = decimal.Decimal("7E-7")
-        fmt = numbers.format_decimal(number, format="@@@", locale='en_US')
+        fmt = numbers.format_decimal(number, pattern="@@@", locale='en_US')
         self.assertEqual('0.000000700', fmt)
 
 
@@ -239,7 +239,7 @@ def test_format_currency():
             == u'EUR 1,099.98')
     assert (numbers.format_currency(1099.98, 'EUR', locale='nl_NL')
             != numbers.format_currency(-1099.98, 'EUR', locale='nl_NL'))
-    assert (numbers.format_currency(1099.98, 'USD', format=None,
+    assert (numbers.format_currency(1099.98, 'USD', pattern=None,
                                     locale='en_US')
             == u'$1,099.98')
 
@@ -358,6 +358,6 @@ def test_numberpattern_repr():
 
     # This implementation looks a bit funny, but that's cause strings are
     # repr'd differently in Python 2 vs 3 and this test runs under both.
-    format = u'¤#,##0.00;(¤#,##0.00)'
-    np = numbers.parse_pattern(format)
-    assert repr(format) in repr(np)
+    pattern = u'¤#,##0.00;(¤#,##0.00)'
+    np = numbers.parse_pattern(pattern)
+    assert repr(pattern) in repr(np)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -19,9 +19,9 @@ def test_smoke_dates(locale):
     locale = Locale.parse(locale)
     instant = datetime.now()
     for width in ("full", "long", "medium", "short"):
-        assert dates.format_date(instant, format=width, locale=locale)
-        assert dates.format_datetime(instant, format=width, locale=locale)
-        assert dates.format_time(instant, format=width, locale=locale)
+        assert dates.format_date(instant, pattern=width, locale=locale)
+        assert dates.format_datetime(instant, pattern=width, locale=locale)
+        assert dates.format_time(instant, pattern=width, locale=locale)
 
 
 @pytest.mark.all_locales


### PR DESCRIPTION
`format()` is a [Python bult-in function](https://docs.python.org/2/library/functions.html#built-in-functions). To avoid collission and override of this default function, I just renamed all instance of `format` variables to `pattern`.

For reference, here is the script I used to perform this renaming:
```shell
sed -i "s/(format)/(pattern)/g" ./tests/test_numbers.py
sed -i "s/ format =/ pattern =/g" ./tests/test_numbers.py
sed -i "s/ format=/ pattern=/g" ./tests/test_numbers.py

sed -i "s/ format=/ pattern=/g" ./tests/test_dates.py
sed -i "s/format\./pattern\./g" ./tests/test_dates.py
sed -i "s/format = /pattern = /g" ./tests/test_dates.py

sed -i "s/ format=/ pattern=/g" ./docs/numbers.rst

sed -i "s/ format=/ pattern=/g" ./docs/dates.rst
sed -i "s/\x60\x60format\x60\x60/\x60\x60pattern\x60\x60/g" ./docs/dates.rst

sed -i "s/ format=format/pattern=pattern/g" ./babel/units.py
sed -i "s/:param format:/:param pattern:/g" ./babel/units.py
sed -i "s/,pattern=pattern,/, pattern=pattern,/g" ./babel/units.py
sed -i "s/, format=None,/, pattern=None,/g" ./babel/units.py
sed -i "s/, format,/, pattern,/g" ./babel/units.py
sed -i "s/\x60\x60format\x60\x60/\x60\x60pattern\x60\x60/g" ./babel/units.py

sed -i "s/, format,/, pattern,/g" ./babel/support.py
sed -i "s/ format=None/ pattern=None/g" ./babel/support.py
sed -i "s/format=format,/pattern=pattern,/g" ./babel/support.py
sed -i "s/format='/pattern='/g" ./babel/support.py

sed -i "s/(format)/(pattern)/g" ./babel/numbers.py
sed -i "s/ format = / pattern = /g" ./babel/numbers.py
sed -i "s/not format:/not pattern:/g" ./babel/numbers.py
sed -i "s/:param format:/:param pattern:/g" ./babel/numbers.py
sed -i "s/ format=None/ pattern=None/g" ./babel/numbers.py

sed -i "s/(format %/(pattern %/g" ./babel/messages/frontend.py
sed -i "s/ format = / pattern = /g" ./babel/messages/frontend.py
sed -i "s/ format % / pattern % /g" ./babel/messages/frontend.py

sed -i "s/, (format, /, (pattern, /g" ./babel/messages/checkers.py
sed -i "s/, format, /, pattern, /g" ./babel/messages/checkers.py
sed -i "s/:param format:/:param pattern:/g" ./babel/messages/checkers.py
sed -i "s/\x60format\x60/\x60pattern\x60/g" ./babel/messages/checkers.py

sed -i "s/>>> format = />>> pattern = /g" ./babel/dates.py
sed -i "s/>>> format\./>>> pattern\./g" ./babel/dates.py
sed -i "s/= format\./= pattern\./g" ./babel/dates.py
sed -i "s/ format = / pattern = /g" ./babel/dates.py
sed -i "s/\[format\]/\[pattern\]/g" ./babel/dates.py
sed -i "s/(format, /(pattern, /g" ./babel/dates.py
sed -i "s/(format)/(pattern)/g" ./babel/dates.py
sed -i "s/if format not in/if pattern not in/g" ./babel/dates.py
sed -i "s/if format in (/if pattern in (/g" ./babel/dates.py
sed -i "s/(format='/(pattern='/g" ./babel/dates.py
sed -i "s/, format,/, pattern,/g" ./babel/dates.py
sed -i "s/if format == /if pattern == /g" ./babel/dates.py
sed -i "s/, format='/, pattern='/g" ./babel/dates.py
sed -i "s/:param format:/:param pattern:/g" ./babel/dates.py
sed -i "s/ = format(/ = pattern(/g" ./babel/dates.py
```