### PR TITLE
CLDR 37 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+exclude_lines =
+    NotImplemented
+    pragma: no cover
+    warnings.warn

--- a/babel/support.py
+++ b/babel/support.py
@@ -79,7 +79,7 @@ class Format(object):
         return format_time(time, format, tzinfo=self.tzinfo, locale=self.locale)
 
     def timedelta(self, delta, granularity='second', threshold=.85,
-                  format='medium', add_direction=False):
+                  format='long', add_direction=False):
         """Return a time delta according to the rules of the given locale.
 
         >>> from datetime import timedelta

--- a/babel/units.py
+++ b/babel/units.py
@@ -75,8 +75,10 @@ def format_unit(value, measurement_unit, length='long', format=None, locale=LC_N
     u'12 metri'
     >>> format_unit(15.5, 'length-mile', locale='fi_FI')
     u'15,5 mailia'
-    >>> format_unit(1200, 'pressure-inch-hg', locale='nb')
-    u'1\\xa0200 tommer kvikks\\xf8lv'
+    >>> format_unit(1200, 'pressure-millimeter-ofhg', locale='nb')
+    u'1\\xa0200 millimeter kvikks\\xf8lv'
+    >>> format_unit(270, 'ton', locale='en')
+    u'270 tons'
 
     Number formats may be overridden with the ``format`` parameter.
 
@@ -271,6 +273,7 @@ def format_compound_unit(
     else:  # Bare denominator
         formatted_denominator = format_decimal(denominator_value, format=format, locale=locale)
 
-    per_pattern = locale._data["compound_unit_patterns"].get("per", {}).get(length, "{0}/{1}")
+    # TODO: this doesn't support "compound_variations" (or "prefix"), and will fall back to the "x/y" representation
+    per_pattern = locale._data["compound_unit_patterns"].get("per", {}).get(length, {}).get("compound", "{0}/{1}")
 
     return per_pattern.format(formatted_numerator, formatted_denominator)

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -13,9 +13,9 @@ except ImportError:
     from urllib import urlretrieve
 
 
-URL = 'http://unicode.org/Public/cldr/36/core.zip'
-FILENAME = 'cldr-core-36.zip'
-FILESUM = '07279e56c1f4266d140b907ef3ec379dce0a99542303a9628562ac5fe460ba43'
+URL = 'http://unicode.org/Public/cldr/37/core.zip'
+FILENAME = 'cldr-core-37.zip'
+FILESUM = 'ba93f5ba256a61a6f8253397c6c4b1a9b9e77531f013cc7ffa7977b5f7e4da57'
 BLKSIZE = 131072
 
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -853,9 +853,23 @@ def parse_unit_patterns(data, tree):
 
         for unit in elem.findall('compoundUnit'):
             unit_type = unit.attrib['type']
-            compound_patterns.setdefault(unit_type, {})[unit_length_type] = (
-                _text(unit.find('compoundUnitPattern'))
-            )
+            compound_unit_info = {}
+            compound_variations = {}
+            for child in unit.getchildren():
+                if child.tag == "unitPrefixPattern":
+                    compound_unit_info['prefix'] = _text(child)
+                elif child.tag == "compoundUnitPattern":
+                    compound_variations[None] = _text(child)
+                elif child.tag == "compoundUnitPattern1":
+                    compound_variations[child.attrib.get('count')] = _text(child)
+            if compound_variations:
+                compound_variation_values = set(compound_variations.values())
+                if len(compound_variation_values) == 1:
+                    # shortcut: if all compound variations are the same, only store one
+                    compound_unit_info['compound'] = next(iter(compound_variation_values))
+                else:
+                    compound_unit_info['compound_variations'] = compound_variations
+            compound_patterns.setdefault(unit_type, {})[unit_length_type] = compound_unit_info
 
 
 def parse_date_fields(data, tree):


### PR DESCRIPTION
This PR adds support for CLDR 37 (published 2020-04).

No new features (prefix compound patterns, grammatical forms) are supported at this time.

It also cleans up some deprecation warnings in certain tests.