### PR TITLE
Addressing problems raised in sphinx_issues #10104

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -35,7 +35,7 @@ PYTHON_FORMAT = re.compile(r'''
             (?:\.(?:\*|[\d]+))?
             [hlL]?
         )
-        ([diouxXeEfFgGcrs%])
+        ((?<!\s)[diouxXeEfFgGcrs%])(?=([\s\'\)\.\,\:\"\!\]\>\?]|$))
 ''', re.VERBOSE)
 
 
@@ -94,7 +94,7 @@ class Message(object):
         if not string and self.pluralizable:
             string = (u'', u'')
         self.string = string
-        self.locations = list(distinct(locations))
+        self.locations = list(set(locations))
         self.flags = set(flags)
         if id and self.python_format:
             self.flags.add('python-format')

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -522,21 +522,15 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
             text = text.encode(catalog.charset, 'backslashreplace')
         fileobj.write(text)
 
-    def _write_comment(comment, prefix='', comment_determinator=None):
+    def _write_comment(comment, prefix=''):
         # NEVER wrap comments, this observation: "xgettext always wraps comments even if --no-wrap is passed;" is FALSE. There seemed to be a bug in the xgettext code, because wrapping doesn't always occur
         # Make sure comments are unique and sorted alphabetically so locations can be easily searched and identify
         has_comment = (bool(comment) and len(comment) > 0)
         if not has_comment:
             return
 
-        try:
-            has_comment_split = (comment_determinator is not None)
-            comment_list = (comment.split(comment_determinator) if has_comment_split else comment)            
-        except Exception as e:
-            # sometimes comment came as a list
-            comment_list = comment
-            
-        comment_list = list(set(comment))
+        is_list_type = isinstance(comment, list)
+        comment_list = (list(comment) if not is_list_type else comment)
         comment_list.sort()
         for line in comment_list:
             _write('#%s %s\n' % (prefix, line.strip()))
@@ -587,11 +581,8 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                 comment_header = u'\n'.join(lines)
             _write(comment_header + u'\n')
 
-        comment_list = '\n'.join(message.user_comments)
-        _write_comment(comment_list, comment_determinator='\n')
-
-        comment_list = '\n'.join(message.auto_comments)
-        _write_comment(comment_list, comment_determinator='\n')
+        _write_comment(message.user_comments)
+        _write_comment(message.auto_comments)
 
         if not no_location:
             locs = []
@@ -613,8 +604,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                     location = u'%s' % filename.replace(os.sep, '/')
                 if location not in locs:
                     locs.append(location)
-            loc_list = '\n'.join(locs)
-            _write_comment(loc_list, prefix=':', comment_determinator='\n')
+            _write_comment(locs, prefix=':')
         if message.flags:
             _write('#%s\n' % ', '.join([''] + sorted(message.flags)))
 
@@ -634,8 +624,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
             catalog.obsolete.values(),
             sort_by=sort_by
         ):
-            comment_list = '\n'.join(message.user_comments)
-            _write_comment(comment_list, comment_determinator='\n')
+            _write_comment(message.user_comments)
             _write_message(message, prefix='#~ ')
             _write('\n')
 

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -522,21 +522,15 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
             text = text.encode(catalog.charset, 'backslashreplace')
         fileobj.write(text)
 
-    def _write_comment(comment, prefix='', comment_determinator=None):
+    def _write_comment(comment, prefix='':
         # NEVER wrap comments, this observation: "xgettext always wraps comments even if --no-wrap is passed;" is FALSE. There seemed to be a bug in the xgettext code, because wrapping doesn't always occur
         # Make sure comments are unique and sorted alphabetically so locations can be easily searched and identify
         has_comment = (bool(comment) and len(comment) > 0)
         if not has_comment:
             return
 
-        try:
-            has_comment_split = (comment_determinator is not None)
-            comment_list = (comment.split(comment_determinator) if has_comment_split else comment)            
-        except Exception as e:
-            # sometimes comment came as a list
-            comment_list = comment
-            
-        comment_list = list(set(comment))
+        is_list_type = isinstance(comment, list)
+        comment_list = (list(comment) if not is_list_type else comment)
         comment_list.sort()
         for line in comment_list:
             _write('#%s %s\n' % (prefix, line.strip()))
@@ -587,11 +581,8 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                 comment_header = u'\n'.join(lines)
             _write(comment_header + u'\n')
 
-        comment_list = '\n'.join(message.user_comments)
-        _write_comment(comment_list, comment_determinator='\n')
-
-        comment_list = '\n'.join(message.auto_comments)
-        _write_comment(comment_list, comment_determinator='\n')
+        _write_comment(message.user_comments)
+        _write_comment(message.auto_comments)
 
         if not no_location:
             locs = []
@@ -613,8 +604,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                     location = u'%s' % filename.replace(os.sep, '/')
                 if location not in locs:
                     locs.append(location)
-            loc_list = '\n'.join(locs)
-            _write_comment(loc_list, prefix=':', comment_determinator='\n')
+            _write_comment(locs, prefix=':')
         if message.flags:
             _write('#%s\n' % ', '.join([''] + sorted(message.flags)))
 
@@ -634,8 +624,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
             catalog.obsolete.values(),
             sort_by=sort_by
         ):
