### PR TITLE
Use try-catch block in order to handle extracting f-strings

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -484,11 +484,11 @@ def extract_python(fileobj, keywords, comment_tags, options):
                 # aid=617979&group_id=5470
                 code = compile('# coding=%s\n%s' % (str(encoding), value),
                                '<string>', 'eval', future_flags)
-                try #in order to fail gracefully on f-strings
+                try: #in order to fail gracefully on f-strings
                     value = eval(code, {'__builtins__': {}}, {})
                 except NameError:
                     continue
-                else
+                else:
                     if PY2 and not isinstance(value, text_type):
                         value = value.decode(encoding)
                     buf.append(value)

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -484,10 +484,14 @@ def extract_python(fileobj, keywords, comment_tags, options):
                 # aid=617979&group_id=5470
                 code = compile('# coding=%s\n%s' % (str(encoding), value),
                                '<string>', 'eval', future_flags)
-                value = eval(code, {'__builtins__': {}}, {})
-                if PY2 and not isinstance(value, text_type):
-                    value = value.decode(encoding)
-                buf.append(value)
+                try #in order to fail gracefully on f-strings
+                    value = eval(code, {'__builtins__': {}}, {})
+                except NameError:
+                    continue
+                else
+                    if PY2 and not isinstance(value, text_type):
+                        value = value.decode(encoding)
+                    buf.append(value)
             elif tok == OP and value == ',':
                 if buf:
                     messages.append(''.join(buf))


### PR DESCRIPTION
Before this request, f-strings were causing the program to crash with an exception. After the try catch block is added in extract.py, f-strings will raise a NameError.