### PR TITLE
Added group_separator feature in number formatting

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -478,11 +478,11 @@ def format_currency(
         ...
     UnknownCurrencyFormatError: "'unknown' is not a known currency format type"
 
-    >>> format_currency(101299.98, 'EUR', locale='en_US', group_separator=False)
-    u'\u20ac101299.98'
+    >>> format_currency(101299.98, 'USD', locale='en_US', group_separator=False)
+    u'$101299.98'
 
-    >>> format_currency(101299.98, 'EUR', locale='en_US', group_separator=True)
-    u'€101,299.98'
+    >>> format_currency(101299.98, 'USD', locale='en_US', group_separator=True)
+    u'$101,299.98'
 
     You can also pass format_type='name' to use long display names. The order of
     the number and currency name, along with the correct localized plural form

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -401,12 +401,18 @@ def format_decimal(
     u'1.235'
     >>> format_decimal(1.2346, locale='en_US', decimal_quantization=False)
     u'1.2346'
+    >>> format_decimal(12345.67, locale='fr_CA', group_separator=False)
+    u'12345,67'
+    >>> format_decimal(12345.67, locale='en_US', group_separator=True)
+    u'12,345.67'
 
     :param number: the number to format
     :param format:
     :param locale: the `Locale` object or locale identifier
     :param decimal_quantization: Truncate and round high-precision numbers to
                                  the format pattern. Defaults to `True`.
+    :param group_separator: Boolean to switch group separator on/off in a locale's
+                            number format.
     """
     locale = Locale.parse(locale)
     if not format:
@@ -472,6 +478,12 @@ def format_currency(
         ...
     UnknownCurrencyFormatError: "'unknown' is not a known currency format type"
 
+    >>> format_currency(101299.98, 'EUR', locale='en_US', group_separator=False)
+    u'\u20ac101299.98'
+
+    >>> format_currency(101299.98, 'EUR', locale='en_US', group_separator=True)
+    u'€101,299.98'
+
     You can also pass format_type='name' to use long display names. The order of
     the number and currency name, along with the correct localized plural form
     of the currency name, is chosen according to locale:
@@ -500,6 +512,8 @@ def format_currency(
     :param format_type: the currency format type to use
     :param decimal_quantization: Truncate and round high-precision numbers to
                                  the format pattern. Defaults to `True`.
+    :param group_separator: Boolean to switch group separator on/off in a locale's
+                            number format.
 
     """
     if format_type == 'name':
@@ -582,11 +596,19 @@ def format_percent(
     >>> format_percent(23.9876, locale='en_US', decimal_quantization=False)
     u'2,398.76%'
 
+    >>> format_percent(229291.1234, locale='pt_BR', group_separator=False)
+    u'22929112%'
+
+    >>> format_percent(229291.1234, locale='pt_BR', group_separator=True)
+    u'22.929.112%'
+
     :param number: the percent number to format
     :param format:
     :param locale: the `Locale` object or locale identifier
     :param decimal_quantization: Truncate and round high-precision numbers to
                                  the format pattern. Defaults to `True`.
+    :param group_separator: Boolean to switch group separator on/off in a locale's
+                            number format.
     """
     locale = Locale.parse(locale)
     if not format:
@@ -597,7 +619,7 @@ def format_percent(
 
 
 def format_scientific(
-        number, format=None, locale=LC_NUMERIC, decimal_quantization=True, group_separator=True):
+        number, format=None, locale=LC_NUMERIC, decimal_quantization=True):
     """Return value formatted in scientific notation for a specific locale.
 
     >>> format_scientific(10000, locale='en_US')
@@ -628,7 +650,7 @@ def format_scientific(
         format = locale.scientific_formats.get(format)
     pattern = parse_pattern(format)
     return pattern.apply(
-        number, locale, decimal_quantization=decimal_quantization, group_separator=group_separator)
+        number, locale, decimal_quantization=decimal_quantization)
 
 
 class NumberFormatError(ValueError):

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -168,6 +168,21 @@ class FormatDecimalTestCase(unittest.TestCase):
                                                             locale='en_US', group_separator=False, format_type='name'))
         self.assertEqual(u'25123412\xa0%', numbers.format_percent(251234.1234, locale='sv_SE', group_separator=False))
 
+        self.assertEqual(u'29,567.12', numbers.format_decimal(29567.12,
+                                                            locale='en_US', group_separator=True))
+        self.assertEqual(u'29\u202f567,12', numbers.format_decimal(29567.12,
+                                                            locale='fr_CA', group_separator=True))
+        self.assertEqual(u'29.567,12', numbers.format_decimal(29567.12,
+                                                            locale='pt_BR', group_separator=True))
+        self.assertEqual(u'$1,099.98', numbers.format_currency(1099.98, 'USD',
+                                                              locale='en_US', group_separator=True))
+        self.assertEqual(u'101\u202f299,98\xa0\u20ac', numbers.format_currency(101299.98, 'EUR',
+                                                                    locale='fr_CA', group_separator=True))
+        self.assertEqual(u'101,299.98 euros', numbers.format_currency(101299.98, 'EUR',
+                                                                    locale='en_US', group_separator=True,
+                                                                    format_type='name'))
+        self.assertEqual(u'25\xa0123\xa0412\xa0%', numbers.format_percent(251234.1234, locale='sv_SE', group_separator=True))
+
 
 class NumberParsingTestCase(unittest.TestCase):
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -154,19 +154,19 @@ class FormatDecimalTestCase(unittest.TestCase):
         self.assertEqual('0.000000700', fmt)
 
     def test_group_separator(self):
-        self.assertEqual('23434567890567.12', numbers.format_decimal(23434567890567.12,
+        self.assertEqual('29567.12', numbers.format_decimal(29567.12,
                                                                      locale='en_US', group_separator=False))
-        self.assertEqual('23434567890567,12', numbers.format_decimal(23434567890567.12,
+        self.assertEqual('29567,12', numbers.format_decimal(29567.12,
                                                                      locale='fr_CA', group_separator=False))
-        self.assertEqual('23434567890567,12', numbers.format_decimal(23434567890567.12,
+        self.assertEqual('29567,12', numbers.format_decimal(29567.12,
                                                                      locale='pt_BR', group_separator=False))
-        self.assertEqual('$1099.98', numbers.format_currency(1099.98, 'USD',
+        self.assertEqual(u'$1099.98', numbers.format_currency(1099.98, 'USD',
                                                              locale='en_US', group_separator=False))
-        self.assertEqual('101299,98\xa0€', numbers.format_currency(101299.98, 'EUR',
+        self.assertEqual(u'101299,98\xa0€', numbers.format_currency(101299.98, 'EUR',
                                                             locale='fr_CA', group_separator=False))
         self.assertEqual('101299.98 euros', numbers.format_currency(101299.98, 'EUR',
                                                             locale='en_US', group_separator=False, format_type='name'))
-        self.assertEqual('25123412\xa0%', numbers.format_percent(251234.1234, locale='sv_SE', group_separator=False))
+        self.assertEqual(u'25123412\xa0%', numbers.format_percent(251234.1234, locale='sv_SE', group_separator=False))
 
 
 class NumberParsingTestCase(unittest.TestCase):

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -153,6 +153,21 @@ class FormatDecimalTestCase(unittest.TestCase):
         fmt = numbers.format_decimal(number, format="@@@", locale='en_US')
         self.assertEqual('0.000000700', fmt)
 
+    def test_group_separator(self):
+        self.assertEqual('23434567890567.12', numbers.format_decimal(23434567890567.12,
+                                                                     locale='en_US', group_separator=False))
+        self.assertEqual('23434567890567,12', numbers.format_decimal(23434567890567.12,
+                                                                     locale='fr_CA', group_separator=False))
+        self.assertEqual('23434567890567,12', numbers.format_decimal(23434567890567.12,
+                                                                     locale='pt_BR', group_separator=False))
+        self.assertEqual('$1099.98', numbers.format_currency(1099.98, 'USD',
+                                                             locale='en_US', group_separator=False))
+        self.assertEqual('101299,98\xa0€', numbers.format_currency(101299.98, 'EUR',
+                                                            locale='fr_CA', group_separator=False))
+        self.assertEqual('101299.98 euros', numbers.format_currency(101299.98, 'EUR',
+                                                            locale='en_US', group_separator=False, format_type='name'))
+        self.assertEqual('25123412\xa0%', numbers.format_percent(251234.1234, locale='sv_SE', group_separator=False))
+
 
 class NumberParsingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Added a new **group_separator** feature in number formatting. **group_separator** is a Boolean parameter default set as `True`, when `False`, it simply means the output should be free of group separator.
Example:
```
format_decimal(23434567890567.1224, locale='fr_CA', group_separator=False)
>>> '23434567890567,12'
```
Default behaviour remains unchanged.
Example:
```
format_decimal(23434567890567.1224, locale='en_US')
>>> '23,434,567,890,567.12
```