### PR TITLE
Use email.Message for pofile header parsing

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -10,7 +10,6 @@
 
 import re
 
-from cgi import parse_header
 from collections import OrderedDict
 from datetime import datetime, time as time_
 from difflib import get_close_matches
@@ -225,6 +224,13 @@ DEFAULT_HEADER = u"""\
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #"""
 
+def parse_separated_header(value: str):
+    # Adapted from https://peps.python.org/pep-0594/#cgi
+    from email.message import Message
+    m = Message()
+    m['content-type'] = value
+    return dict(m.get_params())
+
 
 class Catalog:
     """Representation of a message catalog."""
@@ -424,11 +430,11 @@ class Catalog:
             elif name == 'language-team':
                 self.language_team = value
             elif name == 'content-type':
-                mimetype, params = parse_header(value)
+                params = parse_separated_header(value)
                 if 'charset' in params:
                     self.charset = params['charset'].lower()
             elif name == 'plural-forms':
-                _, params = parse_header(' ;' + value)
+                params = parse_separated_header(' ;' + value)
                 self._num_plurals = int(params.get('nplurals', 2))
                 self._plural_expr = params.get('plural', '(n != 1)')
             elif name == 'pot-creation-date':

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -68,6 +68,17 @@ msgstr "bär"'''.encode('iso-8859-1'))
         catalog = pofile.read_po(buf, locale='de_DE')
         self.assertEqual(u'bär', catalog.get('foo').string)
 
+    def test_encoding_header_read(self):
+        buf = BytesIO(b'msgid ""\nmsgstr ""\n"Content-Type: text/plain; charset=mac_roman\\n"\n')
+        catalog = pofile.read_po(buf, locale='xx_XX')
+        assert catalog.charset == 'mac_roman'
+
+    def test_plural_forms_header_parsed(self):
+        buf = BytesIO(b'msgid ""\nmsgstr ""\n"Plural-Forms: nplurals=42; plural=(n % 11);\\n"\n')
+        catalog = pofile.read_po(buf, locale='xx_XX')
+        assert catalog.plural_expr == '(n % 11)'
+        assert catalog.num_plurals == 42
+
     def test_read_multiline(self):
         buf = StringIO(r'''msgid ""
 "Here's some text that\n"


### PR DESCRIPTION
cgi.parse_header is due to be deprecated.

Fixes #873