### PR TITLE
Fix output of --list-locales to not use bytes reprs

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -22,7 +22,6 @@ from collections import OrderedDict
 from configparser import RawConfigParser
 from datetime import datetime
 from io import StringIO
-from locale import getpreferredencoding
 
 from babel import __version__ as VERSION
 from babel import Locale, localedata
@@ -906,10 +905,7 @@ class CommandLineInterface(object):
             format = u'%%-%ds %%s' % (longest + 1)
             for identifier in identifiers:
                 locale = Locale.parse(identifier)
-                output = format % (identifier, locale.english_name)
-                print(output.encode(sys.stdout.encoding or
-                                    getpreferredencoding() or
-                                    'ascii', 'replace'))
+                print(format % (identifier, locale.english_name))
             return 0
 
         if not args:

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -756,6 +756,17 @@ usage: pybabel command [options] [args]
 pybabel: error: no valid command or option passed. try the -h/--help option for more information.
 """, sys.stderr.getvalue().lower())
 
+    def test_list_locales(self):
+        """
+        Test the command with the --list-locales arg.
+        """
+        result = self.cli.run(sys.argv + ['--list-locales'])
+        assert not result
+        output = sys.stdout.getvalue()
+        assert 'fr_CH' in output
+        assert 'French (Switzerland)' in output
+        assert "\nb'" not in output  # No bytes repr markers in output
+
     def _run_init_catalog(self):
         i18n_dir = os.path.join(data_dir, 'project', 'i18n')
         pot_path = os.path.join(data_dir, 'project', 'i18n', 'messages.pot')


### PR DESCRIPTION
This adds a unit test for the `--list-locales` argument, and updates its implementation to not output bytes reprs.

In other words, goes from this:

```
...
b'fr_CH           French (Switzerland)'
b'fr_CI           French (C\xc3\xb4te d\xe2\x80\x99Ivoire)'
b'fr_CM           French (Cameroon)'
...
```

to this

```
...
fr_CH           French (Switzerland)
fr_CI           French (Côte d’Ivoire)
fr_CM           French (Cameroon)
...
```
