### PR TITLE
Update license.rst

### DIFF
--- a/docs/license.rst
+++ b/docs/license.rst
@@ -19,7 +19,7 @@ Authors
 General License Definitions
 ---------------------------
 
-The following section contains the full license texts for Flask and the
+The following section contains the full license texts for Babel and the
 documentation.
 
 -   "AUTHORS" hereby refers to all the authors listed in the


### PR DESCRIPTION
The documentation refers to the license as the license for _flask_ instead of Babel.