### PR TITLE
Cast number to Decimal in _get_compact_format

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -455,6 +455,7 @@ def _get_compact_format(number, compact_format, locale, fraction_digits=0):
     https://www.unicode.org/reports/tr35/tr35-45/tr35-numbers.html#Compact_Number_Formats.
     """
     format = None
+    number = float(number)
     for magnitude in sorted([int(m) for m in compact_format["other"]], reverse=True):
         if abs(number) >= magnitude:
             # check the pattern using "other" as the amount

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -426,7 +426,7 @@ def format_compact_decimal(number, *, format_type="short", locale=LC_NUMERIC, fr
     >>> format_compact_decimal(12345, format_type="long", locale='en_US')
     u'12 thousand'
     >>> format_compact_decimal(12345, format_type="short", locale='en_US', fraction_digits=2)
-    u'12.35K'
+    u'12.34K'
     >>> format_compact_decimal(1234567, format_type="short", locale="ja_JP")
     u'123万'
     >>> format_compact_decimal(2345678, format_type="long", locale="mk")
@@ -454,8 +454,9 @@ def _get_compact_format(number, compact_format, locale, fraction_digits=0):
     The algorithm is described here:
     https://www.unicode.org/reports/tr35/tr35-45/tr35-numbers.html#Compact_Number_Formats.
     """
+    if not isinstance(number, decimal.Decimal):
+        number = decimal.Decimal(str(number))
     format = None
-    number = float(number)
     for magnitude in sorted([int(m) for m in compact_format["other"]], reverse=True):
         if abs(number) >= magnitude:
             # check the pattern using "other" as the amount
@@ -466,7 +467,7 @@ def _get_compact_format(number, compact_format, locale, fraction_digits=0):
                 break
             # otherwise, we need to divide the number by the magnitude but remove zeros
             # equal to the number of 0's in the pattern minus 1
-            number = number / (magnitude / (10 ** (pattern.count("0") - 1)))
+            number = number / (magnitude // (10 ** (pattern.count("0") - 1)))
             # round to the number of fraction digits requested
             number = round(number, fraction_digits)
             # if the remaining number is singular, use the singular format

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -154,6 +154,8 @@ class FormatDecimalTestCase(unittest.TestCase):
         assert numbers.format_compact_decimal(-123456789, format_type='long', locale='en_US') == u'-123 million'
         assert numbers.format_compact_decimal(2345678, locale='mk', format_type='long') == u'2 милиони'
         assert numbers.format_compact_decimal(21098765, locale='mk', format_type='long') == u'21 милион'
+        assert numbers.format_compact_decimal(decimal.Decimal(123456789), format_type='short', locale='en_US') == u'123M'
+        assert numbers.format_compact_decimal('123456789', format_type='short', locale='en_US') == u'123M'
 
 class NumberParsingTestCase(unittest.TestCase):
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -154,8 +154,6 @@ class FormatDecimalTestCase(unittest.TestCase):
         assert numbers.format_compact_decimal(-123456789, format_type='long', locale='en_US') == u'-123 million'
         assert numbers.format_compact_decimal(2345678, locale='mk', format_type='long') == u'2 милиони'
         assert numbers.format_compact_decimal(21098765, locale='mk', format_type='long') == u'21 милион'
-        assert numbers.format_compact_decimal(decimal.Decimal(123456789), format_type='short', locale='en_US') == u'123M'
-        assert numbers.format_compact_decimal('123456789', format_type='short', locale='en_US') == u'123M'
 
 class NumberParsingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #929 

Division does not work with decimal.Decimal. This uses `//` so integer division is performed instead.

`abs` and `round` don't work with strings. This converts the number to a Decimal so that `_get_compact_format` won't raise a ValueError as long as the number supports Decimal conversion. Also has a fix for how [rounding modes](https://babel.pocoo.org/en/latest/numbers.html#rounding-modes) are treated.

This adds support for `decimal.Decimal` and `str` types to the number parameter of `format_compact_*` functions.

```py
>>> from babel.numbers import *
>>> import decimal
>>> format_compact_decimal(decimal.Decimal("1000"))
"1K"
>>> format_compact_decimal("1000")
"1K"
```