### PR TITLE
Remove deprecated 'sudo: false' from Travis configuraiton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 dist: xenial
 language: python
 
-# Use travis docker infrastructure for greater speed
-sudo: false
-
 cache:
   directories:
   - cldr


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration