### PR TITLE
localedata.py: Do disk lookup once

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -733,15 +733,15 @@ class update_catalog(Command):
                 update_header_comment=self.update_header_comment
             )
 
-            tmpname = os.path.join(os.path.dirname(filename),
-                                   tempfile.gettempprefix() +
-                                   os.path.basename(filename))
+            tmpname = os.path.join(
+                os.path.dirname(filename),
+                tempfile.gettempprefix() + os.path.basename(filename))
             try:
                 with open(tmpname, 'wb') as tmpfile:
                     write_po(tmpfile, catalog,
                              ignore_obsolete=self.ignore_obsolete,
                              include_previous=self.previous, width=self.width)
-            except:
+            except Exception:
                 os.remove(tmpname)
                 raise
 
@@ -811,16 +811,15 @@ class CommandLineInterface(object):
 
         self._configure_logging(options.loglevel)
         if options.list_locales:
-            identifiers = localedata.locale_identifiers()
+            identifiers = localedata.locale_identifiers
             longest = max([len(identifier) for identifier in identifiers])
-            identifiers.sort()
             format = u'%%-%ds %%s' % (longest + 1)
-            for identifier in identifiers:
+            for identifier in sorted(identifiers):
                 locale = Locale.parse(identifier)
                 output = format % (identifier, locale.english_name)
-                print(output.encode(sys.stdout.encoding or
-                                    getpreferredencoding() or
-                                    'ascii', 'replace'))
+                print(output.encode(
+                    sys.stdout.encoding or getpreferredencoding() or 'ascii',
+                    'replace'))
             return 0
 
         if not args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,4 @@ def os_environ(monkeypatch):
 def pytest_generate_tests(metafunc):
     if hasattr(metafunc.function, "all_locales"):
         from babel.localedata import locale_identifiers
-        metafunc.parametrize("locale", list(locale_identifiers()))
+        metafunc.parametrize("locale", list(locale_identifiers))

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -15,7 +15,8 @@ import unittest
 import random
 from operator import methodcaller
 
-from babel import localedata, numbers
+from babel import localedata
+
 
 class MergeResolveTestCase(unittest.TestCase):
 
@@ -75,33 +76,33 @@ def test_merge():
 
 
 def test_locale_identification():
-    for l in localedata.locale_identifiers():
+    for l in localedata.locale_identifiers:
         assert localedata.exists(l)
 
+
 def test_unique_ids():
-    # Check all locale IDs are uniques.
-    all_ids = localedata.locale_identifiers()
-    assert len(all_ids) == len(set(all_ids))
+    all_ids = localedata.locale_identifiers
     # Check locale IDs don't collide after lower-case normalization.
     lower_case_ids = list(map(methodcaller('lower'), all_ids))
     assert len(lower_case_ids) == len(set(lower_case_ids))
 
 
 def test_mixedcased_locale():
-    for l in localedata.locale_identifiers():
+    for l in localedata.locale_identifiers:
         locale_id = ''.join([
             methodcaller(random.choice(['lower', 'upper']))(c) for c in l])
         assert localedata.exists(locale_id)
+
 
 def test_locale_argument_acceptance():
     # Testing None input.
     normalized_locale = localedata.normalize_locale(None)
     assert normalized_locale is None
     locale_exist = localedata.exists(None)
-    assert locale_exist == False
+    assert not locale_exist
 
     # # Testing list input.
     normalized_locale = localedata.normalize_locale(['en_us', None])
     assert normalized_locale is None
     locale_exist = localedata.exists(['en_us', None])
-    assert locale_exist == False
+    assert not locale_exist

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -16,11 +16,10 @@ import pytest
 
 from datetime import date
 
-from babel import Locale, localedata, numbers
+from babel import localedata, numbers
 from babel.numbers import (
     list_currencies, validate_currency, UnknownCurrencyError, is_currency, normalize_currency,
     get_currency_precision, get_decimal_precision, get_currency_unit_pattern)
-from babel.localedata import locale_identifiers
 from babel._compat import decimal
 
 
@@ -221,15 +220,15 @@ def test_validate_currency():
 
 
 def test_is_currency():
-    assert is_currency('EUR') == True
-    assert is_currency('eUr') == False
-    assert is_currency('FUU') == False
-    assert is_currency('') == False
-    assert is_currency(None) == False
-    assert is_currency('   EUR    ') == False
-    assert is_currency('   ') == False
-    assert is_currency([]) == False
-    assert is_currency(set()) == False
+    assert is_currency('EUR')
+    assert not is_currency('eUr')
+    assert not is_currency('FUU')
+    assert not is_currency('')
+    assert not is_currency(None)
+    assert not is_currency('   EUR    ')
+    assert not is_currency('   ')
+    assert not is_currency([])
+    assert not is_currency(set())
 
 
 def test_normalize_currency():
@@ -365,7 +364,7 @@ def test_format_decimal_precision(input_value, expected_value):
 
 def test_format_decimal_quantization():
     # Test all locales.
-    for locale_code in localedata.locale_identifiers():
+    for locale_code in localedata.locale_identifiers:
         assert numbers.format_decimal(
             '0.9999999999', locale=locale_code, decimal_quantization=False).endswith('9999999999') is True
 
@@ -451,7 +450,7 @@ def test_format_currency_precision(input_value, expected_value):
 
 def test_format_currency_quantization():
     # Test all locales.
-    for locale_code in localedata.locale_identifiers():
+    for locale_code in localedata.locale_identifiers:
         assert numbers.format_currency(
             '0.9999999999', 'USD', locale=locale_code, decimal_quantization=False).find('9999999999') > -1
 
@@ -485,7 +484,7 @@ def test_format_currency_long_display_name():
 
 
 def test_format_currency_long_display_name_all():
-    for locale_code in localedata.locale_identifiers():
+    for locale_code in localedata.locale_identifiers:
         assert numbers.format_currency(
             1, 'USD', locale=locale_code, format_type='name').find('1') > -1
         assert numbers.format_currency(
@@ -543,7 +542,7 @@ def test_format_percent_precision(input_value, expected_value):
 
 def test_format_percent_quantization():
     # Test all locales.
-    for locale_code in localedata.locale_identifiers():
+    for locale_code in localedata.locale_identifiers:
         assert numbers.format_percent(
             '0.9999999999', locale=locale_code, decimal_quantization=False).find('99999999') > -1
 
@@ -600,7 +599,7 @@ def test_format_scientific_precision(input_value, expected_value):
 
 def test_format_scientific_quantization():
     # Test all locales.
-    for locale_code in localedata.locale_identifiers():
+    for locale_code in localedata.locale_identifiers:
         assert numbers.format_scientific(
             '0.9999999999', locale=locale_code, decimal_quantization=False).find('999999999') > -1
 


### PR DESCRIPTION
This removes localedata.py:locale_identifiers method in favor of a module level `set` variable. The value returned by the old method never changes (the locale data files are distributed with the lib), so there shouldn't be a need to scan the disk every call.

I noticed a hot spot in this method when profiling a service that uses this library. Specifically I noticed that `babel.Locale.parse` performs very poorly when supplied bogus locales. I ran a small benchmark to demonstrate this:

```
import timeit

import babel


def wrapped():
    try:
        babel.Locale.parse("en_ZH")
    except babel.UnknownLocaleError:
        pass


print(timeit.timeit(wrapped, number=1000))
```

```
Before: 3.91633701324
After: 0.0546479225159 
```