### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ cache:
 matrix:
   include:
     - os: linux
-      python: 2.6
-    - os: linux
-      python: 2.6
-      env:
-      - CDECIMAL=m3-cdecimal
-    - os: linux
       python: 2.7
     - os: linux
       python: 2.7
@@ -27,8 +21,6 @@ matrix:
       python: pypy
     - os: linux
       python: pypy3
-    - os: linux
-      python: 3.3
     - os: linux
       python: 3.4
     - os: linux

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -521,7 +521,7 @@ def get_timezone_location(dt_or_tzinfo=None, locale=LC_TIME, return_city=False):
         territory = 'ZZ'  # invalid/unknown
     territory_name = locale.territories[territory]
     if not return_city and territory and len(get_global('territory_zones').get(territory, [])) == 1:
-        return region_format % (territory_name)
+        return region_format % territory_name
 
     # Otherwise, include the city in the output
     fallback_format = locale.zone_formats['fallback']
@@ -1303,7 +1303,7 @@ class DateTimeFormat(object):
         elif char == 'H':
             return self.value.hour
         elif char == 'h':
-            return (self.value.hour % 12 or 12)
+            return self.value.hour % 12 or 12
         elif char == 'm':
             return self.value.minute
         elif char == 'a':

--- a/babel/languages.py
+++ b/babel/languages.py
@@ -26,7 +26,7 @@ def get_official_languages(territory, regional=False, de_facto=False):
     """
 
     territory = str(territory).upper()
-    allowed_stati = set(("official",))
+    allowed_stati = {"official"}
     if regional:
         allowed_stati.add("official_regional")
     if de_facto:

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -531,7 +531,7 @@ class Catalog(object):
             buf.append('%s: %s' % (name, value))
         flags = set()
         if self.fuzzy:
-            flags |= set(['fuzzy'])
+            flags |= {'fuzzy'}
         yield Message(u'', '\n'.join(buf), flags=flags)
         for key in self._messages:
             yield self._messages[key]
@@ -762,7 +762,7 @@ class Catalog(object):
                 message.string = message.string[0]
             message.flags |= oldmsg.flags
             if fuzzy:
-                message.flags |= set([u'fuzzy'])
+                message.flags |= {u'fuzzy'}
             self[message.id] = message
 
         for message in template:

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -120,8 +120,8 @@ class Message(object):
         """Compare Messages, taking into account plural ids"""
         def values_to_compare(obj):
             if isinstance(obj, Message) and obj.pluralizable:
-                return (obj.id[0], obj.context or '')
-            return (obj.id, obj.context or '')
+                return obj.id[0], obj.context or ''
+            return obj.id, obj.context or ''
         return cmp(values_to_compare(self), values_to_compare(other))
 
     def __gt__(self, other):

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -17,9 +17,9 @@ from babel._compat import string_types, izip
 
 #: list of format chars that are compatible to each other
 _string_format_compatibilities = [
-    set(['i', 'd', 'u']),
-    set(['x', 'X']),
-    set(['f', 'F', 'g', 'G'])
+    {'i', 'd', 'u'},
+    {'x', 'X'},
+    {'f', 'F', 'g', 'G'}
 ]
 
 

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -978,7 +978,7 @@ def parse_mapping(fileobj, filename=None):
                 method = extractors[method]
             method_map[idx] = (pattern, method)
 
-    return (method_map, options_map)
+    return method_map, options_map
 
 
 def parse_keywords(strings=[]):

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -20,16 +20,16 @@
 #  - http://www.unicode.org/reports/tr35/ (Appendix G.6)
 import re
 from datetime import date as date_, datetime as datetime_
-from itertools import chain
 import warnings
 
 from babel.core import default_locale, Locale, get_global
 from babel._compat import decimal, string_types
-from babel.localedata import locale_identifiers
 
 try:
+    # Python 2
     long
 except NameError:
+    # Python 3
     long = int
 
 

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -241,7 +241,7 @@ def to_gettext(rule):
     """
     rule = PluralRule.parse(rule)
 
-    used_tags = rule.tags | set([_fallback_tag])
+    used_tags = rule.tags | {_fallback_tag}
     _compile = _GettextCompiler().compile
     _get_index = [tag for tag in _plural_tags if tag in used_tags].index
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -30,9 +30,8 @@ Python Versions
 
 At the moment the following Python versions should be supported:
 
