### PR TITLE
Started work on supporting CLDR 24

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -35,7 +35,7 @@ def get_currency_name(currency, count=None, locale=LC_NUMERIC):
 
     >>> get_currency_name('USD', locale='en_US')
     u'US Dollar'
-    
+
     .. versionadded:: 0.9.4
 
     :param currency: the currency code

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -13,9 +13,9 @@ except ImportError:
     from urllib import urlretrieve
 
 
-URL = 'http://unicode.org/Public/cldr/23.1/core.zip'
-FILENAME = 'core-23.1.zip'
-FILESUM = 'd44ff35f9b9160becbb3a575468d8a5a'
+URL = 'http://unicode.org/Public/cldr/24/core.zip'
+FILENAME = 'core-24.zip'
+FILESUM = 'cd2e8f31baf65c96bfc7e5377b3b793f'
 BLKSIZE = 131072
 
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -186,6 +186,8 @@ def main():
             # pass our parser anyways.
             if '-' in alias.attrib['type']:
                 continue
+            if 'replacement' not in alias.attrib:
+                continue
             language_aliases[alias.attrib['type']] = alias.attrib['replacement']
 
         # Territory aliases
@@ -574,7 +576,8 @@ def main():
             if ('draft' in elem.attrib or 'alt' in elem.attrib) \
                     and elem.attrib.get('type') in currency_formats:
                 continue
-            pattern = text_type(elem.findtext('currencyFormat/pattern'))
+            pattern = text_type(elem.findtext(
+                'currencyFormat[@type="standard"]/pattern'))
             currency_formats[elem.attrib.get('type')] = \
                 numbers.parse_pattern(pattern)
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -175,11 +175,11 @@ class NumberParsingTestCase(unittest.TestCase):
 
 
 def test_get_currency_name():
-    assert numbers.get_currency_name('USD', 'en_US') == u'US dollars'
+    assert numbers.get_currency_name('USD', locale='en_US') == u'US Dollar'
 
 
 def test_get_currency_symbol():
-    assert numbers.get_currency_symbol('USD', 'en_US') == u'$'
+    assert numbers.get_currency_symbol('USD', locale='en_US') == u'$'
 
 
 def test_get_territory_currencies():


### PR DESCRIPTION
Currently, the extraction code will do an os.walk to perform a deep file search. However, this file exploration could be very slow when there were directories that were deep and contain many files. Even if you have specified some directories to be ignored in the mapping file, the os.walk would explore these directories.

The PR improves the extract process performance via making sure to skip exploring those ignore directory early during os.walk.