### PR TITLE
Safer PyInstaller support

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -22,7 +22,7 @@ from babel._compat import pickle, string_types
 
 
 def get_base_dir():
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, 'frozen', False) and getattr(sys, '_MEIPASS', None):
         # we are running in a |PyInstaller| bundle
         basedir = sys._MEIPASS
     else:


### PR DESCRIPTION
Also check for `sys._MEIPASS` before assuming PyInstallerness

Fixes #525