-            comment_list = '\n'.join(message.user_comments)
-            _write_comment(comment_list, comment_determinator='\n')
+            _write_comment(message.user_comments)
             _write_message(message, prefix='#~ ')
             _write('\n')
 

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -275,8 +275,7 @@ class PoFileParser(object):
                         continue
                     self.locations.append((location[:pos], lineno))
                 else:
-                    self.locations.append((location, None))
-            self.locations = list(set(self.locations))
+                    self.locations.append((location, None))            
         elif line[1:].startswith(','):
             for flag in line[2:].lstrip().split(','):
                 self.flags.append(flag.strip())
@@ -522,21 +521,14 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
             text = text.encode(catalog.charset, 'backslashreplace')
         fileobj.write(text)
 
-    def _write_comment(comment, prefix='', comment_determinator=None):
+    def _write_comment(comment, prefix=''):
         # NEVER wrap comments, this observation: "xgettext always wraps comments even if --no-wrap is passed;" is FALSE. There seemed to be a bug in the xgettext code, because wrapping doesn't always occur
         # Make sure comments are unique and sorted alphabetically so locations can be easily searched and identify
-        has_comment = (bool(comment) and len(comment) > 0)
-        if not has_comment:
+        if not comment:
             return
 
-        try:
-            has_comment_split = (comment_determinator is not None)
-            comment_list = (comment.split(comment_determinator) if has_comment_split else comment)            
-        except Exception as e:
-            # sometimes comment came as a list
-            comment_list = comment
-            
-        comment_list = list(set(comment))
+        is_list_type = isinstance(comment, list)
+        comment_list = (list(comment) if not is_list_type else comment)
         comment_list.sort()
         for line in comment_list:
             _write('#%s %s\n' % (prefix, line.strip()))
@@ -587,11 +579,9 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                 comment_header = u'\n'.join(lines)
             _write(comment_header + u'\n')
 
-        comment_list = '\n'.join(message.user_comments)
-        _write_comment(comment_list, comment_determinator='\n')
+        _write_comment(message.user_comments)
+        _write_comment(message.auto_comments, prefix='.')
 
-        comment_list = '\n'.join(message.auto_comments)
-        _write_comment(comment_list, comment_determinator='\n')
 
         if not no_location:
             locs = []
@@ -613,8 +603,9 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
                     location = u'%s' % filename.replace(os.sep, '/')
                 if location not in locs:
                     locs.append(location)
-            loc_list = '\n'.join(locs)
-            _write_comment(loc_list, prefix=':', comment_determinator='\n')
+
+            _write_comment(locs, prefix=':')
+
         if message.flags:
             _write('#%s\n' % ', '.join([''] + sorted(message.flags)))
 
@@ -634,8 +625,7 @@ def write_po(fileobj, catalog, width=76, no_location=False, omit_header=False,
             catalog.obsolete.values(),
             sort_by=sort_by
         ):
-            comment_list = '\n'.join(message.user_comments)
-            _write_comment(comment_list, comment_determinator='\n')
+            _write_comment(message.user_comments)
             _write_message(message, prefix='#~ ')
             _write('\n')
 


### PR DESCRIPTION
# branch
master

# purpose
- Addressed several issues with PYTHON_FORMAT pattern
- Addressed issues with comment blocks

# details
- The PYTHON_FORMAT pattern wrongly found incidences of percentage sign, such as 50% or %28c in links, and flagging the message as python-format, which is exposed under the use of editors such as PoEdit as a wrong use of python-format feature, which many translators use. This editor is RECOMMENDED by Blender.org for use in the internationalisation projects.
- Problem is solved by added look behind to see if it is not a space character and look ahead to see if the character ended the pattern is one of the allowed symbols - note: many will probably needed to manually enter to allow expansion of the use of '%s %d' etc. - I have only added characters that were found in one of the blender's po file [vi.po file](https://github.com/blender/blender-translations/blob/master/po/vi.po). One can download this file to test and simply use the following Python code:

```
from sphinx_intl import catalog as c
home = os.environ['HOME']
file_path = os.path.join(home, 'vi.po')
out_file = os.path.join(home, 'test_vi.po')
data = c.load_po(file_path)
c.dump_po(out_file, data, line_width=4096)
```
The original file doesn't contain any 'python-format', after the test, there should be 582 entries flagged as python-format, if load into the PoEditor, there should not be any PINK flagging indicating misuse of python-format.

- Comment blocks are particularly good use for developers and translators as they are the quick reference to where the line originated from (which source files) and what comments developers had placed in to notify others. For this reason, several issues are address here:
      - Remove duplications in the entries
      - Sort entries alphabetically for easer spotting and locating the origins
      - Remove the wrapping by line length to the comment block as this SHOULD NOT be done. The observation that xgettext also performing wrapping is a fallacy as test shown using 'msgmerge --no-wrap' doesn't always wrap every lines, only a few incidences are found, indicating there is an error in the original xgettext code.  This wrapping is particularly annoying for developers observing changes in the po files in a repository. Only physical changes to either msgid or msgstr should be observed, not the comment block, especially when there are no changes and the flagging of changes is created by the effects of wrapping functionality of the software. 

# link to the issues:
[Message.locations duplicate unnecessary #10104](https://github.com/sphinx-doc/sphinx/issues/10104)
