### PR TITLE
Handle ZoneInfo objects in get_timezone_location, get_timezone_name

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   # Build data files
-  - "pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.12 backports.zoneinfo"
+  - 'pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.12'
   - "pip install --editable ."
   - "python setup.py import_cldr"
 

--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   # Build data files
-  - "pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.12"
+  - "pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.12 backports.zoneinfo"
   - "pip install --editable ."
   - "python setup.py import_cldr"
 

--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   # Build data files
-  - 'pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.12'
+  - "pip install --upgrade pytest==4.3.1 pytest-cov==2.6.1 codecov freezegun==0.3.12"
   - "pip install --editable ."
   - "python setup.py import_cldr"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
-  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.12 backports.zoneinfo
+  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.12 backports.zoneinfo;python_version<"3.9"
   - pip install --editable .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
-  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.12
+  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.12 backports.zoneinfo
   - pip install --editable .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 install:
   - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
-  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.12 backports.zoneinfo;python_version<"3.9"
+  - pip install --upgrade $CDECIMAL pytest==4.3.1 pytest-cov==2.6.1 freezegun==0.3.12 'backports.zoneinfo;python_version>="3.6" and python_version<"3.9"'
   - pip install --editable .
 
 script:

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -76,6 +76,21 @@ def _get_dt_and_tzinfo(dt_or_tzinfo):
     return dt, tzinfo
 
 
+def _get_tz_name(dt_or_tzinfo):
+    """
+    Get the timezone name out of a time, datetime, or tzinfo object.
+
+    :rtype: str
+    """
+    dt, tzinfo = _get_dt_and_tzinfo(dt_or_tzinfo)
+    if hasattr(tzinfo, 'zone'):  # pytz object
+        return tzinfo.zone
+    elif hasattr(tzinfo, 'key') and tzinfo.key is not None:  # ZoneInfo object
+        return tzinfo.key
+    else:
+        return tzinfo.tzname(dt or datetime.utcnow())
+
+
 def _get_datetime(instant):
     """
     Get a datetime out of an "instant" (date, time, datetime, number).
@@ -500,15 +515,9 @@ def get_timezone_location(dt_or_tzinfo=None, locale=LC_TIME, return_city=False):
     :return: the localized timezone name using location format
 
     """
-    dt, tzinfo = _get_dt_and_tzinfo(dt_or_tzinfo)
     locale = Locale.parse(locale)
 
-    if hasattr(tzinfo, 'zone'):  # pytz object
-        zone = tzinfo.zone
-    elif hasattr(tzinfo, 'key') and tzinfo.key is not None:  # ZoneInfo object
-        zone = tzinfo.key
-    else:
-        zone = tzinfo.tzname(dt or datetime.utcnow())
+    zone = _get_tz_name(dt_or_tzinfo)
 
     # Get the canonical time-zone code
     zone = get_global('zone_aliases').get(zone, zone)
