### PR TITLE
Add a strict mode to `parse_decimal()`

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -634,6 +634,11 @@ def format_scientific(
 class NumberFormatError(ValueError):
     """Exception raised when a string cannot be parsed into a number."""
 
+    def __init__(self, message, suggestions=None):
+        super(NumberFormatError, self).__init__(message)
+        #: a list of properly formatted numbers derived from the invalid input
+        self.suggestions = suggestions
+
 
 def parse_number(string, locale=LC_NUMERIC):
     """Parse localized number string into an integer.
@@ -706,16 +711,16 @@ def parse_decimal(string, locale=LC_NUMERIC, strict=False):
                 parsed_alt = decimal.Decimal(string.replace(decimal_symbol, '')
                                                    .replace(group_symbol, '.'))
             except decimal.InvalidOperation:
-                raise NumberFormatError(
+                raise NumberFormatError((
                     "%r is not a properly formatted decimal number. Did you mean %r?" %
                     (string, proper)
-                )
+                ), suggestions=[proper])
             else:
                 proper_alt = format_decimal(parsed_alt, locale=locale, decimal_quantization=False)
-                raise NumberFormatError(
+                raise NumberFormatError((
                     "%r is not a properly formatted decimal number. Did you mean %r? Or maybe %r?" %
                     (string, proper, proper_alt)
-                )
+                ), suggestions=[proper, proper_alt])
     return parsed
 
 

--- a/docs/api/numbers.rst
+++ b/docs/api/numbers.rst
@@ -30,6 +30,7 @@ Exceptions
 ----------
 
 .. autoexception:: NumberFormatError
+    :members:
 
 Data Access
 -----------

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -167,17 +167,21 @@ class NumberParsingTestCase(unittest.TestCase):
 
     def test_parse_decimal_strict_mode(self):
         # Numbers with a misplaced grouping symbol should be rejected
-        with self.assertRaises(numbers.NumberFormatError):
+        with self.assertRaises(numbers.NumberFormatError) as info:
             numbers.parse_decimal('11.11', locale='de', strict=True)
+        assert info.exception.suggestions == ['1.111', '11,11']
         # Numbers with two misplaced grouping symbols should be rejected
-        with self.assertRaises(numbers.NumberFormatError):
+        with self.assertRaises(numbers.NumberFormatError) as info:
             numbers.parse_decimal('80.00.00', locale='de', strict=True)
+        assert info.exception.suggestions == ['800.000']
         # Partially grouped numbers should be rejected
-        with self.assertRaises(numbers.NumberFormatError):
+        with self.assertRaises(numbers.NumberFormatError) as info:
             numbers.parse_decimal('2000,000', locale='en_US', strict=True)
+        assert info.exception.suggestions == ['2,000,000', '2,000']
         # Numbers with duplicate grouping symbols should be rejected
-        with self.assertRaises(numbers.NumberFormatError):
+        with self.assertRaises(numbers.NumberFormatError) as info:
             numbers.parse_decimal('0,,000', locale='en_US', strict=True)
+        assert info.exception.suggestions == ['0']
         # Properly formatted numbers should be accepted
         assert str(numbers.parse_decimal('1.001', locale='de', strict=True)) == '1001'
         # Trailing zeroes should be accepted

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -165,6 +165,25 @@ class NumberParsingTestCase(unittest.TestCase):
         self.assertRaises(numbers.NumberFormatError,
                           lambda: numbers.parse_decimal('2,109,998', locale='de'))
 
+    def test_parse_decimal_strict_mode(self):
+        # Numbers with a misplaced grouping symbol should be rejected
+        with self.assertRaises(numbers.NumberFormatError):
+            numbers.parse_decimal('11.11', locale='de', strict=True)
+        # Partially grouped numbers should be rejected
+        with self.assertRaises(numbers.NumberFormatError):
+            numbers.parse_decimal('2000,000', locale='en_US', strict=True)
+        # Numbers with duplicate grouping symbols should be rejected
+        with self.assertRaises(numbers.NumberFormatError):
+            numbers.parse_decimal('0,,000', locale='en_US', strict=True)
+        # Properly formatted numbers should be accepted
+        assert str(numbers.parse_decimal('1.001', locale='de', strict=True)) == '1001'
+        # Trailing zeroes should be accepted
+        assert str(numbers.parse_decimal('3.00', locale='en_US', strict=True)) == '3.00'
+        # Numbers without any grouping symbol should be accepted
+        assert str(numbers.parse_decimal('2000.1', locale='en_US', strict=True)) == '2000.1'
+        # High precision numbers should be accepted
+        assert str(numbers.parse_decimal('5,000001', locale='fr', strict=True)) == '5.000001'
+
 
 def test_list_currencies():
     assert isinstance(list_currencies(), set)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -169,6 +169,9 @@ class NumberParsingTestCase(unittest.TestCase):
         # Numbers with a misplaced grouping symbol should be rejected
         with self.assertRaises(numbers.NumberFormatError):
             numbers.parse_decimal('11.11', locale='de', strict=True)
+        # Numbers with two misplaced grouping symbols should be rejected
+        with self.assertRaises(numbers.NumberFormatError):
+            numbers.parse_decimal('80.00.00', locale='de', strict=True)
         # Partially grouped numbers should be rejected
         with self.assertRaises(numbers.NumberFormatError):
             numbers.parse_decimal('2000,000', locale='en_US', strict=True)


### PR DESCRIPTION
This branch adds a `strict` flag to the `parse_decimal` function. When set to `True` an exception is raised if the input number is formatted in a weird way. This is determined by comparing the string to the result of `format_decimal()`.

Closes #589.