### PR TITLE
Fixes #402 and fixes #53 add ignore_dir_prefix option original credit @nandoflorestan

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -63,7 +63,8 @@ def _strip_comment_tags(comments, tags):
 
 def extract_from_dir(dirname=None, method_map=DEFAULT_MAPPING,
                      options_map=None, keywords=DEFAULT_KEYWORDS,
-                     comment_tags=(), callback=None, strip_comment_tags=False):
+                     comment_tags=(), callback=None, strip_comment_tags=False,
+                     ignore_dir_prefixes=None):
     """Extract messages from any source files found in the given directory.
 
     This function generates tuples of the form ``(filename, lineno, message,
@@ -137,10 +138,11 @@ def extract_from_dir(dirname=None, method_map=DEFAULT_MAPPING,
 
     absname = os.path.abspath(dirname)
     for root, dirnames, filenames in os.walk(absname):
-        dirnames[:] = [
-            subdir for subdir in dirnames
-            if not (subdir.startswith('.') or subdir.startswith('_'))
-        ]
+        for subdir in dirnames:
+            if ignore_dir_prefixes:
+                for prefix in ignore_dir_prefixes:
+                    if subdir.startswith(prefix):
+                        dirnames.remove(subdir)
         dirnames.sort()
         filenames.sort()
         for filename in filenames:

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -313,7 +313,7 @@ class extract_messages(Command):
          'files or directories with commas(,)'),  # TODO: Support repetition of this argument
         ('input-dirs=', None,  # TODO (3.x): Remove me.
          'alias for input-paths (does allow files as well as directories).'),
-        ('ignore_dir_prefixes=', None,
+        ('ignore-dir-prefixes=', None,
           'Bypass directories whose name start with PREFIX. You can specify this more than once.'),
     ]
     boolean_options = [

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -313,6 +313,8 @@ class extract_messages(Command):
          'files or directories with commas(,)'),  # TODO: Support repetition of this argument
         ('input-dirs=', None,  # TODO (3.x): Remove me.
          'alias for input-paths (does allow files as well as directories).'),
+        ('ignore_dir_prefixes=', None,
+          'Bypass directories whose name start with PREFIX. You can specify this more than once.'),
     ]
     boolean_options = [
         'no-default-keywords', 'no-location', 'omit-header', 'no-wrap',
@@ -352,6 +354,7 @@ class extract_messages(Command):
         self.add_comments = None
         self.strip_comments = False
         self.include_lineno = True
+        self.ignore_dir_prefixes = None
 
     def finalize_options(self):
         if self.input_dirs:
@@ -419,6 +422,9 @@ class extract_messages(Command):
             self.no_location = True
         elif self.add_location == 'file':
             self.include_lineno = False
+            
+        if self.ignore_dir_prefixes:
+            self.ignore_dir_prefixes = self.ignore_dir_prefixes.split(',')
 
     def run(self):
         mappings = self._get_mappings()
@@ -462,7 +468,8 @@ class extract_messages(Command):
                         keywords=self.keywords,
                         comment_tags=self.add_comments,
                         callback=callback,
-                        strip_comment_tags=self.strip_comments
+                        strip_comment_tags=self.strip_comments,
+                        ignore_dir_prefixes=self.ignore_dir_prefixes,
                     )
                 for filename, lineno, message, comments, context in extracted:
                     if os.path.isfile(path):


### PR DESCRIPTION
Babel currently ignores directories prefixed . and _ 
Variously listed as feature / bug since this behavior is not explicit
To exclude directories now use --ignore_dir_prefix option and specify a prefix, e.g. _

based on the following by @nandoflorestan
https://github.com/nandoflorestan/babel/commit/9d2e0ba5cc19ef871a72d4d8a60459e179df1b6b#diff-870e23eed5eae4756d0fe90bb4799c81L896