### PR TITLE
Add support for compact decimal formats

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -565,6 +565,18 @@ class Locale:
         return self._data['decimal_formats']
 
     @property
+    def compact_decimal_formats(self):
+        """Locale patterns for compact decimal number formatting.
+
+        .. note:: The format of the value returned may change between
+                  Babel versions.
+
+        >>> Locale('en', 'US').compact_decimal_formats["short"]["one"]["1000"]
+        <NumberPattern u'0K'>
+        """
+        return self._data['compact_decimal_formats']
+
+    @property
     def currency_formats(self):
         """Locale patterns for currency number formatting.
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -770,8 +770,6 @@ def parse_decimal_formats(data, tree):
 
                     # These are mapped into a `compact_decimal_formats` dictionary
                     # with the format {length: {count: {multiplier: pattern}}}.
-
-                    # TODO: Add support for formatting them.
                     compact_decimal_formats = data.setdefault('compact_decimal_formats', {})
                     length_map = compact_decimal_formats.setdefault(length_type, {})
                     length_count_map = length_map.setdefault(pattern_el.attrib['count'], {})

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -121,6 +121,33 @@ class FormatDecimalTestCase(unittest.TestCase):
         assert numbers.format_currency(101299.98, 'EUR', locale='en_US', group_separator=True, format_type='name') == u'101,299.98 euros'
         assert numbers.format_percent(251234.1234, locale='sv_SE', group_separator=True) == u'25\xa0123\xa0412\xa0%'
 
+    def test_compact(self):
+        assert numbers.format_decimal(1, locale='en_US', compact="short") == u'1'
+        assert numbers.format_decimal(999, locale='en_US', compact="short") == u'999'
+        assert numbers.format_decimal(1000, locale='en_US', compact="short") == u'1K'
+        assert numbers.format_decimal(9000, locale='en_US', compact="short") == u'9K'
+        assert numbers.format_decimal(9123, locale='en_US', compact="short", compact_fraction_digits=2) == u'9.12K'
+        assert numbers.format_decimal(10000, locale='en_US', compact="short") == u'10K'
+        assert numbers.format_decimal(10000, locale='en_US', compact="short", compact_fraction_digits=2) == u'10K'
+        assert numbers.format_decimal(1000000, locale='en_US', compact="short") == u'1M'
+        assert numbers.format_decimal(9000999, locale='en_US', compact="short") == u'9M'
+        assert numbers.format_decimal(9000900099, locale='en_US', compact="short", compact_fraction_digits=5) == u'9.0009B'
+        assert numbers.format_decimal(1, locale='en_US', compact="long") == u'1'
+        assert numbers.format_decimal(999, locale='en_US', compact="long") == u'999'
+        assert numbers.format_decimal(1000, locale='en_US', compact="long") == u'1 thousand'
+        assert numbers.format_decimal(9000, locale='en_US', compact="long") == u'9 thousand'
+        assert numbers.format_decimal(9000, locale='en_US', compact="long", compact_fraction_digits=2) == u'9 thousand'
+        assert numbers.format_decimal(10000, locale='en_US', compact="long") == u'10 thousand'
+        assert numbers.format_decimal(10000, locale='en_US', compact="long", compact_fraction_digits=2) == u'10 thousand'
+        assert numbers.format_decimal(1000000, locale='en_US', compact="long") == u'1 million'
+        assert numbers.format_decimal(9999999, locale='en_US', compact="long") == u'10 million'
+        assert numbers.format_decimal(9999999999, locale='en_US', compact="long", compact_fraction_digits=5) == u'10 billion'
+        assert numbers.format_decimal(1, locale='ja_JP', compact="short") == u'1'
+        assert numbers.format_decimal(999, locale='ja_JP', compact="short") == u'999'
+        assert numbers.format_decimal(1000, locale='ja_JP', compact="short") == u'1000'
+        assert numbers.format_decimal(9123, locale='ja_JP', compact="short") == u'9123'
+        assert numbers.format_decimal(10000, locale='ja_JP', compact="short") == u'1万'
+        assert numbers.format_decimal(1234567, locale='ja_JP', compact="long") == u'123万'
 
 class NumberParsingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Adds support for compact decimal formats.

Implementation based on details found at https://www.unicode.org/reports/tr35/tr35-45/tr35-numbers.html#Compact_Number_Formats

```py
>>> format_decimal(12345, locale='en_US', compact="short")
u'12K'
>>> format_decimal(12345, locale='en_US', compact="long")
u'12 thousand'
>>> format_decimal(12345, locale='en_US', compact="short", compact_fraction_digits=2)
u'12.35K'
>>> format_decimal(1234567, locale='ja_JP', compact="short")
u'123万'
```

Closes #908 