### PR TITLE
parse_locale(): upper-case variant tag to match file system

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -1048,6 +1048,12 @@ def parse_locale(identifier, sep='_'):
     ('zh', 'CN', None, None)
     >>> parse_locale('zh_Hans_CN')
     ('zh', 'CN', 'Hans', None)
+    >>> parse_locale('ca_es_valencia')
+    ('ca', 'ES', None, 'VALENCIA')
+    >>> parse_locale('en_150')
+    ('en', '150', None, None)
+    >>> parse_locale('en_us_posix')
+    ('en', 'US', None, 'POSIX')
 
     The default component separator is "_", but a different separator can be
     specified using the `sep` parameter:
@@ -1107,7 +1113,7 @@ def parse_locale(identifier, sep='_'):
     if parts:
         if len(parts[0]) == 4 and parts[0][0].isdigit() or \
                 len(parts[0]) >= 5 and parts[0][0].isalpha():
-            variant = parts.pop()
+            variant = parts.pop().upper()
 
     if parts:
         raise ValueError('%r is not a valid locale identifier' % identifier)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -325,3 +325,9 @@ def test_issue_601_no_language_name_but_has_variant():
     # part of a language name.
 
     assert Locale.parse('fi_FI').get_display_name('kw_GB') == None
+
+
+def test_issue_814():
+    loc = Locale.parse('ca_ES_valencia')
+    assert loc.variant == "VALENCIA"
+    assert loc.get_display_name() == 'català (Espanya, valencià)'


### PR DESCRIPTION
Upper-casing the variant tag should be okay, since quoth [the spec](https://datatracker.ietf.org/doc/html/rfc5646#section-2.1.1):

>   At all times, language tags and their subtags, including private use
>  and extensions, are to be treated as case insensitive: there exist
>  conventions for the capitalization of some of the subtags, but these
>  MUST NOT be taken to carry meaning.

Fixes #814