### PR TITLE
Message comparison fixes

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -16,8 +16,7 @@ import re
 
 from babel.messages.catalog import Catalog, Message
 from babel.util import wraptext
-from babel._compat import text_type
-
+from babel._compat import text_type, cmp
 
 
 def unescape(string):
@@ -98,6 +97,36 @@ class _NormalizedString(object):
 
     def __nonzero__(self):
         return bool(self._strs)
+
+    __bool__ = __nonzero__
+
+    def __repr__(self):
+        return os.linesep.join(self._strs)
+
+    def __cmp__(self, other):
+        if not other:
+            return 1
+
+        return cmp(text_type(self), text_type(other))
+
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
+
 
 
 class PoFileParser(object):

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -581,7 +581,16 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
 
         if not no_location:
             locs = []
-            for filename, lineno in sorted(message.locations):
+
+            # Attempt to sort the locations.  If we can't do that, for instance
+            # because there are mixed integers and Nones or whatnot (see issue #606)
+            # then give up, but also don't just crash.
+            try:
+                locations = sorted(message.locations)
+            except TypeError:  # e.g. "TypeError: unorderable types: NoneType() < int()"
+                locations = message.locations
+
+            for filename, lineno in locations:
                 if lineno and include_lineno:
                     locs.append(u'%s:%d' % (filename.replace(os.sep, '/'), lineno))
                 else:

--- a/tests/messages/test_normalized_string.py
+++ b/tests/messages/test_normalized_string.py
@@ -1,0 +1,17 @@
+from babel.messages.pofile import _NormalizedString
+
+
+def test_normalized_string():
+    ab1 = _NormalizedString('a', 'b ')
+    ab2 = _NormalizedString('a', ' b')
+    ac1 = _NormalizedString('a', 'c')
+    ac2 = _NormalizedString('  a', 'c  ')
+    z = _NormalizedString()
+    assert ab1 == ab2 and ac1 == ac2  # __eq__
+    assert ab1 < ac1  # __lt__
+    assert ac1 > ab2  # __gt__
+    assert ac1 >= ac2  # __ge__
+    assert ab1 <= ab2  # __le__
+    assert ab1 != ac1  # __ne__
+    assert not z  # __nonzero__ / __bool__
+    assert sorted([ab1, ab2, ac1])  # the sort order is not stable so we can't really check it, just that we can sort


### PR DESCRIPTION
* Add comparison operators to _NormalizedString (fixes #612)
* Don't crash when message.locations can't be sorted (leave them unsorted) (fixes #606)