### PR TITLE
Add currency utilities and helpers.

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -45,6 +45,7 @@ def get_global(key):
 
     The keys available are:
 
+    - ``all_currencies``
     - ``currency_fractions``
     - ``language_aliases``
     - ``likely_subtags``


### PR DESCRIPTION
Add a couple of new utilities for currencies:
* `list_currency`: to list the whole set of currency codes supported by Babel.
* `validate_currency `.
* `is_currency `: to quickly validate if a currency is supported by Babel or not, not unlike what is currently available for locale (see: `babel.localedata.exists()`).
* `normalize_currency`: to normalize a currency string to the format expected by Babel.
* `get_currency_precision`: to get the natural precision of a currency.