### PR TITLE
Allow extractors to provide message flags

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -27,18 +27,6 @@ from babel.util import distinct, LOCALTZ, FixedOffsetTimezone, _cmp
 __all__ = ['Message', 'Catalog', 'TranslationError']
 
 
-PYTHON_FORMAT = re.compile(r'''
-    \%
-        (?:\(([\w]*)\))?
-        (
-            [-#0\ +]?(?:\*|[\d]+)?
-            (?:\.(?:\*|[\d]+))?
-            [hlL]?
-        )
-        ([diouxXeEfFgGcrs%])
-''', re.VERBOSE)
-
-
 def _parse_datetime_header(value):
     match = re.match(r'^(?P<datetime>.*?)(?P<tzoffset>[+-]\d{4})?$', value)
 
@@ -96,10 +84,6 @@ class Message(object):
         self.string = string
         self.locations = list(distinct(locations))
         self.flags = set(flags)
-        if id and self.python_format:
-            self.flags.add('python-format')
-        else:
-            self.flags.discard('python-format')
         self.auto_comments = list(distinct(auto_comments))
         self.user_comments = list(distinct(user_comments))
         if isinstance(previous_id, str):
@@ -201,10 +185,7 @@ class Message(object):
         True
 
         :type:  `bool`"""
-        ids = self.id
-        if not isinstance(ids, (list, tuple)):
-            ids = [ids]
-        return any(PYTHON_FORMAT.search(id) for id in ids)
+        return 'python-format' in self.flags
 
 
 class TranslationError(Exception):

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -11,7 +11,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from babel.messages.catalog import TranslationError, PYTHON_FORMAT
+from babel.messages.catalog import TranslationError
+from babel.util import PYTHON_FORMAT
 
 
 #: list of format chars that are compatible to each other

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -502,14 +502,14 @@ class extract_messages(Command):
                         strip_comment_tags=self.strip_comments,
                         directory_filter=self.directory_filter,
                     )
-                for filename, lineno, message, comments, context in extracted:
+                for filename, lineno, message, comments, context, flags in extracted:
                     if os.path.isfile(path):
                         filepath = filename  # already normalized
                     else:
                         filepath = os.path.normpath(os.path.join(path, filename))
 
                     catalog.add(message, None, [(filepath, lineno)],
-                                auto_comments=comments, context=context)
+                                auto_comments=comments, context=context, flags=flags)
 
             self.log.info('writing PO template file to %s', self.output_file)
             write_po(outfile, catalog, width=self.width,

--- a/babel/util.py
+++ b/babel/util.py
@@ -263,3 +263,21 @@ ZERO = localtime.ZERO
 
 def _cmp(a, b):
     return (a > b) - (a < b)
+
+
+PYTHON_FORMAT = re.compile(r'''
+    \%
+        (?:\(([\w]*)\))?
+        (
+            [-#0\ +]?(?:\*|[\d]+)?
+            (?:\.(?:\*|[\d]+))?
+            [hlL]?
+        )
+        ([diouxXeEfFgGcrs%])
+''', re.VERBOSE)
+
+
+def has_python_format(ids):
+    if isinstance(ids, str):
+        ids = [ids]
+    return any(PYTHON_FORMAT.search(id) for id in ids)

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -23,23 +23,6 @@ from babel.util import FixedOffsetTimezone
 
 class MessageTestCase(unittest.TestCase):
 
-    def test_python_format(self):
-        assert catalog.PYTHON_FORMAT.search('foo %d bar')
-        assert catalog.PYTHON_FORMAT.search('foo %s bar')
-        assert catalog.PYTHON_FORMAT.search('foo %r bar')
-        assert catalog.PYTHON_FORMAT.search('foo %(name).1f')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)3.3f')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)3f')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)06d')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)Li')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)#d')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)-4.4hs')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)*.3f')
-        assert catalog.PYTHON_FORMAT.search('foo %(name).*f')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)3.*f')
-        assert catalog.PYTHON_FORMAT.search('foo %(name)*.*f')
-        assert catalog.PYTHON_FORMAT.search('foo %()s')
-
     def test_translator_comments(self):
         mess = catalog.Message('foo', user_comments=['Comment About `foo`'])
         self.assertEqual(mess.user_comments, ['Comment About `foo`'])

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -38,16 +38,16 @@ msg10 = dngettext(getDomain(), 'Page', 'Pages', 3)
                                                extract.DEFAULT_KEYWORDS.keys(),
                                                [], {}))
         self.assertEqual([
-            (1, '_', None, []),
-            (2, 'ungettext', (None, None, None), []),
-            (3, 'ungettext', (u'Babel', None, None), []),
-            (4, 'ungettext', (None, u'Babels', None), []),
-            (5, 'ungettext', (u'bunny', u'bunnies', None), []),
-            (6, 'ungettext', (None, u'bunnies', None), []),
-            (7, '_', None, []),
-            (8, 'gettext', u'Rabbit', []),
-            (9, 'dgettext', (u'wiki', None), []),
-            (10, 'dngettext', (None, u'Page', u'Pages', None), [])],
+            (1, '_', None, [], set()),
+            (2, 'ungettext', (None, None, None), [], set()),
+            (3, 'ungettext', (u'Babel', None, None), [], set()),
+            (4, 'ungettext', (None, u'Babels', None), [], set()),
+            (5, 'ungettext', (u'bunny', u'bunnies', None), [], set()),
+            (6, 'ungettext', (None, u'bunnies', None), [], set()),
+            (7, '_', None, [], set()),
+            (8, 'gettext', u'Rabbit', [], set()),
+            (9, 'dgettext', (u'wiki', None), [], set()),
+            (10, 'dngettext', (None, u'Page', u'Pages', None), [], set())],
             messages)
 
     def test_extract_default_encoding_ascii(self):
@@ -56,14 +56,14 @@ msg10 = dngettext(getDomain(), 'Page', 'Pages', 3)
             buf, list(extract.DEFAULT_KEYWORDS), [], {},
         ))
         # Should work great in both py2 and py3
-        self.assertEqual([(1, '_', 'a', [])], messages)
+        self.assertEqual([(1, '_', 'a', [], set())], messages)
 
     def test_extract_default_encoding_utf8(self):
         buf = BytesIO(u'_("☃")'.encode('UTF-8'))
         messages = list(extract.extract_python(
             buf, list(extract.DEFAULT_KEYWORDS), [], {},
         ))
-        self.assertEqual([(1, '_', u'☃', [])], messages)
+        self.assertEqual([(1, '_', u'☃', [], set())], messages)
 
     def test_nested_comments(self):
         buf = BytesIO(b"""\
