### PR TITLE
CLDR 40

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -322,7 +322,7 @@ def get_day_names(width='wide', context='format', locale=LC_TIME):
     >>> get_day_names('short', locale='en_US')[1]
     u'Tu'
     >>> get_day_names('abbreviated', locale='es')[1]
-    u'mar.'
+    u'mar'
     >>> get_day_names('narrow', context='stand-alone', locale='de_DE')[1]
     u'D'
 
@@ -339,7 +339,7 @@ def get_month_names(width='wide', context='format', locale=LC_TIME):
     >>> get_month_names('wide', locale='en_US')[1]
     u'January'
     >>> get_month_names('abbreviated', locale='es')[1]
-    u'ene.'
+    u'ene'
     >>> get_month_names('narrow', context='stand-alone', locale='de_DE')[1]
     u'J'
 

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -79,7 +79,7 @@ def main():
     show_progress = (False if os.environ.get("BABEL_CLDR_NO_DOWNLOAD_PROGRESS") else sys.stdout.isatty())
 
     while not is_good_file(zip_path):
-        log('Downloading \'%s\'', FILENAME)
+        log("Downloading '%s' from %s", FILENAME, URL)
         if os.path.isfile(zip_path):
             os.remove(zip_path)
         urlretrieve(URL, zip_path, (reporthook if show_progress else None))

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -13,9 +13,10 @@ except ImportError:
     from urllib import urlretrieve
 
 
-URL = 'http://unicode.org/Public/cldr/37/core.zip'
-FILENAME = 'cldr-core-37.zip'
-FILESUM = 'ba93f5ba256a61a6f8253397c6c4b1a9b9e77531f013cc7ffa7977b5f7e4da57'
+URL = 'http://unicode.org/Public/cldr/40/cldr-common-40.0.zip'
+FILENAME = 'cldr-common-40.0.zip'
+# Via https://unicode.org/Public/cldr/40/hashes/SHASUM512.txt
+FILESUM = 'b45ea381002210cf5963a2ba52fa45ee4e9b1e80ae1180bcecf61f431d64e4e0faba700b3d56a96a33355deab3abdb8bcbae9222b60a8ca85536476718175645'
 BLKSIZE = 131072
 
 
@@ -53,7 +54,7 @@ def is_good_file(filename):
     if not os.path.isfile(filename):
         log('Local copy \'%s\' not found', filename)
         return False
-    h = hashlib.sha256()
+    h = hashlib.sha512()
     with open(filename, 'rb') as f:
         while 1:
             blk = f.read(BLKSIZE)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -548,14 +548,14 @@ def test_get_period_names():
 def test_get_day_names():
     assert dates.get_day_names('wide', locale='en_US')[1] == u'Tuesday'
     assert dates.get_day_names('short', locale='en_US')[1] == u'Tu'
-    assert dates.get_day_names('abbreviated', locale='es')[1] == u'mar.'
+    assert dates.get_day_names('abbreviated', locale='es')[1] == u'mar'
     de = dates.get_day_names('narrow', context='stand-alone', locale='de_DE')
     assert de[1] == u'D'
 
 
 def test_get_month_names():
     assert dates.get_month_names('wide', locale='en_US')[1] == u'January'
-    assert dates.get_month_names('abbreviated', locale='es')[1] == u'ene.'
+    assert dates.get_month_names('abbreviated', locale='es')[1] == u'ene'
     de = dates.get_month_names('narrow', context='stand-alone', locale='de_DE')
     assert de[1] == u'J'
 
@@ -834,7 +834,7 @@ def test_lithuanian_long_format():
 
 def test_zh_TW_format():
     # Refs GitHub issue #378
-    assert dates.format_time(datetime(2016, 4, 8, 12, 34, 56), locale='zh_TW') == u'\u4e0b\u534812:34:56'
+    assert dates.format_time(datetime(2016, 4, 8, 12, 34, 56), locale='zh_TW') == u'B12:34:56'
 
 
 def test_format_current_moment():

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -170,13 +170,13 @@ class FormatDecimalTestCase(unittest.TestCase):
 
         self.assertEqual(u'29,567.12', numbers.format_decimal(29567.12,
                                                             locale='en_US', group_separator=True))
