### PR TITLE
Add symbol to currency code mapping

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -531,6 +531,17 @@ class Locale(object):
         return self._data['currency_names']
 
     @property
+    def currency_codes(self):
+        """Mapping of currency symbols to codes.
+
+        >>> Locale('en', 'US').currency_codes['$']
+        u'USD'
+        >>> Locale('es', 'CO').currency_codes['US$']
+        u'USD'
+        """
+        return self._data['currency_codes']
+
+    @property
     def currency_symbols(self):
         """Mapping of currency codes to symbols.
 

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -109,6 +109,18 @@ def normalize_currency(currency, locale=None):
     return currency
 
 
+def get_currency_code(symbol, locale=LC_NUMERIC):
+    """Returns the code used by the locale for the specified currency symbol.
+
+    >>> get_currency_code('$', locale='en_US')
+    u'USD'
+
+    :param symbol: the currency symbol.
+    :param locale: the `Locale` object or locale identifier.
+    """
+    return Locale.parse(locale).currency_codes.get(symbol, symbol)
+
+
 def get_currency_name(currency, count=None, locale=LC_NUMERIC):
     """Return the name used by the locale for the specified currency.
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -810,6 +810,7 @@ def parse_currency_names(data, tree):
     currency_names = data.setdefault('currency_names', {})
     currency_names_plural = data.setdefault('currency_names_plural', {})
     currency_symbols = data.setdefault('currency_symbols', {})
+    currency_codes = data.setdefault('currency_codes', {})
     for elem in tree.findall('.//currencies/currency'):
         code = elem.attrib['type']
         for name in elem.findall('displayName'):
@@ -826,6 +827,7 @@ def parse_currency_names(data, tree):
             if symbol.attrib.get('alt'):  # Skip alternate forms
                 continue
             currency_symbols[code] = text_type(symbol.text)
+            currency_codes[text_type(symbol.text)] = code
 
 
 def parse_unit_patterns(data, tree):

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -252,6 +252,10 @@ def test_get_currency_symbol():
     assert numbers.get_currency_symbol('USD', 'en_US') == u'$'
 
 
+def test_get_currency_code():
+    assert numbers.get_currency_code('$', 'en_US') == u'USD'
+
+
 def test_get_currency_precision():
     assert get_currency_precision('EUR') == 2
     assert get_currency_precision('JPY') == 0


### PR DESCRIPTION
During cldr import the `currency_codes` mapping is created on `data` and
internally exposed by the `Locale.currency_codes` property.
The `numbers.get_currency_code` API is made available to convert a
currency symbol into a currency code.

Partially addresses issue #141