### PR TITLE
Fix duplicate locations when writing without lineno

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -597,9 +597,11 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
 
             for filename, lineno in locations:
                 if lineno and include_lineno:
-                    locs.append(u'%s:%d' % (filename.replace(os.sep, '/'), lineno))
+                    location = u'%s:%d' % (filename.replace(os.sep, '/'), lineno)
                 else:
-                    locs.append(u'%s' % filename.replace(os.sep, '/'))
+                    location = u'%s' % filename.replace(os.sep, '/')
+                if location not in locs:
+                    locs.append(location)
             _write_comment(' '.join(locs), prefix=':')
         if message.flags:
             _write('#%s\n' % ', '.join([''] + sorted(message.flags)))

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -827,6 +827,7 @@ msgstr ""''', buf.getvalue().strip())
     def test_no_include_lineno(self):
         catalog = Catalog()
         catalog.add(u'foo', locations=[('main.py', 1)])
+        catalog.add(u'foo', locations=[('main.py', 2)])
         catalog.add(u'foo', locations=[('utils.py', 3)])
         buf = BytesIO()
         pofile.write_po(buf, catalog, omit_header=True, include_lineno=False)


### PR DESCRIPTION
If the same translation appears multiple times in the same file,
duplicate locations would be written to the .po file when using
`write_po(..., include_lineno=False)`.