### PR TITLE
catalog.py: added trailing semicolon in Plural-Forms header entry

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -529,7 +529,7 @@ class Catalog(object):
         'nplurals=2; plural=(n > 1)'
 
         :type: `str`"""
-        return 'nplurals=%s; plural=%s' % (self.num_plurals, self.plural_expr)
+        return 'nplurals=%s; plural=%s;' % (self.num_plurals, self.plural_expr)
 
     def __contains__(self, id):
         """Return whether the catalog has a message with the specified ID."""


### PR DESCRIPTION
catalog.py: added trailing semicolon in Plural-Forms header entry
Closes https://github.com/python-babel/babel/issues/836