### PR TITLE
Fix DeprecationWarning in 3.7

### DIFF
--- a/babel/_compat.py
+++ b/babel/_compat.py
@@ -78,3 +78,12 @@ else:
         import cdecimal as decimal
     except ImportError:
         import decimal
+
+# In Python 3.7, importing ABCs directly from the collections module shows a
+# warning and in Python 3.8 it will stop working
+# Refer : https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320
+
+if not PY2:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -14,10 +14,9 @@
 
 import os
 import threading
-from collections import MutableMapping
 from itertools import chain
 
-from babel._compat import pickle, string_types
+from babel._compat import pickle, string_types, MutableMapping
 
 
 _cache = {}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     pytest==3.3.2
     pytest-cov==2.5.1
     cdecimal: m3-cdecimal
-    freezegun==0.3.9
+    freezegun==0.3.11
 whitelist_externals = make
 commands = make clean-cldr test
 passenv = PYTHON_TEST_FLAGS


### PR DESCRIPTION
* This PR fixes the deprecation warnings in 3.7
* Upgrade freezegun to support 3.7. Current version is incompatible with 3.7 so I have upgraded it (Reference : https://github.com/spulec/freezegun/pull/231)
* Grepping for similar imports doesn't show up any places related to this

Successful build : https://travis-ci.org/tirkarthi/babel/builds/446248386

I added 3.7 but it seems Travis has problems with 3.7 and Ubuntu 14.04 so I have reverted it. Since the CI passes on 3.6 and 2.7 I think it's safe to merge. I cannot verify them locally due to setting up locales and test data in my Ubuntu machine.

Travis issue : https://github.com/travis-ci/travis-ci/issues/9815
Python 3.7 and Ubuntu 14.04 issue : https://github.com/travis-ci/travis-ci/issues/9069

closes #607 

Friendly ping @akx 

Thanks