### PR TITLE
Fix babel.dates.parse_date()

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1141,7 +1141,7 @@ def parse_date(string, locale=LC_TIME):
     :param locale: a `Locale` object or a locale identifier
     """
     # TODO: try ISO format first?
-    format = get_date_format(locale=locale).pattern.lower()
+    format = get_date_format(format='short', locale=locale).pattern.lower()
     year_idx = format.index('y')
     month_idx = format.index('m')
     if month_idx < 0:


### PR DESCRIPTION
Set the format to 'short' in ``babel.dates.parse_date()`` l. 1144.
``parse_date()`` only works for the short format anyway and
it failed for the 'sv_SE' locale because the year is not at the same
position in the short and medium formats.

Closes https://github.com/python-babel/babel/issues/657