### PR TITLE
Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ cache:
 matrix:
   include:
     - os: linux
-      python: 2.6
+      python: "2.6"
     - os: linux
-      python: 2.6
+      python: "2.6"
       env:
       - CDECIMAL=m3-cdecimal
     - os: linux
-      python: 2.7
+      python: "2.7"
     - os: linux
-      python: 2.7
+      python: "2.7"
       env:
       - CDECIMAL=m3-cdecimal
     - os: linux
@@ -28,11 +28,11 @@ matrix:
     - os: linux
       python: pypy3
     - os: linux
-      python: 3.3
+      python: "3.3"
     - os: linux
-      python: 3.4
+      python: "3.4"
     - os: linux
-      python: 3.5
+      python: "3.5"
       env:
       - PYTHON_TEST_FLAGS=-bb
 


### PR DESCRIPTION
The python versions defined in the Travis CI configuration may be parsed as decimals.  This could be the reason behind the latest Travis *failures*.

First attempt to fix the situation.