### PR TITLE
Add explicit signatures to some date autofunctions

### DIFF
--- a/docs/api/dates.rst
+++ b/docs/api/dates.rst
@@ -9,17 +9,17 @@ Python `datetime`, `date` and `time` objects and work with timezones.
 Date and Time Formatting
 ------------------------
 
-.. autofunction:: format_datetime
+.. autofunction:: format_datetime(datetime=None, format='medium', tzinfo=None, locale=default_locale('LC_TIME'))
 
-.. autofunction:: format_date
+.. autofunction:: format_date(date=None, format='medium', locale=default_locale('LC_TIME'))
 
-.. autofunction:: format_time
+.. autofunction:: format_time(time=None, format='medium', tzinfo=None, locale=default_locale('LC_TIME'))
 
-.. autofunction:: format_timedelta
+.. autofunction:: format_timedelta(delta, granularity='second', threshold=.85, add_direction=False, format='long', locale=default_locale('LC_TIME'))
 
-.. autofunction:: format_skeleton
+.. autofunction:: format_skeleton(skeleton, datetime=None, tzinfo=None, fuzzy=True, locale=default_locale('LC_TIME'))
 
-.. autofunction:: format_interval
+.. autofunction:: format_interval(start, end, skeleton=None, tzinfo=None, fuzzy=True, locale=default_locale('LC_TIME'))
 
 Timezone Functionality
 ----------------------


### PR DESCRIPTION
Because `default_locale` is eager, it generates misleading documentation when built (including on the site) as the doc will show the LC_TIME for the machine which built the doc.

An explicit autofunction signature fixes that and provides a more correct view of the signature. 

Alternative fix: have dates.LC_TIME be a custom object with a relevant repr e.g.

```python
class _LC(str):
    def __new__(cls, category):
        category = 'LC_' + category
        v = str.__new__(cls, default_locale(category))
        v._category = category
        return v

    def __repr__(self):
        return "default_locale('%s')" % self._category
LC_TIME = _LC('TIME')
```