### PR TITLE
feat: Adds `Format.compact_decimal` utility

### DIFF
--- a/babel/support.py
+++ b/babel/support.py
@@ -18,7 +18,7 @@ from babel.core import Locale
 from babel.dates import format_date, format_datetime, format_time, \
     format_timedelta
 from babel.numbers import format_decimal, format_currency, \
-    format_percent, format_scientific
+    format_percent, format_scientific, format_compact_decimal
 
 
 class Format:
@@ -107,6 +107,17 @@ class Format:
         u'1.234'
         """
         return format_decimal(number, format, locale=self.locale)
+
+    def compact_decimal(self, number, format_type='short', fraction_digits=0):
+        """Return a number formatted in compact form for the locale.
+
+        >>> fmt = Format('en_US')
+        >>> fmt.compact_decimal(123456789)
+        u'123M'
+        """
+        return format_compact_decimal(number, format_type=format_type,
+                                      fraction_digits=fraction_digits,
+                                      locale=self.locale)
 
     def currency(self, number, currency):
         """Return a number in the given currency formatted for the locale.

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -329,6 +329,11 @@ def test_format_decimal():
     assert fmt.decimal(1.2345) == '1.234'
 
 
+def test_format_compact_decimal():
+    fmt = support.Format('en_US')
+    assert fmt.compact_decimal(1234567, format_type='long', fraction_digits=2) == '1.23 million'
+
+
 def test_format_percent():
     fmt = support.Format('en_US')
     assert fmt.percent(0.34) == '34%'


### PR DESCRIPTION
Adds a shortcut to Format support utility for `compact_decimal`

```py
>>> fmt = Format('en_US')
>>> fmt.compact_decimal(123456789)
u'123M'
```