### PR TITLE
Date intervals: allow using `other` as fallback form

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -948,7 +948,7 @@ def format_timedelta(delta, granularity='second', threshold=.85,
             pattern = None
             for patterns in _iter_patterns(unit):
                 if patterns is not None:
-                    pattern = patterns[plural_form]
+                    pattern = patterns.get(plural_form) or patterns.get('other')
                     break
             # This really should not happen
             if pattern is None:

--- a/tests/test_date_intervals.py
+++ b/tests/test_date_intervals.py
@@ -52,3 +52,13 @@ def test_format_interval_invalid_skeleton():
     t2 = TEST_DATE + datetime.timedelta(days=1)
     assert dates.format_interval(t1, t2, "mumumu", fuzzy=False, locale="fi") == u"8.1.2016\u20139.1.2016"
     assert dates.format_interval(t1, t2, fuzzy=False, locale="fi") == u"8.1.2016\u20139.1.2016"
+
+
+def test_issue_825():
+    assert dates.format_timedelta(
+        datetime.timedelta(hours=1),
+        granularity='hour',
+        threshold=100,
+        format='short',
+        locale='pt',
+    ) == '1 h'


### PR DESCRIPTION
Fixes #825