### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ setup(
     author_email='armin.ronacher@active-4.com',
     license='BSD',
     url='http://babel.pocoo.org/',
+    project_urls={
+        'Source': 'https://github.com/python-babel/babel',
+    },
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.