@@ -621,12 +630,7 @@ def get_timezone_name(dt_or_tzinfo=None, width='long', uncommon=False,
     dt, tzinfo = _get_dt_and_tzinfo(dt_or_tzinfo)
     locale = Locale.parse(locale)
 
-    if hasattr(tzinfo, 'zone'):  # pytz object
-        zone = tzinfo.zone
-    elif hasattr(tzinfo, 'key') and tzinfo.key is not None:  # ZoneInfo object
-        zone = tzinfo.key
-    else:
-        zone = tzinfo.tzname(dt)
+    zone = _get_tz_name(dt_or_tzinfo)
 
     if zone_variant is None:
         if dt is None:

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -503,8 +503,10 @@ def get_timezone_location(dt_or_tzinfo=None, locale=LC_TIME, return_city=False):
     dt, tzinfo = _get_dt_and_tzinfo(dt_or_tzinfo)
     locale = Locale.parse(locale)
 
-    if hasattr(tzinfo, 'zone'):
+    if hasattr(tzinfo, 'zone'):  # pytz object
         zone = tzinfo.zone
+    elif hasattr(tzinfo, 'key') and tzinfo.key is not None:  # ZoneInfo object
+        zone = tzinfo.key
     else:
         zone = tzinfo.tzname(dt or datetime.utcnow())
 
@@ -619,8 +621,10 @@ def get_timezone_name(dt_or_tzinfo=None, width='long', uncommon=False,
     dt, tzinfo = _get_dt_and_tzinfo(dt_or_tzinfo)
     locale = Locale.parse(locale)
 
-    if hasattr(tzinfo, 'zone'):
+    if hasattr(tzinfo, 'zone'):  # pytz object
         zone = tzinfo.zone
+    elif hasattr(tzinfo, 'key') and tzinfo.key is not None:  # ZoneInfo object
+        zone = tzinfo.key
     else:
         zone = tzinfo.tzname(dt)
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -618,45 +618,87 @@ def test_get_timezone_location(timezone_getter):
             u'Deutschland (Berlin) Zeit')
 
 
-@pytest.mark.parametrize("tzname, params, expected", [
-    ("America/Los_Angeles", {"locale": "en_US"}, u"Pacific Time"),
-    ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u"PT"),
-    ("Europe/Berlin", {"locale": "de_DE"}, u"Mitteleurop\xe4ische Zeit"),
-    ("Europe/Berlin", {"locale": "pt_BR"}, u"Hor\xe1rio da Europa Central"),
-    ("America/St_Johns", {"locale": "de_DE"}, u'Neufundland-Zeit'),
-    ("America/Los_Angeles", {"locale": "en", "width": "short", "zone_variant": "generic"}, u'PT'),
-    ("America/Los_Angeles", {"locale": "en", "width": "short", "zone_variant": "standard"}, u'PST'),
-    ("America/Los_Angeles", {"locale": "en", "width": "short", "zone_variant": "daylight"}, u'PDT'),
-    ("America/Los_Angeles", {"locale": "en", "width": "long", "zone_variant": "generic"}, u'Pacific Time'),
-    ("America/Los_Angeles", {"locale": "en", "width": "long", "zone_variant": "standard"}, u'Pacific Standard Time'),
-    ("America/Los_Angeles", {"locale": "en", "width": "long", "zone_variant": "daylight"}, u'Pacific Daylight Time'),
-    ("Europe/Berlin", {"locale": "en_US"}, u'Central European Time'),
-])
+@pytest.mark.parametrize(
+    "tzname, params, expected",
+    [
+        ("America/Los_Angeles", {"locale": "en_US"}, u"Pacific Time"),
+        ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u"PT"),
+        ("Europe/Berlin", {"locale": "de_DE"}, u"Mitteleurop\xe4ische Zeit"),
+        ("Europe/Berlin", {"locale": "pt_BR"}, u"Hor\xe1rio da Europa Central"),
+        ("America/St_Johns", {"locale": "de_DE"}, u"Neufundland-Zeit"),
+        (
+            "America/Los_Angeles",
+            {"locale": "en", "width": "short", "zone_variant": "generic"},
+            u"PT",
+        ),
+        (
+            "America/Los_Angeles",
+            {"locale": "en", "width": "short", "zone_variant": "standard"},
+            u"PST",
+        ),
+        (
+            "America/Los_Angeles",
+            {"locale": "en", "width": "short", "zone_variant": "daylight"},
+            u"PDT",
+        ),
+        (
+            "America/Los_Angeles",
+            {"locale": "en", "width": "long", "zone_variant": "generic"},
+            u"Pacific Time",
+        ),
+        (
+            "America/Los_Angeles",
+            {"locale": "en", "width": "long", "zone_variant": "standard"},
+            u"Pacific Standard Time",
+        ),
+        (
+            "America/Los_Angeles",
+            {"locale": "en", "width": "long", "zone_variant": "daylight"},
+            u"Pacific Daylight Time",
+        ),
+        ("Europe/Berlin", {"locale": "en_US"}, u"Central European Time"),
+    ],
+)
 def test_get_timezone_name_tzinfo(timezone_getter, tzname, params, expected):
     tz = timezone_getter(tzname)
     assert dates.get_timezone_name(tz, **params) == expected
 
 
 @pytest.mark.parametrize("timezone_getter", ["pytz.timezone"], indirect=True)
-@pytest.mark.parametrize("tzname, params, expected", [
-    ("America/Los_Angeles", {"locale": "en_US"}, u'Pacific Standard Time'),
-    ("America/Los_Angeles", {"locale": "en_US", "return_zone": True}, u'America/Los_Angeles'),
-    ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u'PST'),
-])
+@pytest.mark.parametrize(
+    "tzname, params, expected",
+    [
+        ("America/Los_Angeles", {"locale": "en_US"}, u"Pacific Standard Time"),
+        (
+            "America/Los_Angeles",
+            {"locale": "en_US", "return_zone": True},
+            u"America/Los_Angeles",
+        ),
+        ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u"PST"),
+    ],
+)
 def test_get_timezone_name_time_pytz(timezone_getter, tzname, params, expected):
