### PR TITLE
Replace usage of parser.suite with ast.parse

### DIFF
--- a/babel/util.py
+++ b/babel/util.py
@@ -68,8 +68,8 @@ def parse_encoding(fp):
         m = PYTHON_MAGIC_COMMENT_re.match(line1)
         if not m:
             try:
-                import parser
-                parser.suite(line1.decode('latin-1'))
+                import ast
+                ast.parse(line1.decode('latin-1'))
             except (ImportError, SyntaxError, UnicodeEncodeError):
                 # Either it's a real syntax error, in which case the source is
                 # not valid python source, or line2 is a continuation of line1,


### PR DESCRIPTION
Replaced usage of the long-superseded "parser.suite" module in the mako.util package for parsing the python magic encoding comment with the "ast.parse" function introduced many years ago in Python 2.5, as "parser.suite" is emitting deprecation warnings in Python 3.9.

Fixes https://github.com/sqlalchemy/mako/issues/310
See also https://github.com/sqlalchemy/mako/commit/2dae7d2c3da73653e6de329dc15c55056a0b9ab6