### PR TITLE
Allow both dash and underscore separated locale identifiers in pofiles

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -395,6 +395,7 @@ class Catalog(object):
             elif name == 'last-translator':
                 self.last_translator = value
             elif name == 'language':
+                value = value.replace('-', '_')
                 self.locale = Locale.parse(value)
             elif name == 'language-team':
                 self.language_team = value

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -36,6 +36,12 @@ msgstr ""
 "Language: en_US\n"''')
         catalog = pofile.read_po(buf, locale='de')
         self.assertEqual(Locale('en', 'US'), catalog.locale)
+        buf = StringIO(r'''
+msgid ""
+msgstr ""
+"Language: ko-KR\n"''')
+        catalog = pofile.read_po(buf, locale='de')
+        self.assertEqual(Locale('ko', 'KR'), catalog.locale)
 
     def test_preserve_domain(self):
         buf = StringIO(r'''msgid "foo"


### PR DESCRIPTION
Fixes #489
Augments #420 (08b9c5e76e19ae)