### PR TITLE
Don't use the deprecated format_number function internally or in tests

### DIFF
--- a/babel/support.py
+++ b/babel/support.py
@@ -18,7 +18,7 @@ import locale
 from babel.core import Locale
 from babel.dates import format_date, format_datetime, format_time, \
     format_timedelta
-from babel.numbers import format_number, format_decimal, format_currency, \
+from babel.numbers import format_decimal, format_currency, \
     format_percent, format_scientific
 
 
@@ -98,7 +98,7 @@ class Format(object):
         >>> fmt.number(1099)
         u'1,099'
         """
-        return format_number(number, locale=self.locale)
+        return format_decimal(number, locale=self.locale)
 
     def decimal(self, number, format=None):
         """Return a decimal number formatted for the locale.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,9 @@ norecursedirs = venv* .* _* scripts {args}
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL
 markers =
     all_locales: parameterize test with all locales
+filterwarnings =
+    # The doctest for format_number would raise this, but we don't really want to see it.
+    ignore:babel.numbers.format_decimal:DeprecationWarning
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -346,12 +346,9 @@ def test_decimal_precision():
     assert get_decimal_precision(decimal.Decimal('10000')) == 0
 
 
-def test_format_number():
-    assert numbers.format_number(1099, locale='en_US') == u'1,099'
-    assert numbers.format_number(1099, locale='de_DE') == u'1.099'
-
-
 def test_format_decimal():
+    assert numbers.format_decimal(1099, locale='en_US') == u'1,099'
+    assert numbers.format_decimal(1099, locale='de_DE') == u'1.099'
     assert numbers.format_decimal(1.2345, locale='en_US') == u'1.234'
     assert numbers.format_decimal(1.2346, locale='en_US') == u'1.235'
     assert numbers.format_decimal(-1.2346, locale='en_US') == u'-1.235'


### PR DESCRIPTION
Quenches some test warnings.

Refs https://github.com/python-babel/babel/issues/802#issuecomment-1029133205