### PR TITLE
Remove superfluous `__unicode__` declarations

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1281,9 +1281,6 @@ class DateTimePattern:
     def __repr__(self):
         return '<%s %r>' % (type(self).__name__, self.pattern)
 
-    def __unicode__(self):
-        return self.pattern
-
     def __str__(self):
         pat = self.pattern
         return pat

--- a/babel/support.py
+++ b/babel/support.py
@@ -207,9 +207,6 @@ class LazyProxy:
     def __str__(self):
         return str(self.value)
 
-    def __unicode__(self):
-        return unicode(self.value)
-
     def __add__(self, other):
         return self.value + other
 


### PR DESCRIPTION
The `__unicode__` protocol is not used in python3, and furthermore the `unicode()` builtin does not exist anymore.

I found this while browsing through the source code and given that babel requires ≥3.6 I thought I could just open a PR.