-        self.assertEqual(u'29\u202f567,12', numbers.format_decimal(29567.12,
+        self.assertEqual(u'29\xa0567,12', numbers.format_decimal(29567.12,
                                                             locale='fr_CA', group_separator=True))
         self.assertEqual(u'29.567,12', numbers.format_decimal(29567.12,
                                                             locale='pt_BR', group_separator=True))
         self.assertEqual(u'$1,099.98', numbers.format_currency(1099.98, 'USD',
                                                               locale='en_US', group_separator=True))
-        self.assertEqual(u'101\u202f299,98\xa0\u20ac', numbers.format_currency(101299.98, 'EUR',
+        self.assertEqual(u'101\xa0299,98\xa0\u20ac', numbers.format_currency(101299.98, 'EUR',
                                                                     locale='fr_CA', group_separator=True))
         self.assertEqual(u'101,299.98 euros', numbers.format_currency(101299.98, 'EUR',
                                                                     locale='en_US', group_separator=True,

--- a/tests/test_plural.py
+++ b/tests/test_plural.py
@@ -255,13 +255,15 @@ EXTRACT_OPERANDS_TESTS = (
 
 @pytest.mark.parametrize('source,n,i,v,w,f,t', EXTRACT_OPERANDS_TESTS)
 def test_extract_operands(source, n, i, v, w, f, t):
-    e_n, e_i, e_v, e_w, e_f, e_t = plural.extract_operands(source)
+    e_n, e_i, e_v, e_w, e_f, e_t, e_c, e_e = plural.extract_operands(source)
     assert abs(e_n - decimal.Decimal(n)) <= EPSILON  # float-decimal conversion inaccuracy
     assert e_i == i
     assert e_v == v
     assert e_w == w
     assert e_f == f
     assert e_t == t
+    assert not e_c  # Not supported at present
+    assert not e_e  # Not supported at present
 
 
 @pytest.mark.parametrize('locale', ('ru', 'pl'))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6,32 +6,51 @@ operations don't fail due to odd corner cases on any locale that
 we ship.
 """
 import decimal
-from datetime import datetime
-
+import datetime
 import pytest
-from babel import Locale
-from babel import dates
-from babel import numbers
+
+from babel import Locale, units, dates, numbers
+
+NUMBERS = (
+    decimal.Decimal("-33.76"),  # Negative Decimal
+    decimal.Decimal("13.37"),  # Positive Decimal
+    1.2 - 1.0,  # Inaccurate float
+    10,  # Plain old integer
+    0,  # Zero
+)
 
 
 @pytest.mark.all_locales
 def test_smoke_dates(locale):
     locale = Locale.parse(locale)
-    instant = datetime.now()
+    instant = datetime.datetime.now()
     for width in ("full", "long", "medium", "short"):
         assert dates.format_date(instant, format=width, locale=locale)
         assert dates.format_datetime(instant, format=width, locale=locale)
         assert dates.format_time(instant, format=width, locale=locale)
+    # Interval test
+    past = instant - datetime.timedelta(hours=23)
+    assert dates.format_interval(past, instant, locale=locale)
+    # Duration test - at the time of writing, all locales seem to have `short` width,
+    # so let's test that.
+    duration = instant - instant.replace(hour=0, minute=0, second=0)
+    for granularity in ('second', 'minute', 'hour', 'day'):
+        assert dates.format_timedelta(duration, granularity=granularity, format="short", locale=locale)
 
 
 @pytest.mark.all_locales
 def test_smoke_numbers(locale):
     locale = Locale.parse(locale)
-    for number in (
-        decimal.Decimal("-33.76"),  # Negative Decimal
-        decimal.Decimal("13.37"),  # Positive Decimal
-        1.2 - 1.0,  # Inaccurate float
-        10,  # Plain old integer
-        0,  # Zero
-    ):
+    for number in NUMBERS:
         assert numbers.format_decimal(number, locale=locale)
+        assert numbers.format_currency(number, "EUR", locale=locale)
+        assert numbers.format_scientific(number, locale=locale)
+        assert numbers.format_percent(number / 100, locale=locale)
+
+
+@pytest.mark.all_locales
+def test_smoke_units(locale):
+    locale = Locale.parse(locale)
+    for unit in ('length-meter', 'mass-kilogram', 'energy-calorie', 'volume-liter'):
+        for number in NUMBERS:
+            assert units.format_unit(number, measurement_unit=unit, locale=locale)


### PR DESCRIPTION
This PR bumps the CLDR version used by Babel from 37.0 to 40.0.

* The new `c` and `e` plural operands are parsed, but not supported otherwise.