### PR TITLE
Fix an invalid string to bytes comparison in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
       python: 3.4
     - os: linux
       python: 3.5
+      env:
+      - PYTHON_TEST_FLAGS=-bb
 
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test: import-cldr
-	@PYTHONWARNINGS=default python -m pytest
+	@PYTHONWARNINGS=default python ${PYTHON_TEST_FLAGS} -m pytest
 
 test-cov: import-cldr
-	@PYTHONWARNINGS=default python -m pytest --cov=babel
+	@PYTHONWARNINGS=default python ${PYTHON_TEST_FLAGS} -m pytest --cov=babel
 
 test-env:
 	@virtualenv test-env

--- a/babel/localtime/_unix.py
+++ b/babel/localtime/_unix.py
@@ -87,7 +87,7 @@ def _get_localzone(_root='/'):
 
             # Issue #3 in tzlocal was that /etc/timezone was a zoneinfo file.
             # That's a misconfiguration, but we need to handle it gracefully:
-            if data[:5] != 'TZif2':
+            if data[:5] != b'TZif2':
                 etctz = data.strip().decode()
                 # Get rid of host definitions and comments:
                 if ' ' in etctz:


### PR DESCRIPTION
In Python 3 this branch would never evaluate to `False` due to comparing a string to bytes.

This was flagged by running some unit tests with the `-bb` flag, so I've added
`-bb` to run with the babel unit tests in Python3.5

Here's some docs on the `-bb` flag:
https://docs.python.org/3.5/library/warnings.html#default-warning-filters
https://docs.python.org/3/howto/pyporting.html#use-continuous-integration-to-stay-compatible