### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/_templates/sidebar-links.html
+++ b/docs/_templates/sidebar-links.html
@@ -9,7 +9,7 @@
 <h3>Useful Links</h3>
 <ul>
   <li><a href="http://babel.pocoo.org/">Babel Website</a></li>
-  <li><a href="http://pypi.python.org/pypi/Babel">Babel @ PyPI</a></li>
+  <li><a href="https://pypi.org/project/Babel/">Babel @ PyPI</a></li>
   <li><a href="http://github.com/python-babel/babel">Babel @ github</a></li>
   <li><a href="http://github.com/python-babel/babel/issues">Issue Tracker</a></li>
 </ul>

--- a/docs/numbers.rst
+++ b/docs/numbers.rst
@@ -135,7 +135,7 @@ behaves as desired.
 .. _Decimal: https://docs.python.org/3/library/decimal.html#decimal-objects
 .. _Context: https://docs.python.org/3/library/decimal.html#context-objects
 .. _`UTS #35 section 3.3`: http://www.unicode.org/reports/tr35/tr35-numbers.html#Formatting
-.. _cdecimal: https://pypi.python.org/pypi/cdecimal
+.. _cdecimal: https://pypi.org/project/cdecimal/
 
 
 Parsing Numbers


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html