@@ -73,7 +73,7 @@ msg = ngettext('pylon',  # TRANSLATORS: shouldn't be
 """)
         messages = list(extract.extract_python(buf, ('ngettext',),
                                                ['TRANSLATORS:'], {}))
-        self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), [])],
+        self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), [], set())],
                          messages)
 
     def test_comments_with_calls_that_spawn_multiple_lines(self):
@@ -98,21 +98,21 @@ add_notice(req, ngettext("Bar deleted.",
 
                                                {'strip_comment_tags': False}))
         self.assertEqual((6, '_', 'Locale deleted.',
-                          [u'NOTE: This Comment SHOULD Be Extracted']),
+                          [u'NOTE: This Comment SHOULD Be Extracted'], set()),
                          messages[1])
         self.assertEqual((10, 'ngettext', (u'Foo deleted.', u'Foos deleted.',
                                            None),
-                          [u'NOTE: This Comment SHOULD Be Extracted']),
+                          [u'NOTE: This Comment SHOULD Be Extracted'], set()),
                          messages[2])
         self.assertEqual((3, 'ngettext',
                           (u'Catalog deleted.',
                            u'Catalogs deleted.', None),
-                          [u'NOTE: This Comment SHOULD Be Extracted']),
+                          [u'NOTE: This Comment SHOULD Be Extracted'], set()),
                          messages[0])
         self.assertEqual((15, 'ngettext', (u'Bar deleted.', u'Bars deleted.',
                                            None),
                           [u'NOTE: This Comment SHOULD Be Extracted',
-                           u'NOTE: And This One Too']),
+                           u'NOTE: And This One Too'], set()),
                          messages[3])
 
     def test_declarations(self):
@@ -129,9 +129,9 @@ class Meta:
         messages = list(extract.extract_python(buf,
                                                extract.DEFAULT_KEYWORDS.keys(),
                                                [], {}))
-        self.assertEqual([(3, '_', u'Page arg 1', []),
-                          (3, '_', u'Page arg 2', []),
-                          (8, '_', u'log entry', [])],
+        self.assertEqual([(3, '_', u'Page arg 1', [], set()),
+                          (3, '_', u'Page arg 2', [], set()),
+                          (8, '_', u'log entry', [], set())],
                          messages)
 
     def test_multiline(self):
@@ -143,8 +143,8 @@ msg2 = ngettext('elvis',
                  count)
 """)
         messages = list(extract.extract_python(buf, ('ngettext',), [], {}))
