### PR TITLE
Parse string date times indepentent of time zone

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -10,7 +10,6 @@
 """
 
 import re
-import time
 
 from cgi import parse_header
 from collections import OrderedDict
@@ -44,9 +43,7 @@ PYTHON_FORMAT = re.compile(r'''
 def _parse_datetime_header(value):
     match = re.match(r'^(?P<datetime>.*?)(?P<tzoffset>[+-]\d{4})?$', value)
 
-    tt = time.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
-    ts = time.mktime(tt)
-    dt = datetime.fromtimestamp(ts)
+    dt = datetime.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
 
     # Separate the offset into a sign component, hours, and # minutes
     tzoffset = match.group('tzoffset')


### PR DESCRIPTION
Parsing a date time string (such as for ``POT-Creation-Date`` or
``PO-Revision-Date``) as UTC time, in particular independent of the
local time zone.

Closes: #700