### PR TITLE
set cli default value to False for boolean_options

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -904,7 +904,7 @@ class CommandLineInterface(object):
             if name == as_args:
                 parser.usage += "<%s>" % name
             elif name in cmdclass.boolean_options:
-                parser.add_option(*strs, action="store_true", help=help)
+                parser.add_option(*strs, action="store_true", help=help, default=False)
             elif name in cmdclass.multiple_value_options:
                 parser.add_option(*strs, action="append", help=help, choices=choices)
             else:


### PR DESCRIPTION
update PO files with fuzzy match require 'no-fuzzy-matching' option set to False (https://github.com/python-babel/babel/blob/0cfa69e087a24364ba788ff9d862949b65f0ff12/babel/messages/catalog.py#L810) but add_option default value is 'null'