### PR TITLE
Add Python 3.8 & 3.9 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py34, py35, py36, py37, pypy3, py27-cdecimal
+envlist = py27, pypy, py34, py35, py36, py37, py38, py39, pypy3, py27-cdecimal
 
 [testenv]
 deps =


### PR DESCRIPTION
Add py38 and py39 to `tox.ini`.

Would you consider dropping support for 2.7, 3.4, and 3.5 (all of them after EOL)?