### PR TITLE
tests/test_dates.py: Fix broken test

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -761,7 +761,6 @@ def test_zh_TW_format():
 
 
 def test_format_current_moment(monkeypatch):
-    import datetime as datetime_module
     frozen_instant = datetime.utcnow()
 
     class frozen_datetime(datetime):
@@ -771,7 +770,7 @@ def test_format_current_moment(monkeypatch):
             return frozen_instant
 
     # Freeze time! Well, some of it anyway.
-    monkeypatch.setattr(datetime_module, "datetime", frozen_datetime)
+    monkeypatch.setattr(dates, "datetime_", frozen_datetime)
     assert dates.format_datetime(locale="en_US") == dates.format_datetime(frozen_instant, locale="en_US")
 
 


### PR DESCRIPTION
datetime was being incorrectly patched, so the unittest was failing

Closes https://github.com/python-babel/babel/issues/675