### PR TITLE
CLDR 41

### DIFF
--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -13,10 +13,10 @@ except ImportError:
     from urllib import urlretrieve
 
 
-URL = 'http://unicode.org/Public/cldr/40/cldr-common-40.0.zip'
-FILENAME = 'cldr-common-40.0.zip'
-# Via https://unicode.org/Public/cldr/40/hashes/SHASUM512.txt
-FILESUM = 'b45ea381002210cf5963a2ba52fa45ee4e9b1e80ae1180bcecf61f431d64e4e0faba700b3d56a96a33355deab3abdb8bcbae9222b60a8ca85536476718175645'
+URL = 'http://unicode.org/Public/cldr/41/cldr-common-41.0.zip'
+FILENAME = 'cldr-common-41.0.zip'
+# Via https://unicode.org/Public/cldr/41/hashes/SHASUM512
+FILESUM = 'c64f3338e292962817b043dd11e9c47f533c9b70d432f83e80654e20f4937c72b37e66a60485df43f734b1ff94ebf0452547a063076917889303c9653b4d6ce5'
 BLKSIZE = 131072
 
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -845,6 +845,9 @@ def parse_unit_patterns(data, tree):
             unit_type = unit.attrib['type']
             unit_and_length_patterns = unit_patterns.setdefault(unit_type, {}).setdefault(unit_length_type, {})
             for pattern in unit.findall('unitPattern'):
+                if pattern.attrib.get('case', 'nominative') != 'nominative':
+                    # Skip non-nominative cases.
+                    continue
                 unit_and_length_patterns[pattern.attrib['count']] = _text(pattern)
 
             per_unit_pat = unit.find('perUnitPattern')
@@ -860,6 +863,9 @@ def parse_unit_patterns(data, tree):
             compound_unit_info = {}
             compound_variations = {}
             for child in unit:
+                if child.attrib.get('case', 'nominative') != 'nominative':
+                    # Skip non-nominative cases.
+                    continue
                 if child.tag == "unitPrefixPattern":
                     compound_unit_info['prefix'] = _text(child)
                 elif child.tag == "compoundUnitPattern":

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -238,7 +238,7 @@ def test_list_currencies():
 
     assert list_currencies(locale='pa_Arab') == {'PKR', 'INR', 'EUR'}
 
-    assert len(list_currencies()) == 303
+    assert len(list_currencies()) == 305
 
 
 def test_validate_currency():


### PR DESCRIPTION
[CLDR 41 was released 6 April 2022](https://cldr.unicode.org/index/downloads/cldr-41) (all of two days old at the time of writing).

This PR upgrades things to use that brand new version – an interesting new feature in CLDR 41 is that units are adorned with `case=""`; glad we have a couple of test cases that caught the fact that genitive case would have overridden nominative :)

Based on

```
ag case= | grep -v unitPattern | grep -v compoundUnitPattern | grep -v caseMinimalPairs
```

the only tags with `case=`s are the three above, and those are all handled by the current import code.