-*   Python 2.6
 *   Python 2.7
-*   Python 3.3 and up
+*   Python 3.4 and up
 *   PyPy tracking 2.7 and 3.2 and up
 
 While PyPy does not currently support 3.3, it does support traditional

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -56,6 +54,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     packages=['babel', 'babel.messages', 'babel.localtime'],
     include_package_data=True,
     install_requires=[

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -101,7 +101,7 @@ class CatalogTestCase(unittest.TestCase):
 
     def test_update_message_changed_to_simple(self):
         cat = catalog.Catalog()
-        cat.add((u'foo' u'foos'), (u'Voh', u'Vöhs'))
+        cat.add(u'foo' u'foos', (u'Voh', u'Vöhs'))
         tmpl = catalog.Catalog()
         tmpl.add(u'foo')
         cat.update(tmpl)

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -178,7 +178,7 @@ msg2 = ngettext(\"\"\"elvis\"\"\", 'elvises', count)
         messages = list(extract.extract_python(buf,
                                                extract.DEFAULT_KEYWORDS.keys(),
                                                [], {}))
-        self.assertEqual([(1, '_', (u'pylons'), []),
+        self.assertEqual([(1, '_', u'pylons', []),
                           (2, 'ngettext', (u'elvis', u'elvises', None), []),
                           (3, 'ngettext', (u'elvis', u'elvises', None), [])],
                          messages)
@@ -350,7 +350,7 @@ n = ngettext('foo')
         self.assertEqual((None, u'hello', u'there'), messages[2][2])
         self.assertEqual((None, None), messages[3][2])
         self.assertEqual(None, messages[4][2])
-        self.assertEqual(('foo'), messages[5][2])
+        self.assertEqual('foo', messages[5][2])
 
     def test_utf8_message(self):
         buf = BytesIO(u"""

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1140,7 +1140,7 @@ msgstr[2] ""
         assert not os.path.isfile(mo_file), 'Expected no file at %r' % mo_file
         self.assertEqual("""\
 catalog %s is marked as fuzzy, skipping
-""" % (po_file), sys.stderr.getvalue())
+""" % po_file, sys.stderr.getvalue())
 
     def test_compile_fuzzy_catalog(self):
         po_file = self._po_file('de_DE')

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1343,26 +1343,14 @@ def test_extract_keyword_args_384(split, arg_name):
         "extract -F babel-django.cfg --add-comments Translators: -o django232.pot %s ." % kwarg_text
     )
     assert isinstance(cmdinst, extract_messages)
-    assert set(cmdinst.keywords.keys()) == set((
-        '_',
-        'dgettext',
-        'dngettext',
-        'gettext',
-        'gettext_lazy',
-        'gettext_noop',
-        'N_',
-        'ngettext',
-        'ngettext_lazy',
-        'npgettext',
-        'npgettext_lazy',
-        'pgettext',
-        'pgettext_lazy',
-        'ugettext',
-        'ugettext_lazy',
-        'ugettext_noop',
-        'ungettext',
-        'ungettext_lazy',
-    ))
+    assert set(cmdinst.keywords.keys()) == {'_', 'dgettext', 'dngettext',
+                                            'gettext', 'gettext_lazy',
+                                            'gettext_noop', 'N_', 'ngettext',
+                                            'ngettext_lazy', 'npgettext',
+                                            'npgettext_lazy', 'pgettext',
+                                            'pgettext_lazy', 'ugettext',
+                                            'ugettext_lazy', 'ugettext_noop',
+                                            'ungettext', 'ungettext_lazy'}
 
 
 @pytest.mark.parametrize("kwarg,expected", [
@@ -1384,7 +1372,7 @@ def test_extract_distutils_keyword_arg_388(kwarg, expected):
     assert set(cmdinst.keywords.keys()) == set(expected)
 
     # Test the comma-separated comment argument while we're at it:
-    assert set(cmdinst.add_comments) == set(("Bar", "Foo"))
+    assert set(cmdinst.add_comments) == {"Bar", "Foo"}
 
 
 def test_update_catalog_boolean_args():

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -11,4 +11,6 @@ def test_official_languages():
 
 
 def test_get_language_info():
-    assert set(get_territory_language_info("HU").keys()) == set(("hu", "en", "de", "ro", "hr", "sk", "sl"))
+    assert set(get_territory_language_info("HU").keys()) == {"hu", "en", "de",
+                                                             "ro", "hr", "sk",
+                                                             "sl"}

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -108,12 +108,12 @@ def test_pi_support_not_frozen():
 def test_locale_argument_acceptance():
     # Testing None input.
     normalized_locale = localedata.normalize_locale(None)
-    assert normalized_locale == None
+    assert normalized_locale is None
     locale_exist = localedata.exists(None)
     assert locale_exist == False
 
     # # Testing list input.
     normalized_locale = localedata.normalize_locale(['en_us', None])
-    assert normalized_locale == None
+    assert normalized_locale is None
     locale_exist = localedata.exists(['en_us', None])
     assert locale_exist == False

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -177,7 +177,7 @@ def test_list_currencies():
         list_currencies('yo!')
     assert excinfo.value.args[0] == "expected only letters, got 'yo!'"
 
-    assert list_currencies(locale='pa_Arab') == set(['PKR', 'INR', 'EUR'])
+    assert list_currencies(locale='pa_Arab') == {'PKR', 'INR', 'EUR'}
     assert list_currencies(locale='kok') == set([])
 
     assert len(list_currencies()) == 296

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -206,13 +206,13 @@ def test_is_currency():
 def test_normalize_currency():
     assert normalize_currency('EUR') == 'EUR'
     assert normalize_currency('eUr') == 'EUR'
-    assert normalize_currency('FUU') == None
-    assert normalize_currency('') == None
-    assert normalize_currency(None) == None
-    assert normalize_currency('   EUR    ') == None
-    assert normalize_currency('   ') == None
-    assert normalize_currency([]) == None
-    assert normalize_currency(set()) == None
+    assert normalize_currency('FUU') is None
+    assert normalize_currency('') is None
+    assert normalize_currency(None) is None
+    assert normalize_currency('   EUR    ') is None
+    assert normalize_currency('   ') is None
+    assert normalize_currency([]) is None
+    assert normalize_currency(set()) is None
 
 
 def test_get_currency_name():

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -358,4 +358,4 @@ def test_catalog_merge_files():
     t2._catalog["bar"] = "quux"
     t1.merge(t2)
     assert t1.files == ["pro.mo"]
-    assert set(t1._catalog.keys()) == set(('', 'foo', 'bar'))
+    assert set(t1._catalog.keys()) == {'', 'foo', 'bar'}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py33, py34, py35, py36, pypy3, py27-cdecimal
+envlist = py27, pypy, py34, py35, py36, pypy3, py27-cdecimal
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34, py35, py36, pypy3, py26-cdecimal, py27-cdecimal
+envlist = py27, pypy, py33, py34, py35, py36, pypy3, py27-cdecimal
 
 [testenv]
 deps =


### PR DESCRIPTION
Further to https://github.com/python-babel/babel/pull/455, I'd like to suggest dropping support for Python 2.6 and 3.3. Both are EOL (2.6 for four years), meaning they no longer receive updates, including security updates. 

Removing them will help ease the maintenance burden, and allow to use more modern features of Python. Travis CI will also quicker, from ~23 min run time (total time ~1 hr 4 min) to ~11 min run time (total time ~43 min).

![image](https://user-images.githubusercontent.com/1324225/34263159-38b766bc-e677-11e7-918b-54bc889cfff0.png)

https://en.wikipedia.org/wiki/CPython#Version_history

See also:
* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org

They're also little used. Here's the pip installs for babel from PyPI for the last month (via `pypinfo --percent --pip --markdown babel pyversion`).

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   75.2% |        965,130 |
| 3.6            |   10.8% |        139,110 |
| 3.5            |    8.1% |        103,400 |
| 3.4            |    5.4% |         69,261 |
| 2.6            |    0.2% |          2,948 |
| 3.3            |    0.2% |          2,069 |
| 3.7            |    0.1% |          1,865 |
| 3.2            |    0.0% |             55 |
| None           |    0.0% |             17 |

This PR also adds `python_requires` to help pip and does some minor tidy ups.