### PR TITLE
Prefer setuptools imports to distutils imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@
 
 import subprocess
 import sys
-from distutils.cmd import Command
 
-from setuptools import setup
+from setuptools import setup, Command
 
 try:
     from babel import __version__

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -11,12 +11,10 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
 import shlex
-from freezegun import freeze_time
 from datetime import datetime
-from distutils.dist import Distribution
-from distutils.errors import DistutilsOptionError
-from distutils.log import _global_log
+from freezegun import freeze_time
 from io import StringIO
+from setuptools import Distribution
 import logging
 import os
 import shutil
@@ -29,7 +27,7 @@ import pytest
 from babel import __version__ as VERSION
 from babel.dates import format_datetime
 from babel.messages import frontend, Catalog
-from babel.messages.frontend import CommandLineInterface, extract_messages, update_catalog
+from babel.messages.frontend import CommandLineInterface, extract_messages, update_catalog, OptionError
 from babel.util import LOCALTZ
 from babel.messages.pofile import read_po, write_po
 
@@ -49,7 +47,6 @@ class CompileCatalogTestCase(unittest.TestCase):
     def setUp(self):
         self.olddir = os.getcwd()
         os.chdir(data_dir)
-        _global_log.threshold = 5  # shut up distutils logging
 
         self.dist = Distribution(dict(
             name='TestProject',
@@ -65,12 +62,12 @@ class CompileCatalogTestCase(unittest.TestCase):
     def test_no_directory_or_output_file_specified(self):
         self.cmd.locale = 'en_US'
         self.cmd.input_file = 'dummy'
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     def test_no_directory_or_input_file_specified(self):
         self.cmd.locale = 'en_US'
         self.cmd.output_file = 'dummy'
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
 
 class ExtractMessagesTestCase(unittest.TestCase):
@@ -78,7 +75,6 @@ class ExtractMessagesTestCase(unittest.TestCase):
     def setUp(self):
         self.olddir = os.getcwd()
         os.chdir(data_dir)
-        _global_log.threshold = 5  # shut up distutils logging
 
         self.dist = Distribution(dict(
             name='TestProject',
@@ -100,21 +96,21 @@ class ExtractMessagesTestCase(unittest.TestCase):
     def test_neither_default_nor_custom_keywords(self):
         self.cmd.output_file = 'dummy'
         self.cmd.no_default_keywords = True
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     def test_no_output_file_specified(self):
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     def test_both_sort_output_and_sort_by_file(self):
         self.cmd.output_file = 'dummy'
         self.cmd.sort_output = True
         self.cmd.sort_by_file = True
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     def test_invalid_file_or_dir_input_path(self):
         self.cmd.input_paths = 'nonexistent_path'
         self.cmd.output_file = 'dummy'
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     def test_input_paths_is_treated_as_list(self):
         self.cmd.input_paths = data_dir
@@ -146,7 +142,7 @@ class ExtractMessagesTestCase(unittest.TestCase):
         self.cmd.input_dirs = this_dir
         self.cmd.input_paths = this_dir
         self.cmd.output_file = pot_file
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     @freeze_time("1994-11-11")
     def test_extraction_with_default_mapping(self):
@@ -354,7 +350,6 @@ class InitCatalogTestCase(unittest.TestCase):
     def setUp(self):
         self.olddir = os.getcwd()
         os.chdir(data_dir)
-        _global_log.threshold = 5  # shut up distutils logging
 
         self.dist = Distribution(dict(
             name='TestProject',
@@ -375,12 +370,12 @@ class InitCatalogTestCase(unittest.TestCase):
     def test_no_input_file(self):
         self.cmd.locale = 'en_US'
         self.cmd.output_file = 'dummy'
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     def test_no_locale(self):
         self.cmd.input_file = 'dummy'
         self.cmd.output_file = 'dummy'
-        self.assertRaises(DistutilsOptionError, self.cmd.finalize_options)
+        self.assertRaises(OptionError, self.cmd.finalize_options)
 
     @freeze_time("1994-11-11")
     def test_with_output_dir(self):


### PR DESCRIPTION
Considering distutils is being deprecated, this fixes up things so imports from `setuptools` are used where available instead.

The non-conditional imports have been around for 6 to 17 years, so they should be safe in conservative situations too.

Refs #824