### PR TITLE
Using ABCs from collections instead of collections.abc is deprecated.

### DIFF
--- a/babel/_compat.py
+++ b/babel/_compat.py
@@ -29,6 +29,7 @@ if not PY2:
     cmp = lambda a, b: (a > b) - (a < b)
 
     array_tobytes = array.array.tobytes
+    from collections import abc
 
 else:
     text_type = unicode
@@ -54,7 +55,7 @@ else:
     cmp = cmp
 
     array_tobytes = array.array.tostring
-
+    import collections as abc
 
 number_types = integer_types + (float,)
 

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -14,10 +14,9 @@
 
 import os
 import threading
-from collections import MutableMapping
 from itertools import chain
 
-from babel._compat import pickle, string_types
+from babel._compat import pickle, string_types, abc
 
 
 _cache = {}
@@ -187,7 +186,7 @@ class Alias(object):
         return data
 
 
-class LocaleDataDict(MutableMapping):
+class LocaleDataDict(abc.MutableMapping):
     """Dictionary wrapper that automatically resolves aliases to the actual
     values.
     """


### PR DESCRIPTION
And it will stop working in Python 3.8 according to the warning.