-    """pytz design can't find out if the time is in dst or not, so it will always return Standard time"""
+    """pytz (by design) can't determine if the time is in DST or not,
+    so it will always return Standard time"""
     dt = time(15, 30, tzinfo=timezone_getter(tzname))
     assert dates.get_timezone_name(dt, **params) == expected
 
 
-@pytest.mark.parametrize("tzname, params, expected", [
-    ("America/Los_Angeles", {"locale": "en_US"}, u'Pacific Daylight Time'),
-    ("America/Los_Angeles", {"locale": "en_US", "return_zone": True}, u'America/Los_Angeles'),
-    ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u'PDT'),
-])
+@pytest.mark.parametrize(
+    "tzname, params, expected",
+    [
+        ("America/Los_Angeles", {"locale": "en_US"}, u"Pacific Daylight Time"),
+        (
+            "America/Los_Angeles",
+            {"locale": "en_US", "return_zone": True},
+            u"America/Los_Angeles",
+        ),
+        ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u"PDT"),
+    ],
+)
 @pytest.mark.parametrize("timezone_getter", ["zoneinfo.ZoneInfo"], indirect=True)
 def test_get_timezone_name_time_zoneinfo(timezone_getter, tzname, params, expected):
-    """zoneinfo will actually return dst/non dst correctly
+    """zoneinfo will correctly detect DST from the object.
     FIXME: this test will only succeed in the winter.
     """
     dt = time(15, 30, tzinfo=timezone_getter(tzname))

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -15,6 +15,7 @@ import calendar
 from datetime import date, datetime, time, timedelta
 import unittest
 
+from backports import zoneinfo
 import pytest
 import pytz
 from pytz import timezone
@@ -583,8 +584,9 @@ def test_get_timezone_gmt():
     assert dates.get_timezone_gmt(dt, 'long', locale='fr_FR') == u'UTC-07:00'
 
 
-def test_get_timezone_location():
-    tz = timezone('America/St_Johns')
+@pytest.mark.parametrize("timezone_creator", [timezone, zoneinfo.ZoneInfo])
+def test_get_timezone_location(timezone_creator):
+    tz = timezone_creator('America/St_Johns')
     assert (dates.get_timezone_location(tz, locale='de_DE') ==
             u"Kanada (St. John\u2019s) Zeit")
     assert (dates.get_timezone_location(tz, locale='en') ==
@@ -592,37 +594,38 @@ def test_get_timezone_location():
     assert (dates.get_timezone_location(tz, locale='en', return_city=True) ==
             u'St. John’s')
 
-    tz = timezone('America/Mexico_City')
+    tz = timezone_creator('America/Mexico_City')
     assert (dates.get_timezone_location(tz, locale='de_DE') ==
             u'Mexiko (Mexiko-Stadt) Zeit')
 
-    tz = timezone('Europe/Berlin')
+    tz = timezone_creator('Europe/Berlin')
     assert (dates.get_timezone_location(tz, locale='de_DE') ==
             u'Deutschland (Berlin) Zeit')
 
 
-def test_get_timezone_name():
-    dt = time(15, 30, tzinfo=timezone('America/Los_Angeles'))
+@pytest.mark.parametrize("timezone_creator", [timezone, zoneinfo.ZoneInfo])
+def test_get_timezone_name(timezone_creator):
+    dt = time(15, 30, tzinfo=timezone_creator('America/Los_Angeles'))
     assert (dates.get_timezone_name(dt, locale='en_US') ==
             u'Pacific Standard Time')
     assert (dates.get_timezone_name(dt, locale='en_US', return_zone=True) ==
             u'America/Los_Angeles')
     assert dates.get_timezone_name(dt, width='short', locale='en_US') == u'PST'
 
-    tz = timezone('America/Los_Angeles')
+    tz = timezone_creator('America/Los_Angeles')
     assert dates.get_timezone_name(tz, locale='en_US') == u'Pacific Time'
     assert dates.get_timezone_name(tz, 'short', locale='en_US') == u'PT'
 
-    tz = timezone('Europe/Berlin')
+    tz = timezone_creator('Europe/Berlin')
     assert (dates.get_timezone_name(tz, locale='de_DE') ==
             u'Mitteleurop\xe4ische Zeit')
     assert (dates.get_timezone_name(tz, locale='pt_BR') ==
             u'Hor\xe1rio da Europa Central')
 
-    tz = timezone('America/St_Johns')
+    tz = timezone_creator('America/St_Johns')
     assert dates.get_timezone_name(tz, locale='de_DE') == u'Neufundland-Zeit'
 
-    tz = timezone('America/Los_Angeles')
+    tz = timezone_creator('America/Los_Angeles')
     assert dates.get_timezone_name(tz, locale='en', width='short',
                                    zone_variant='generic') == u'PT'
     assert dates.get_timezone_name(tz, locale='en', width='short',
@@ -636,7 +639,7 @@ def test_get_timezone_name():
     assert dates.get_timezone_name(tz, locale='en', width='long',
                                    zone_variant='daylight') == u'Pacific Daylight Time'
 
-    localnow = datetime.utcnow().replace(tzinfo=timezone('UTC')).astimezone(dates.LOCALTZ)
+    localnow = datetime.utcnow().replace(tzinfo=timezone_creator('UTC')).astimezone(dates.LOCALTZ)
     assert (dates.get_timezone_name(None, locale='en_US') ==
             dates.get_timezone_name(localnow, locale='en_US'))
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -596,7 +596,7 @@ def test_get_timezone_gmt():
     [
         timezone,
         pytest.param(
-            zoneinfo.ZoneInfo,
+            lambda v: zoneinfo.ZoneInfo(v),
             marks=pytest.mark.skipif(zoneinfo is None, reason="zoneinfo not available"),
         ),
     ],
@@ -624,7 +624,7 @@ def test_get_timezone_location(timezone_creator):
     [
         timezone,
         pytest.param(
-            zoneinfo.ZoneInfo,
+            lambda v: zoneinfo.ZoneInfo(v),
             marks=pytest.mark.skipif(zoneinfo is None, reason="zoneinfo not available"),
         ),
     ],

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -632,19 +632,22 @@ def test_get_timezone_location(timezone_getter):
     ("America/Los_Angeles", {"locale": "en", "width": "long", "zone_variant": "daylight"}, u'Pacific Daylight Time'),
     ("Europe/Berlin", {"locale": "en_US"}, u'Central European Time'),
 ])
-def test_get_timezone_name_tz(timezone_getter, tzname, params, expected):
+def test_get_timezone_name_tzinfo(timezone_getter, tzname, params, expected):
     tz = timezone_getter(tzname)
     assert dates.get_timezone_name(tz, **params) == expected
 
 
-def test_get_timezone_name_non_tzinfo(timezone_getter):
-    dt = time(15, 30, tzinfo=timezone_getter('America/Los_Angeles'))
-    assert (dates.get_timezone_name(dt, locale='en_US') ==
-            u'Pacific Standard Time')
-    assert (dates.get_timezone_name(dt, locale='en_US', return_zone=True) ==
-            u'America/Los_Angeles')
-    assert dates.get_timezone_name(dt, width='short', locale='en_US') == u'PST'
+@pytest.mark.parametrize("tzname, params, expected", [
+    ("America/Los_Angeles", {"locale": "en_US"}, u'Pacific Standard Time'),
+    ("America/Los_Angeles", {"locale": "en_US", "return_zone": True}, u'America/Los_Angeles'),
+    ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u'PST'),
+])
+def test_get_timezone_name_time(timezone_getter, tzname, params, expected):
+    dt = time(15, 30, tzinfo=timezone_getter(tzname))
+    assert dates.get_timezone_name(dt, **params) == expected
 
+
+def test_get_timezone_name_misc(timezone_getter):
     localnow = datetime.utcnow().replace(tzinfo=timezone_getter('UTC')).astimezone(dates.LOCALTZ)
     assert (dates.get_timezone_name(None, locale='en_US') ==
             dates.get_timezone_name(localnow, locale='en_US'))

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -15,7 +15,14 @@ import calendar
 from datetime import date, datetime, time, timedelta
 import unittest
 
-from backports import zoneinfo
+try:
+    import zoneinfo
+except ImportError:
+    try:
+        from backports import zoneinfo
+    except ImportError:
+        zoneinfo = None
+
 import pytest
 import pytz
 from pytz import timezone
@@ -584,7 +591,16 @@ def test_get_timezone_gmt():
     assert dates.get_timezone_gmt(dt, 'long', locale='fr_FR') == u'UTC-07:00'
 
 
-@pytest.mark.parametrize("timezone_creator", [timezone, zoneinfo.ZoneInfo])
+@pytest.mark.parametrize(
+    "timezone_creator",
+    [
+        timezone,
+        pytest.param(
+            zoneinfo.ZoneInfo,
+            marks=pytest.mark.skipif(zoneinfo is None, reason="zoneinfo not available"),
+        ),
+    ],
+)
 def test_get_timezone_location(timezone_creator):
     tz = timezone_creator('America/St_Johns')
     assert (dates.get_timezone_location(tz, locale='de_DE') ==
@@ -603,7 +619,16 @@ def test_get_timezone_location(timezone_creator):
             u'Deutschland (Berlin) Zeit')
 
 
-@pytest.mark.parametrize("timezone_creator", [timezone, zoneinfo.ZoneInfo])
+@pytest.mark.parametrize(
+    "timezone_creator",
+    [
+        timezone,
+        pytest.param(
+            zoneinfo.ZoneInfo,
+            marks=pytest.mark.skipif(zoneinfo is None, reason="zoneinfo not available"),
+        ),
+    ],
+)
 def test_get_timezone_name(timezone_creator):
     dt = time(15, 30, tzinfo=timezone_creator('America/Los_Angeles'))
     assert (dates.get_timezone_name(dt, locale='en_US') ==

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -684,27 +684,6 @@ def test_get_timezone_name_time_pytz(timezone_getter, tzname, params, expected):
     assert dates.get_timezone_name(dt, **params) == expected
 
 
-@pytest.mark.parametrize(
-    "tzname, params, expected",
-    [
-        ("America/Los_Angeles", {"locale": "en_US"}, u"Pacific Daylight Time"),
-        (
-            "America/Los_Angeles",
-            {"locale": "en_US", "return_zone": True},
-            u"America/Los_Angeles",
-        ),
-        ("America/Los_Angeles", {"width": "short", "locale": "en_US"}, u"PDT"),
-    ],
-)
-@pytest.mark.parametrize("timezone_getter", ["zoneinfo.ZoneInfo"], indirect=True)
-def test_get_timezone_name_time_zoneinfo(timezone_getter, tzname, params, expected):
-    """zoneinfo will correctly detect DST from the object.
-    FIXME: this test will only succeed in the winter.
-    """
-    dt = time(15, 30, tzinfo=timezone_getter(tzname))
-    assert dates.get_timezone_name(dt, **params) == expected
-
-
 def test_get_timezone_name_misc(timezone_getter):
     localnow = datetime.utcnow().replace(tzinfo=timezone_getter('UTC')).astimezone(dates.LOCALTZ)
     assert (dates.get_timezone_name(None, locale='en_US') ==

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pytest-cov==2.6.1
     cdecimal: m3-cdecimal
     freezegun==0.3.12
+    backports.zoneinfo
 whitelist_externals = make
 commands = make clean-cldr test
 passenv = PYTHON_TEST_FLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov==2.6.1
     cdecimal: m3-cdecimal
     freezegun==0.3.12
-    backports.zoneinfo
+    backports.zoneinfo;python_version<"3.9"
 whitelist_externals = make
 commands = make clean-cldr test
 passenv = PYTHON_TEST_FLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov==2.6.1
     cdecimal: m3-cdecimal
     freezegun==0.3.12
-    backports.zoneinfo;python_version>"3.7" and python_version<"3.9"
+    backports.zoneinfo;python_version>"3.6" and python_version<"3.9"
 whitelist_externals = make
 commands = make clean-cldr test
 passenv = PYTHON_TEST_FLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest-cov==2.6.1
     cdecimal: m3-cdecimal
     freezegun==0.3.12
-    backports.zoneinfo;python_version<"3.9"
+    backports.zoneinfo;python_version>"3.7" and python_version<"3.9"
 whitelist_externals = make
 commands = make clean-cldr test
 passenv = PYTHON_TEST_FLAGS


### PR DESCRIPTION
Python 3.9 introduced ZoneInfo objects, and they are available as a [backport](https://pypi.org/project/backports.zoneinfo/) back to python 3.6.
This PR adds support for these objects.

Fixes https://github.com/python-babel/babel/issues/740