### PR TITLE
fix #53 (now directories starting with '_' are not ignored)

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -139,7 +139,7 @@ def extract_from_dir(dirname=None, method_map=DEFAULT_MAPPING,
     for root, dirnames, filenames in os.walk(absname):
         dirnames[:] = [
             subdir for subdir in dirnames
-            if not (subdir.startswith('.') or subdir.startswith('_'))
+            if not (subdir.startswith('.') or subdir == '_')
         ]
         dirnames.sort()
         filenames.sort()


### PR DESCRIPTION
Fixed a small issue, when babel ignored directories starting with `_`.
I thought that it's still a good idea to ignore dirs whose entire name is `_`.