### PR TITLE
add `--ignore-dirs` to `extract`

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -24,7 +24,7 @@ from tokenize import generate_tokens, COMMENT, NAME, OP, STRING
 
 from babel.util import parse_encoding, parse_future_flags, pathmatch
 from textwrap import dedent
-
+from fnmatch import fnmatch
 
 GROUP_NAME = 'babel.extractors'
 
@@ -62,7 +62,8 @@ def _strip_comment_tags(comments, tags):
 
 def extract_from_dir(dirname=None, method_map=DEFAULT_MAPPING,
                      options_map=None, keywords=DEFAULT_KEYWORDS,
-                     comment_tags=(), callback=None, strip_comment_tags=False):
+                     comment_tags=(), callback=None, strip_comment_tags=False,
+                     ignore_dirs=('.*','_*')):
     """Extract messages from any source files found in the given directory.
 
     This function generates tuples of the form ``(filename, lineno, message,
@@ -128,6 +129,8 @@ def extract_from_dir(dirname=None, method_map=DEFAULT_MAPPING,
     :param strip_comment_tags: a flag that if set to `True` causes all comment
                                tags to be removed from the collected comments.
     :see: `pathmatch`
+    :param ignore_dirs: a list of fnmatch compatible patterns for directory 
+                        names to ignore and not descend.
     """
     if dirname is None:
         dirname = os.getcwd()
@@ -138,7 +141,9 @@ def extract_from_dir(dirname=None, method_map=DEFAULT_MAPPING,
     for root, dirnames, filenames in os.walk(absname):
         dirnames[:] = [
             subdir for subdir in dirnames
-            if not (subdir.startswith('.') or subdir.startswith('_'))
+            # ignore files if they match any of the ignore_dirs patterns
+            if not any(map(lambda x: fnmatch(subdir,x),
+                            ignore_dirs))
         ]
         dirnames.sort()
         filenames.sort()

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -320,6 +320,9 @@ class extract_messages(Command):
          'files or directories with commas(,)'),  # TODO: Support repetition of this argument
         ('input-dirs=', None,  # TODO (3.x): Remove me.
          'alias for input-paths (does allow files as well as directories).'),
+        ('ignore-dirs',None,
+        'UNIX style patterns for directories to ignore when scanning for messages.'
+        ' Separate multiple patterns with spaces (default ".* ._")'),
     ]
     boolean_options = [
         'no-default-keywords', 'no-location', 'omit-header', 'no-wrap',
@@ -359,6 +362,7 @@ class extract_messages(Command):
         self.add_comments = None
         self.strip_comments = False
         self.include_lineno = True
+        self.ignore_dirs = '.* ._'
 
     def finalize_options(self):
         if self.input_dirs:
@@ -426,6 +430,7 @@ class extract_messages(Command):
             self.no_location = True
         elif self.add_location == 'file':
             self.include_lineno = False
+        self.ignore_dirs = listify_value(self.ignore_dirs)
 
     def run(self):
         mappings = self._get_mappings()
@@ -469,7 +474,8 @@ class extract_messages(Command):
                         keywords=self.keywords,
                         comment_tags=self.add_comments,
                         callback=callback,
-                        strip_comment_tags=self.strip_comments
+                        strip_comment_tags=self.strip_comments,
+                        ignore_dirs=self.ignore_dirs,
                     )
                 for filename, lineno, message, comments, context in extracted:
                     if os.path.isfile(path):


### PR DESCRIPTION
fixes #53, fixes #253, fixes #124, fixes #402.
Implemented an `--ignore-dirs` argument to `extract` which takes in `fnmatch` compatible pattern to exclude the directories as suggested in the comments of PR #447. 
The same has been implemented in `extract_from_dir` function in `extract.py` and `frontend.py`
It defaults to  `"_*"` and `".*"` to maintain backwards compatibility.
