### PR TITLE
Add Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Overview Description
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Actual Results
+
+## Expected Results
+
+## Reproducibility
+
+## Additional Information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,29 +7,6 @@ still need proper phrasing - if you'd like to help - be sure to make a PR.
 Please know that we do appreciate all contributions - bug reports as well as
 Pull Requests.
 
-## Filing Issues
-
-When filing an issue, please use this template:
-
-```
-# Overview Description
-
-# Steps to Reproduce
-
-1.
-2.
-3.
-
-# Actual Results
-
-# Expected Results
-
-# Reproducibility
-
-# Additional Information:
-
-```
-
 ## PR Merge Criteria
 
 For a PR to be merged, the following statements must hold true:


### PR DESCRIPTION
Replaces "Filling issues" contributing guide section by Github template, so if an user open an issue, the needed text is already included.