### PR TITLE
Month and Day must be valid tokens

### DIFF
--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -286,7 +286,7 @@ directly interface with it from within Babel:
 
     >>> from datetime import time
     >>> from babel.dates import get_timezone, UTC
-    >>> dt = datetime(2007, 04, 01, 15, 30, tzinfo=UTC)
+    >>> dt = datetime(2007, 4, 1, 15, 30, tzinfo=UTC)
     >>> eastern = get_timezone('US/Eastern')
     >>> format_datetime(dt, 'H:mm Z', tzinfo=eastern, locale='en_US')
     u'11:30 -0400'


### PR DESCRIPTION
This is the result when following the tutorial:

```
>>> dt = datetime(2007, 04, 01, 15, 30, tzinfo=UTC)
  File "<stdin>", line 1
    dt = datetime(2007, 04, 01, 15, 30, tzinfo=UTC)
                         ^
SyntaxError: invalid token
```
It should be written like this:

`>>> dt = datetime(2007, 4, 1, 15, 30, tzinfo=UTC)`

See: https://docs.python.org/3.5/library/datetime.html#datetime.datetime.month