### PR TITLE
Bumped version requirement on pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         # This version identifier is currently necessary as
         # pytz otherwise does not install on pip 1.4 or
         # higher.
-        'pytz>=0a',
+        'pytz>=2015.7',
     ],
 
     cmdclass={'import_cldr': import_cldr},


### PR DESCRIPTION
Here you use the utc attribute on the _pytz object: https://github.com/python-babel/babel/blob/23ca4bf2b187748e5e8372c6dae541fbcc5fbe5d/babel/util.py#L304

Which was added in this commit https://github.com/stub42/pytz/commit/ae82fbc71b374a5a5b32bf3bbb38ebb97af6e715

Corrected the version requirement to match the version where that attribute was added.