### PR TITLE
Keep tox dependencies in sync

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py26, py27, pypy, py33, py34, py26-cdecimal, py27-cdecimal
 deps =
     pytest
     cdecimal: m3-cdecimal
+    freezegun
 whitelist_externals = make
 commands = make clean-cldr test
 


### PR DESCRIPTION
Travis config was updated in 1da04fd0af20162fe4e2b503a5fcae8f25267010 to address #520, and adds a dependency on `freezegun`. That dependency was  forgotten in `tox.ini`.