### PR TITLE
Remove all references to deprecated easy_install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,8 +5,7 @@ Installation
 
 Babel is distributed as a standard Python package fully set up with all
 the dependencies it needs.  It primarily depends on the excellent `pytz`_
-library for timezone handling.  To install it you can use ``easy_install``
-or ``pip``.
+library for timezone handling.  To install it you can use ``pip``.
 
 .. _pytz: http://pytz.sourceforge.net/
 
@@ -17,17 +16,12 @@ virtualenv
 
 Virtualenv is probably what you want to use during development, and if you
 have shell access to your production machines, you'll probably want to use
-it there, too.
+it there, too.  Use ``pip`` to install it::
 
-If you are on Mac OS X or Linux, chances are that one of the following two
-commands will work for you::
+    $ sudo pip install virtualenv
 
-    $ sudo easy_install virtualenv
-
-If you are on Windows and don't have the `easy_install` command, you must
-install it first.  Check the :ref:`windows-easy-install` section for more
-information about how to do that.  Once you have it installed, run the same
-commands as above, but without the `sudo` prefix.
+If you're on Windows, run it in a command-prompt window with administrator
+privileges, and leave out ``sudo``.
 
 Once you have virtualenv installed, just fire up a shell and create
 your own environment.  I usually create a project folder and a `venv`
@@ -66,8 +60,6 @@ with root privileges::
 
     $ sudo pip install Babel
 
-If `pip` is not available on your system you can use `easy_install`.
-
 (On Windows systems, run it in a command-prompt window with administrator
 privileges, and leave out `sudo`.)
 
@@ -101,38 +93,3 @@ This will pull also in the dependencies and activate the git head as the
 current version inside the virtualenv.  Then all you have to do is run
 ``git pull origin`` to update to the latest version.  If the CLDR data
 changes you will have to re-run ``python setup.py import_cldr``.
-
-.. _windows-easy-install:
-
-`pip` and `distribute` on Windows
------------------------------------
-
-On Windows, installation of `easy_install` is a little bit trickier, but
-still quite easy.  The easiest way to do it is to download the
-`distribute_setup.py`_ file and run it.  The easiest way to run the file
-is to open your downloads folder and double-click on the file.
-
-Next, add the `easy_install` command and other Python scripts to the
-command search path, by adding your Python installation's Scripts folder
-to the `PATH` environment variable.  To do that, right-click on the
-"Computer" icon on the Desktop or in the Start menu, and choose "Properties".
-Then click on "Advanced System settings" (in Windows XP, click on the
-"Advanced" tab instead).  Then click on the "Environment variables" button.
-Finally, double-click on the "Path" variable in the "System variables" section,
-and add the path of your Python interpreter's Scripts folder. Be sure to
-delimit it from existing values with a semicolon.  Assuming you are using
-Python 2.7 on the default path, add the following value::
-
-
-    ;C:\Python27\Scripts
-
-And you are done!  To check that it worked, open the Command Prompt and execute
-``easy_install``.  If you have User Account Control enabled on Windows Vista or
-Windows 7, it should prompt you for administrator privileges.
-
-Now that you have ``easy_install``, you can use it to install ``pip``::
-
-    > easy_install pip
-
-
-.. _distribute_setup.py: http://python-distribute.org/distribute_setup.py


### PR DESCRIPTION
easy_install is deprecated and its use is discouraged by PyPA:

https://setuptools.readthedocs.io/en/latest/easy_install.html

> Warning: Easy Install is deprecated. Do not use it. Instead use pip.

Follow upstream advice and only recommended supported tools.