### PR TITLE
Implement directory filter for extract

### DIFF
--- a/tests/messages/data/project/_hidden_by_default/hidden_file.py
+++ b/tests/messages/data/project/_hidden_by_default/hidden_file.py
@@ -1,0 +1,5 @@
+from gettext import gettext
+
+
+def foo():
+    print(gettext('ssshhh....'))


### PR DESCRIPTION
This PR:

* adds a `directory_filter` callback argument to `extract_from_dir` that defaults to the current behavior of ignoring dot and underscore directories
* adds a frontend `--ignore-dirs` (that can be repeated) to replace the default `.*` / `_*` filtering with other patterns

---

Fixes #53 – set `--ignore-dirs` to disable the default dot and underscore filters
Fixes #402 – implements it :)

Refs #124 – there is still no way to set this in the mapping configuration file, though (that's #694)
Refs #253 – one could now `--ignore-dirs=node_modules`, for instance.
Refs #694 – could be reimplemented on top of this `directory_filter`?

Closes #447 – supersedes it
Closes #563 – supersedes it
Closes #761 – you can set `--ignore-dirs='.*'`
Closes #813 – supersedes it (thanks for the wording for the CLI parameter!)
Closes #793 – you can set `--ignore-dirs='.* _* venv'`