-        self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), []),
-                          (3, 'ngettext', (u'elvis', u'elvises', None), [])],
+        self.assertEqual([(1, 'ngettext', (u'pylon', u'pylons', None), [], set()),
+                          (3, 'ngettext', (u'elvis', u'elvises', None), [], set())],
                          messages)
 
     def test_npgettext(self):
@@ -156,8 +156,8 @@ msg2 = npgettext('Strings','elvis',
                  count)
 """)
         messages = list(extract.extract_python(buf, ('npgettext',), [], {}))
-        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), []),
-                          (3, 'npgettext', (u'Strings', u'elvis', u'elvises', None), [])],
+        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), [], set()),
+                          (3, 'npgettext', (u'Strings', u'elvis', u'elvises', None), [], set())],
                          messages)
         buf = BytesIO(b"""\
 msg = npgettext('Strings', 'pylon',  # TRANSLATORS: shouldn't be
@@ -166,7 +166,7 @@ msg = npgettext('Strings', 'pylon',  # TRANSLATORS: shouldn't be
 """)
         messages = list(extract.extract_python(buf, ('npgettext',),
                                                ['TRANSLATORS:'], {}))
-        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), [])],
+        self.assertEqual([(1, 'npgettext', (u'Strings', u'pylon', u'pylons', None), [], set())],
                          messages)
 
     def test_triple_quoted_strings(self):
@@ -178,9 +178,9 @@ msg2 = ngettext(\"\"\"elvis\"\"\", 'elvises', count)
         messages = list(extract.extract_python(buf,
                                                extract.DEFAULT_KEYWORDS.keys(),
                                                [], {}))
-        self.assertEqual([(1, '_', u'pylons', []),
-                          (2, 'ngettext', (u'elvis', u'elvises', None), []),
-                          (3, 'ngettext', (u'elvis', u'elvises', None), [])],
+        self.assertEqual([(1, '_', u'pylons', [], set()),
+                          (2, 'ngettext', (u'elvis', u'elvises', None), [], set()),
+                          (3, 'ngettext', (u'elvis', u'elvises', None), [], set())],
                          messages)
 
     def test_multiline_strings(self):
@@ -196,7 +196,7 @@ gettext message catalog library.''')
             [(1, '_',
               u'This module provides internationalization and localization\n'
               'support for your Python programs by providing an interface to '
-              'the GNU\ngettext message catalog library.', [])],
+              'the GNU\ngettext message catalog library.', [], set())],
             messages)
 
     def test_concatenated_strings(self):
@@ -474,9 +474,9 @@ msg10 = dngettext(domain, 'Page', 'Pages', 3)
         messages = \
             list(extract.extract('python', buf, extract.DEFAULT_KEYWORDS, [],
                                  {}))
-        self.assertEqual([(5, (u'bunny', u'bunnies'), [], None),
-                          (8, u'Rabbit', [], None),
-                          (10, (u'Page', u'Pages'), [], None)], messages)
+        self.assertEqual([(5, (u'bunny', u'bunnies'), [], None, set()),
+                          (8, u'Rabbit', [], None, set()),
+                          (10, (u'Page', u'Pages'), [], None, set())], messages)
 
     def test_invalid_extract_method(self):
         buf = BytesIO(b'')

--- a/tests/messages/test_js_extract.py
+++ b/tests/messages/test_js_extract.py
@@ -14,9 +14,9 @@ msg3 = ngettext('s', 'p', 42)
         list(extract.extract('javascript', buf, extract.DEFAULT_KEYWORDS,
                              [], {}))
 
-    assert messages == [(1, 'simple', [], None),
-                        (2, 'simple', [], None),
-                        (3, ('s', 'p'), [], None)]
+    assert messages == [(1, 'simple', [], None, set()),
+                        (2, 'simple', [], None, set()),
+                        (3, ('s', 'p'), [], None, set())]
 
 
 def test_various_calls():
@@ -36,9 +36,9 @@ msg10 = dngettext(domain, 'Page', 'Pages', 3)
         list(extract.extract('javascript', buf, extract.DEFAULT_KEYWORDS, [],
                              {}))
     assert messages == [
-        (5, (u'bunny', u'bunnies'), [], None),
-        (8, u'Rabbit', [], None),
-        (10, (u'Page', u'Pages'), [], None)
+        (5, (u'bunny', u'bunnies'), [], None, set()),
+        (8, u'Rabbit', [], None, set()),
+        (10, (u'Page', u'Pages'), [], None, set())
     ]
 
 
@@ -132,7 +132,7 @@ def test_dotted_keyword_extract():
         extract.extract('javascript', buf, {"com.corporate.i18n.formatMessage": None}, [], {})
     )
 
-    assert messages == [(1, 'Insert coin to continue', [], None)]
+    assert messages == [(1, 'Insert coin to continue', [], None, set())]
 
 
 def test_template_string_standard_usage():
@@ -141,7 +141,7 @@ def test_template_string_standard_usage():
         extract.extract('javascript', buf, {"gettext": None}, [], {})
     )
 
-    assert messages == [(1, 'Very template, wow', [], None)]
+    assert messages == [(1, 'Very template, wow', [], None, set())]
 
 
 def test_template_string_tag_usage():
@@ -150,4 +150,4 @@ def test_template_string_tag_usage():
         extract.extract('javascript', buf, {"i18n": None}, [], {})
     )
 
-    assert messages == [(1, 'Tag template, wow', [], None)]
+    assert messages == [(1, 'Tag template, wow', [], None, set())]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,7 +18,7 @@ from io import BytesIO
 import pytest
 
 from babel import util
-from babel.util import parse_future_flags
+from babel.util import parse_future_flags, has_python_format
 
 
 class _FF:
@@ -101,3 +101,29 @@ def test_parse_future(source, result):
     fp = BytesIO(source.encode('latin-1'))
     flags = parse_future_flags(fp)
     assert flags == result
+
+@pytest.mark.parametrize('ids', [
+    ('foo %d bar',),
+    ('foo %s bar',),
+    ('foo %r bar',),
+    ('foo %(name).1f',),
+    ('foo %(name)3.3f',),
+    ('foo %(name)3f',),
+    ('foo %(name)06d',),
+    ('foo %(name)Li',),
+    ('foo %(name)#d',),
+    ('foo %(name)-4.4hs',),
+    ('foo %(name)*.3f',),
+    ('foo %(name).*f',),
+    ('foo %(name)3.*f',),
+    ('foo %(name)*.*f',),
+    ('foo %()s',),
+])
+def test_has_python_format(ids):
+    assert has_python_format(ids)
+
+@pytest.mark.parametrize('ids', [
+    ('foo',),
+])
+def test_not_has_python_format(ids):
+    assert not has_python_format(ids)


### PR DESCRIPTION
This adds a sixth value to the tuple returned by the extractor functions
which should be a set of flags.

Which flags should be applied to a message should be determined by the
extractor, as it depends on e.g. the file format being parsed. For
example "%s" should have the python-format flag if it was parsed from a
Python file and the c-format flag if it was extracted from a C file.

The logic of detecting python-format flags is also moved to the Python
extractor in this PR.

NOTE:

This is partially a breaking change. Backwards compability is maintained
with extractors that return 5-tuples instead of 6-tuples, but the
interface Babel exposes for extracting messages always returns 6-tuples.
I don't see a good way around this.

Removing the python-format detection from Message.__init__ is also a
breaking change, but that could potentially be put back for now.

Fixes #35