### PR TITLE
Remove unnecessary compat shim 'binary_type'

### DIFF
--- a/babel/_compat.py
+++ b/babel/_compat.py
@@ -8,7 +8,6 @@ _identity = lambda x: x
 
 if not PY2:
     text_type = str
-    binary_type = bytes
     string_types = (str,)
     integer_types = (int, )
 
@@ -32,7 +31,6 @@ if not PY2:
 
 else:
     text_type = unicode
-    binary_type = str
     string_types = (str, unicode)
     integer_types = (int, long)
 
@@ -62,7 +60,7 @@ number_types = integer_types + (float,)
 def force_text(s, encoding='utf-8', errors='strict'):
     if isinstance(s, text_type):
         return s
-    if isinstance(s, binary_type):
+    if isinstance(s, bytes):
         return s.decode(encoding, errors)
     return text_type(s)
 


### PR DESCRIPTION
The bytes type is available on all supported Pythons. On Python 2, it is an alias of `str`, same as `binary_type`. By removing the shim, makes the code more forward compatible.