### PR TITLE
Fix PyInstaller support

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -68,7 +68,7 @@ def get_global(key):
     """
     global _global_data
     if _global_data is None:
-        dirname = localedata.get_base_dir()
+        dirname = os.path.join(os.path.dirname(__file__))
         filename = os.path.join(dirname, 'global.dat')
         if not os.path.isfile(filename):
             _raise_no_data_error()

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -22,7 +22,7 @@ from babel._compat import pickle, string_types
 
 
 def get_base_dir():
-    if getattr(sys, 'frozen', False) and getattr(sys, '_MEIPASS', None):
+    if getattr(sys, 'frozen', False):
         # we are running in a |PyInstaller| bundle
         basedir = sys._MEIPASS
     else:

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -16,23 +16,13 @@ import os
 import threading
 from collections import MutableMapping
 from itertools import chain
-import sys
 
 from babel._compat import pickle, string_types
 
 
-def get_base_dir():
-    if getattr(sys, 'frozen', False):
-        # we are running in a |PyInstaller| bundle
-        basedir = sys._MEIPASS
-    else:
-        # we are running in a normal Python environment
-        basedir = os.path.dirname(__file__)
-    return basedir
-
 _cache = {}
 _cache_lock = threading.RLock()
-_dirname = os.path.join(get_base_dir(), 'locale-data')
+_dirname = os.path.join(os.path.dirname(__file__), 'locale-data')
 
 
 def normalize_locale(name):

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -14,7 +14,6 @@
 import unittest
 import random
 from operator import methodcaller
-import sys
 
 from babel import localedata, numbers
 
@@ -93,17 +92,6 @@ def test_mixedcased_locale():
         locale_id = ''.join([
             methodcaller(random.choice(['lower', 'upper']))(c) for c in l])
         assert localedata.exists(locale_id)
-
-
-def test_pi_support_frozen(monkeypatch):
-    monkeypatch.setattr(sys, '_MEIPASS', 'testdir', raising=False)
-    monkeypatch.setattr(sys, 'frozen', True, raising=False)
-    assert localedata.get_base_dir() == 'testdir'
-
-
-def test_pi_support_not_frozen():
-    assert not getattr(sys, 'frozen', False)
-    assert localedata.get_base_dir().endswith('babel')
 
 def test_locale_argument_acceptance():
     # Testing None input.


### PR DESCRIPTION
PyInstaller+Babel was supported for quite a while before 2.5.0 - which broke support for this configuration by default. PyInstaller actually synthesizes a `__file__` for frozen aka bundled code that makes this "just work".

Closes #529.