### PR TITLE
localedata.py: Do disk lookup once

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -36,10 +36,8 @@ def normalize_locale(name):
     """
     if not name or not isinstance(name, string_types):
         return None
-    try:
-        return _locale_identifiers_normalization_map[name.strip().lower()]
-    except KeyError:
-        return None
+
+    return _locale_identifiers_normalization_map.get(name.strip().lower())
 
 
 def exists(name):

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -14,7 +14,6 @@
 
 import os
 import threading
-from itertools import chain
 
 from babel._compat import pickle, string_types, abc
 
@@ -22,6 +21,10 @@ from babel._compat import pickle, string_types, abc
 _cache = {}
 _cache_lock = threading.RLock()
 _dirname = os.path.join(os.path.dirname(__file__), 'locale-data')
+_locale_identifiers = set(stem for stem, extension in [
+    os.path.splitext(filename) for filename in os.listdir(_dirname)
+] if extension == '.dat' and stem != 'root')
+_locale_identifiers_lower = set(s.lower() for s in _locale_identifiers)
 
 
 def normalize_locale(name):
@@ -33,9 +36,8 @@ def normalize_locale(name):
     if not name or not isinstance(name, string_types):
         return None
     name = name.strip().lower()
-    for locale_id in chain.from_iterable([_cache, locale_identifiers()]):
-        if name == locale_id.lower():
-            return locale_id
+    if name in _locale_identifiers_lower:
+        return name
 
 
 def exists(name):
@@ -61,9 +63,7 @@ def locale_identifiers():
 
     :return: a list of locale identifiers (strings)
     """
-    return [stem for stem, extension in [
-        os.path.splitext(filename) for filename in os.listdir(_dirname)
-    ] if extension == '.dat' and stem != 'root']
+    return list(_locale_identifiers)
 
 
 def load(name, merge_inherited=True):

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -95,9 +95,9 @@ def load(name, merge_inherited=True):
                       identifier, or one of the locales it inherits from
     """
     _cache_lock.acquire()
-    cache_key = 'root' if name == 'root' else normalize_locale(name)
+    name = 'root' if name == 'root' else normalize_locale(name)
     try:
-        data = _cache.get(cache_key)
+        data = _cache.get(name)
         if not data:
             # Load inherited data
             if name == 'root' or not merge_inherited:
@@ -118,7 +118,7 @@ def load(name, merge_inherited=True):
                     merge(data, pickle.load(fileobj))
                 else:
                     data = pickle.load(fileobj)
-            _cache[cache_key] = data
+            _cache[name] = data
 
         return data
     finally:


### PR DESCRIPTION
After this change, `localedata.locale_identifiers` will only read the available locale identifiers from disk once. Since the locale data files are distributed with the lib, there shouldn't be a need to scan the disk every time this is called.

I noticed a hot spot in this method when profiling a service that uses this library. Specifically I noticed that `babel.Locale.parse` performs very poorly when supplied bogus locales. I ran a small benchmark to demonstrate this:

```
import timeit

import babel


def wrapped():
    try:
        babel.Locale.parse("en_ZH")
    except babel.UnknownLocaleError:
        pass


print(timeit.timeit(wrapped, number=1000))
```

```
Before: 3.91633701324
After: 0.0591921806335
```