### PR TITLE
Remove `__nonzero__` methods

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -92,10 +92,8 @@ class _NormalizedString:
     def denormalize(self):
         return ''.join(map(unescape, self._strs))
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self._strs)
-
-    __bool__ = __nonzero__
 
     def __repr__(self):
         return os.linesep.join(self._strs)

--- a/babel/support.py
+++ b/babel/support.py
@@ -192,7 +192,7 @@ class LazyProxy:
     def __contains__(self, key):
         return key in self.value
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.value)
 
     def __dir__(self):


### PR DESCRIPTION
`__nonzero__` is not used in python3, instead we now use `__bool__`.
Since `setup.py` declares to support `python >= 3.6`, I guess it is safe to remove these methods.

`setup.py`: https://github.com/python-babel/babel/blob/d8584405a66a79d79bed44b5d80df0bc89f8eee3/setup.py#L59
