### PR TITLE
catalog.rst: Add __iter__ to Catalog documentation

### DIFF
--- a/docs/api/messages/catalog.rst
+++ b/docs/api/messages/catalog.rst
@@ -12,6 +12,7 @@ Catalogs
 
 .. autoclass:: Catalog
    :members:
+   :special-members: __iter__
 
 Messages
 --------


### PR DESCRIPTION
The declaration of \_\_iter__ under the special-members
directive makes it visible in the documentation.
The docstring describing \_\_iter__ already exists.


Closes https://github.com/python-babel/babel/issues/128