### PR TITLE
add support to util.pathmatch for matching the start of a string

### DIFF
--- a/babel/util.py
+++ b/babel/util.py
@@ -151,6 +151,16 @@ def pathmatch(pattern, filename):
     >>> pathmatch('**.py', 'templates/index.html')
     False
 
+    >>> pathmatch('./foo/**.py', 'foo/bar/baz.py')
+    True
+    >>> pathmatch('./foo/**.py', 'bar/baz.py')
+    False
+
+    >>> pathmatch('^foo/**.py', 'foo/bar/baz.py')
+    True
+    >>> pathmatch('^foo/**.py', 'bar/baz.py')
+    False
+
     >>> pathmatch('**/templates/*.html', 'templates/index.html')
     True
     >>> pathmatch('**/templates/*.html', 'templates/foo/bar.html')
@@ -167,7 +177,16 @@ def pathmatch(pattern, filename):
         '**/': '(?:.+/)*?',
         '**': '(?:.+/)*?[^/]+',
     }
-    buf = []
+
+    if pattern.startswith('^'):
+        buf = ['^']
+        pattern = pattern[1:]
+    elif pattern.startswith('./'):
+        buf = ['^']
+        pattern = pattern[2:]
+    else:
+        buf = []
+
     for idx, part in enumerate(re.split('([?*]+/?)', pattern)):
         if idx % 2:
             buf.append(symbols[part])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,6 +31,11 @@ def test_pathmatch():
     assert not util.pathmatch('**.py', 'templates/index.html')
     assert util.pathmatch('**/templates/*.html', 'templates/index.html')
     assert not util.pathmatch('**/templates/*.html', 'templates/foo/bar.html')
+    assert util.pathmatch('^foo/**.py', 'foo/bar/baz/blah.py')
+    assert not util.pathmatch('^foo/**.py', 'blah/foo/bar/baz.py')
+    assert util.pathmatch('./foo/**.py', 'foo/bar/baz/blah.py')
+    assert util.pathmatch('./blah.py', 'blah.py')
+    assert not util.pathmatch('./foo/**.py', 'blah/foo/bar/baz.py')
 
 
 def test_odict_pop():


### PR DESCRIPTION
This PR adds support to `util.pathmatch` for forcing the match of the start of a string. This is useful for example if you want to place a `babel.cfg` file in a subdirectory and only extract messages from under that directory. The added (equivalent) syntax looks like so:

```ini
[python: ./**.py]
[python: ^**.py]
```
