### PR TITLE
Avoid KeyError trying to get data on WindowsXP

### DIFF
--- a/babel/localtime/_win32.py
+++ b/babel/localtime/_win32.py
@@ -66,7 +66,7 @@ def get_localzone_name():
             sub = winreg.OpenKey(tzkey, subkey)
             data = valuestodict(sub)
             sub.Close()
-            if data['Std'] == tzwin:
+            if data.get('Std', None) == tzwin:
                 tzkeyname = subkey
                 break
 


### PR DESCRIPTION
I've found this issue trying to compile documentation with Sphinx on WindowsXP with `make html` command. Some data dictionaries are void on my machine, so using lazy 'get' on those can prevent next `KeyError`:

```
C:\Path\to\my\project\doc>make html
{'MapID': '8,9', 'Index': 165, 'Std': 'Hora estándar árabe', 'Display': '(GMT+04
:00) Abu Dhabi, Muscat', 'TZI': b'\x10\xff\xff\xff\x00\x00\x00\x00\xc4\xff\xff\x
ff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x
00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'Dlt': 'Hora de verano árab
e'}
{'MapID': '-1,71', 'Index': 158, 'Std': 'Hora estándar árabe D', 'Display': '(GM
T+03:00) Baghdad', 'TZI': b'L\xff\xff\xff\x00\x00\x00\x00\xc4\xff\xff\xff\x00\x0
0\n\x00\x00\x00\x01\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\
x01\x00\x03\x00\x00\x00\x00\x00\x00\x00', 'Dlt': 'Hora de verano árabe'}
{'MapID': '12,13', 'Index': 195, 'Std': 'Hora estándar de Asia C.', 'Display': '
(GMT+06:00) Astana, Dhaka', 'TZI': b'\x98\xfe\xff\xff\x00\x00\x00\x00\xc4\xff\xf
f\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'Dlt': 'Hora de verano d
e Asia C.'}
{}
Traceback (most recent call last):
  File "c:\python34\lib\runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python34\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python34\Scripts\sphinx-build.exe\__main__.py", line 5, in <module>
  File "c:\python34\lib\site-packages\sphinx\cmd\build.py", line 25, in <module>

    from sphinx.application import Sphinx
  File "c:\python34\lib\site-packages\sphinx\application.py", line 29, in <modul
e>
    from sphinx.config import Config, check_unicode
  File "c:\python34\lib\site-packages\sphinx\config.py", line 28, in <module>
    from sphinx.util.i18n import format_date
  File "c:\python34\lib\site-packages\sphinx\util\i18n.py", line 20, in <module>

    import babel.dates
  File "c:\python34\lib\site-packages\babel\dates.py", line 29, in <module>
    from babel.util import UTC, LOCALTZ
  File "c:\python34\lib\site-packages\babel\util.py", line 19, in <module>
    from babel import localtime
  File "c:\python34\lib\site-packages\babel\localtime\__init__.py", line 74, in
<module>
    LOCALTZ = get_localzone()
  File "c:\python34\lib\site-packages\babel\localtime\__init__.py", line 70, in
get_localzone
    return _get_localzone()
  File "c:\python34\lib\site-packages\babel\localtime\_win32.py", line 97, in _g
et_localzone
    return pytz.timezone(get_localzone_name())
  File "c:\python34\lib\site-packages\babel\localtime\_win32.py", line 70, in ge
t_localzone_name
    if data['Std'] == tzwin:
KeyError: 'Std'
```