### PR TITLE
Add format argument to ``parse_date()``

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1126,7 +1126,7 @@ def get_period_id(time, tzinfo=None, type=None, locale=LC_TIME):
         return "pm"
 
 
-def parse_date(string, locale=LC_TIME):
+def parse_date(string, locale=LC_TIME, format='medium'):
     """Parse a date from a string.
 
     This function uses the date format for the locale as a hint to determine
@@ -1139,14 +1139,16 @@ def parse_date(string, locale=LC_TIME):
 
     :param string: the string containing the date
     :param locale: a `Locale` object or a locale identifier
+    :param format: the format to use, one of "full", "long", "medium", or
+                   "short"
     """
     # TODO: try ISO format first?
-    format = get_date_format(locale=locale).pattern.lower()
-    year_idx = format.index('y')
-    month_idx = format.index('m')
+    date_format = get_date_format(format=format, locale=locale).pattern.lower()
+    year_idx = date_format.index('y')
+    month_idx = date_format.index('m')
     if month_idx < 0:
-        month_idx = format.index('l')
-    day_idx = format.index('d')
+        month_idx = date_format.index('l')
+    day_idx = date_format.index('d')
 
     indexes = [(year_idx, 'Y'), (month_idx, 'M'), (day_idx, 'D')]
     indexes.sort()

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -725,6 +725,7 @@ def test_format_timedelta():
 def test_parse_date():
     assert dates.parse_date('4/1/04', locale='en_US') == date(2004, 4, 1)
     assert dates.parse_date('01.04.2004', locale='de_DE') == date(2004, 4, 1)
+    assert dates.parse_date('2004-04-01', locale='sv_SE', format='short') == date(2004, 4, 1)
 
 
 def test_parse_time():


### PR DESCRIPTION
``parse_date()`` does not allow the user to specify the date's format
and the 'medium' format is used by default in the call to
``get_date_format()`` on line 1144. This results in a failure to parse
the date in short format for the locale 'sv_SE'. 

This PR adds the ``format`` argument to avoid this kind of failures. The default value is
set to 'medium' to preserve the old behavior. Parsing a date in short format for the locale 'sv_SE' now works when passing the `format='short'` option.

Closes https://github.com/python-babel/babel/issues/657.

Giving the right format solves all the failures for short dates:
- without specifying the format:
	```python
	from babel.localedata import locale_identifiers
	from babel.dates import *
	locales = locale_identifiers()
	locales.sort()
	d = date(2019, 7, 19)
	err = 0
	for locale in locales:
		try:
			parse_date(format_date(d, 'short', locale), locale)
		except Exception:
			err += 1
			print(locale, 'error')
	print('errors: %i / %i' % (err, len(locales)))
	```
    gives
    ```
   	af error
	af_NA error
	af_ZA error
	en_CA error
	en_SE error
	en_ZA error
	fa error
	fa_AF error
	fa_IR error
	kl error
	kl_GL error
	sv error
	sv_AX error
	sv_SE error
	ug error
	ug_CN error
	uz_Arab error
	uz_Arab_AF error
	wae error
	wae_CH error
	zh_Hant_HK error
	zh_Hant_MO error
	errors: 22 / 757
    ```
- when setting the format to short:
   ``` python
	from babel.localedata import locale_identifiers
	from babel.dates import *
	locales = locale_identifiers()
	locales.sort()
	d = date(2019, 7, 19)
	err = 0
	for locale in locales:
		try:
			parse_date(format_date(d, 'short', locale), locale, 'short')
		except Exception:
			err += 1
			print(locale, 'error')
	print('errors: %i / %i' % (err, len(locales)))
    ```
    gives
    ```errors: 0 / 757```

By the way, ``parse_date()`` fails for most dates in medium format:
```python
from babel.localedata import locale_identifiers
from babel.dates import *
locales = locale_identifiers()
locales.sort()
d = date(2019, 7, 19)
err = 0
for locale in locales:
	try:
		parse_date(format_date(d, 'medium', locale), locale, 'medium')
	except Exception:
		err += 1
print('errors: %i / %i' % (err, len(locales)))
```
gives
``errors: 613 / 757``