### PR TITLE
Support for hex escapes in JavaScript strings

### DIFF
--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
     babel.messages.jslexer
     ~~~~~~~~~~~~~~~~~~~~~~
@@ -27,6 +28,7 @@ regex_re = re.compile(r'/(?:[^/\\]*(?:\\.[^/\\]*)*)/[a-zA-Z]*', re.DOTALL)
 line_re = re.compile(r'(\r\n|\n|\r)')
 line_join_re = re.compile(r'\\' + line_re.pattern)
 uni_escape_re = re.compile(r'[a-fA-F0-9]{1,4}')
+hex_escape_re = re.compile(r'[a-fA-F0-9]{1,2}')
 
 Token = namedtuple('Token', 'type value lineno')
 
@@ -123,6 +125,17 @@ def unquote_string(string):
                         continue
                 add(next_char + escaped_value)
                 pos = escaped.end()
+                continue
+            else:
+                add(next_char)
+
+        # hex escapes. conversion from 2-digits hex to char is infallible
+        elif next_char in 'xX':
+            escaped = hex_escape_re.match(string, escape_pos + 2)
+            if escaped is not None:
+                escaped_value = escaped.group()
+                add(chr(int(escaped_value, 16)))
+                pos = escape_pos + 2 + len(escaped_value)
                 continue
             else:
                 add(next_char)

--- a/tests/messages/test_jslexer.py
+++ b/tests/messages/test_jslexer.py
@@ -4,6 +4,8 @@ from babel.messages import jslexer
 def test_unquote():
     assert jslexer.unquote_string('""') == ''
     assert jslexer.unquote_string(r'"h\u00ebllo"') == u"hëllo"
+    assert jslexer.unquote_string(r'"h\xebllo"') == u"hëllo"
+    assert jslexer.unquote_string(r'"\xebb"') == u"ëb"
 
 
 def test_dollar_in_identifier():


### PR DESCRIPTION
Currently Babel only supports `\u`-style Unicode escapes in JavaScript string literals.

Unfortunately, I have to deal witth JS files (WebPack-generated) that contain `\x`-style escapes. I believe Babel should support it, as it's perfectly legitimate JS syntax.