### PR TITLE
Small fixes to avoid stack traces due to badly formatted .po file

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -183,9 +183,12 @@ class PoFileParser(object):
     def _process_keyword_line(self, lineno, line, obsolete=False):
 
         for keyword in self._keywords:
-            if line.startswith(keyword) and line[len(keyword)] in [' ', '[']:
-                arg = line[len(keyword):]
-                break
+            try:
+                if line.startswith(keyword) and line[len(keyword)] in [' ', '[']:
+                    arg = line[len(keyword):]
+                    break
+            except IndexError:
+                self._invalid_pofile(line, lineno, "Keyword must be followed by a string")
         else:
             self._invalid_pofile(line, lineno, "Start of line didn't match any expected keyword.")
             return
@@ -290,7 +293,7 @@ class PoFileParser(object):
         if self.abort_invalid:
             raise PoFileError(msg, self.catalog, line, lineno)
         print("WARNING:", msg)
-        print("WARNING: Problem on line {0}: {1}".format(lineno + 1, line))
+        print(u"WARNING: Problem on line {0}: {1}".format(lineno + 1, line))
 
 
 def read_po(fileobj, locale=None, domain=None, ignore_obsolete=False, charset=None, abort_invalid=False):

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -456,16 +456,8 @@ msgstr[2] "Vohs [text]"
             '''
         # Catalog not created, throws Unicode Error
         buf = StringIO(invalid_po)
-        output = None
-
-        # This should only be thrown under py27
-        if sys.version_info.major == 2:
-            with self.assertRaises(UnicodeEncodeError):
-                output = pofile.read_po(buf, locale='fr', abort_invalid=False)
-            assert not output
-        else:
-            output = pofile.read_po(buf, locale='fr', abort_invalid=False)
-            assert isinstance(output, Catalog)
+        output = pofile.read_po(buf, locale='fr', abort_invalid=False)
+        assert isinstance(output, Catalog)
 
         # Catalog not created, throws PoFileError
         buf = StringIO(invalid_po_2)


### PR DESCRIPTION
A couple of very small fixes to avoid stack traces due to errors in the .po file.

1. Line 186
If a keyword - e.g. 'msgid' appears on a line by itself, the 'len(keyword)' call used to raise an IndexError exception rather than reporting the error

2. Line 293
If the offending line in the .po file contains unicode characters - e.g. accents - the 'format()' call was raising a UnicodeEncodeError rather than reporting the location of the error.
