### PR TITLE
catalog.py: Fix header formatting

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -529,7 +529,7 @@ class Catalog(object):
         'nplurals=2; plural=(n > 1)'
 
         :type: `str`"""
-        return 'nplurals=%s; plural=%s' % (self.num_plurals, self.plural_expr)
+        return 'nplurals=%s; plural=%s;' % (self.num_plurals, self.plural_expr)
 
     def __contains__(self, id):
         """Return whether the catalog has a message with the specified ID."""


### PR DESCRIPTION
Fix formatting for Plural-Forms header by adding a trailing semicolon

Closes https://github.com/python-babel/babel/issues/836