### PR TITLE
Small downloader improvements

### DIFF
--- a/babel/localtime/_win32.py
+++ b/babel/localtime/_win32.py
@@ -1,10 +1,7 @@
 try:
-    import _winreg as winreg
+    import winreg
 except ImportError:
-    try:
-        import winreg
-    except ImportError:
-        winreg = None
+    winreg = None
 
 from babel.core import get_global
 import pytz

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -64,9 +64,9 @@ def main():
 
     while not is_good_file(zip_path):
         log("Downloading '%s' from %s", FILENAME, URL)
-        if os.path.isfile(zip_path):
-            os.remove(zip_path)
-        urlretrieve(URL, zip_path, (reporthook if show_progress else None))
+        tmp_path = f"{zip_path}.tmp"
+        urlretrieve(URL, tmp_path, (reporthook if show_progress else None))
+        os.replace(tmp_path, zip_path)
         changed = True
         print()
     common_path = os.path.join(cldr_path, 'common')

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -28,15 +28,13 @@ def reporthook(block_count, block_size, total_size):
     sys.stdout.flush()
 
 
-def log(message, *args):
-    if args:
-        message = message % args
-    sys.stderr.write(message + '\n')
+def log(message):
+    sys.stderr.write(f'{message}\n')
 
 
 def is_good_file(filename):
     if not os.path.isfile(filename):
-        log('Local copy \'%s\' not found', filename)
+        log(f"Local copy '{filename}' not found")
         return False
     h = hashlib.sha512()
     with open(filename, 'rb') as f:
@@ -47,8 +45,7 @@ def is_good_file(filename):
             h.update(blk)
         digest = h.hexdigest()
         if digest != FILESUM:
-            raise RuntimeError('Checksum mismatch: %r != %r'
-                               % (digest, FILESUM))
+            raise RuntimeError(f'Checksum mismatch: {digest!r} != {FILESUM!r}')
         else:
             return True
 
@@ -63,7 +60,7 @@ def main():
     show_progress = (False if os.environ.get("BABEL_CLDR_NO_DOWNLOAD_PROGRESS") else sys.stdout.isatty())
 
     while not is_good_file(zip_path):
-        log("Downloading '%s' from %s", FILENAME, URL)
+        log(f"Downloading '{FILENAME}' from {URL}")
         tmp_path = f"{zip_path}.tmp"
         urlretrieve(URL, tmp_path, (reporthook if show_progress else None))
         os.replace(tmp_path, zip_path)
@@ -73,10 +70,10 @@ def main():
 
     if changed or not os.path.isdir(common_path):
         if os.path.isdir(common_path):
-            log('Deleting old CLDR checkout in \'%s\'', cldr_path)
+            log(f"Deleting old CLDR checkout in '{cldr_path}'")
             shutil.rmtree(common_path)
 
-        log('Extracting CLDR to \'%s\'', cldr_path)
+        log(f"Extracting CLDR to '{cldr_path}'")
         with contextlib.closing(zipfile.ZipFile(zip_path)) as z:
             z.extractall(cldr_path)
 

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -7,10 +7,7 @@ import shutil
 import hashlib
 import zipfile
 import subprocess
-try:
-    from urllib.request import urlretrieve
-except ImportError:
-    from urllib import urlretrieve
+from urllib.request import urlretrieve
 
 
 URL = 'http://unicode.org/Public/cldr/41/cldr-common-41.0.zip'

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -17,27 +17,14 @@ FILESUM = 'c64f3338e292962817b043dd11e9c47f533c9b70d432f83e80654e20f4937c72b37e6
 BLKSIZE = 131072
 
 
-def get_terminal_width():
-    try:
-        import fcntl
-        import termios
-        import struct
-        fd = sys.stdin.fileno()
-        cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
-        return cr[1]
-    except Exception:
-        return 80
-
-
 def reporthook(block_count, block_size, total_size):
     bytes_transmitted = block_count * block_size
-    cols = get_terminal_width()
+    cols = shutil.get_terminal_size().columns
     buffer = 6
     percent = float(bytes_transmitted) / (total_size or 1)
     done = int(percent * (cols - buffer))
-    sys.stdout.write('\r')
-    sys.stdout.write(' ' + '=' * done + ' ' * (cols - done - buffer))
-    sys.stdout.write('% 4d%%' % (percent * 100))
+    bar = ('=' * done).ljust(cols - buffer)
+    sys.stdout.write(f'\r{bar}{int(percent * 100): 4d}%')
     sys.stdout.flush()
 
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -19,10 +19,7 @@ import re
 import sys
 import logging
 
-try:
-    from xml.etree import cElementTree as ElementTree
-except ImportError:
-    from xml.etree import ElementTree
+from xml.etree import ElementTree
 
 # Make sure we're using Babel source, and not some previously installed version
 CHECKOUT_ROOT = os.path.abspath(os.path.join(


### PR DESCRIPTION
I came across `shutil.get_terminal_size()` and remembered there was a homespun implementation of it in the downloader script, so this replaces it, and fixes up the downloader a bit in other senses too.

I also realized there were some no-longer-relevant import guards around, so away with them too.