### PR TITLE
Fix conftest.py compatibility with pytest 4.3

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   # Build data files
-  - "pip install --upgrade pytest==3.3.2 pytest-cov==2.5.1 codecov freezegun==0.3.11"
+  - "pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.11"
   - "pip install --editable ."
   - "python setup.py import_cldr"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
-  - pip install --upgrade $CDECIMAL pytest==3.3.2 pytest-cov==2.5.1 freezegun==0.3.11
+  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.11
   - pip install --editable .
 
 script:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ def os_environ(monkeypatch):
 
 
 def pytest_generate_tests(metafunc):
-    if hasattr(metafunc.function, "all_locales"):
-        from babel.localedata import locale_identifiers
-        metafunc.parametrize("locale", list(locale_identifiers()))
+    if hasattr(metafunc.function, "pytestmark"):
+        for mark in metafunc.function.pytestmark:
+            if mark.name == "all_locales":
+                from babel.localedata import locale_identifiers
+                metafunc.parametrize("locale", list(locale_identifiers()))
+                break

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py27, pypy, py34, py35, py36, py37, pypy3, py27-cdecimal
 
 [testenv]
 deps =
-    pytest==3.3.2
-    pytest-cov==2.5.1
+    pytest==4.3.1
+    pytest-cov==2.6.1
     cdecimal: m3-cdecimal
     freezegun==0.3.11
 whitelist_externals = make


### PR DESCRIPTION
While pytest in tox.ini is explicitly set to be 3.3.2, in Fedora 31 we are about to update to a newer version of pytest. In order to be able to test babel, we need pytest 4.3 support.

This adds support for pytest 4.3 without breaking support for 3.3.2.

Switching to 4.3 in tox.ini is left at the discretion of the maintainers.