### PR TITLE
Javascript lexer improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,14 @@
 Babel Changelog
 ===============
 
+Version 2.10.0
+--------------
+
+Improvements
+~~~~~~~~~~~~
+
+* Support for javascript template strings
+
 Version 2.9.1
 -------------
 

--- a/babel/__init__.py
+++ b/babel/__init__.py
@@ -21,4 +21,4 @@ from babel.core import UnknownLocaleError, Locale, default_locale, \
     negotiate_locale, parse_locale, get_locale_identifier
 
 
-__version__ = '2.9.1'
+__version__ = '2.10.0'

--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -25,7 +25,57 @@ escapes = {'b': '\b', 'f': '\f', 'n': '\n', 'r': '\r', 't': '\t'}
 name_re = re.compile(r'[\w$_][\w\d$_]*', re.UNICODE)
 dotted_name_re = re.compile(r'[\w$_][\w\d$_.]*[\w\d$_.]', re.UNICODE)
 division_re = re.compile(r'/=?')
-regex_re = re.compile(r'/(?:[^/\\]*(?:\\.[^/\\]*)*)/[a-zA-Z]*', re.DOTALL)
+
+regex_re = re.compile(
+    r'''
+
+        # Opening slash of the regex
+        /
+
+        (?:
+
+            # 1) Blackslashed character
+            #
+            # Match a backslash `\` and then it's following character, allowing
+            # to blackslash the `/` for example.
+            (?:\\.)?
+
+            |
+
+            # 2) Regex character class `[a-z]`
+            #
+            # Match regex character class, like `[a-z]`. Inside a character
+            # class, a `/` character may appear, which does not close the
+            # regex. Therefore we allow it here inside a character class.
+            \[
+                (?:
+                    [^\]]*
+                    |
+                    \\\]
+                )*
+            \]
+
+            |
+
+            # 3) Other characters
+            #
+            # Match anything except a closing slash `/`, a backslash `\`, or a
+            # opening bracket `[`. Those last two will be handled by the other
+            # matchers.
+            [^/\\\[]*
+
+        )*
+
+        # Closing slash of the regex
+        /
+
+        # regex flags
+        [a-zA-Z]*
+
+    ''',
+    re.DOTALL + re.VERBOSE
+)
+
 line_re = re.compile(r'(\r\n|\n|\r)')
 line_join_re = re.compile(r'\\' + line_re.pattern)
 uni_escape_re = re.compile(r'[a-fA-F0-9]{1,4}')


### PR DESCRIPTION
Add option `parse_template_string` that improves parsing of javascript templates expressions, like:

    `${gettext('my text')}`

And it also works with nested expressions like:

    ${`some text ${gettext('my text')} more text`}

You have to enable template string extraction with an option in the [`option_map`](http://babel.pocoo.org/en/latest/api/messages/extract.html?highlight=options_map#babel.messages.extract.extract_from_dir):

    extract_from_dir(
        # ...
        options_map={
            '**': {'parse_template_string': True}
        }
    )

Then it should work.

On this branch I also fixed another issue that I was facing. In a JS library that I use, there was regex with a `/` inside a character class `[a-z]`. The babel JS lexer thought this closed the regex, but JavaScript allows this as a normal match character within a character class, and does not close the regex. I updated the regex so that it will cover this exception.