### PR TITLE
Fix compact singular formats and patterns with no numbers

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -474,8 +474,6 @@ def _get_compact_format(number, compact_format, locale, fraction_digits=0):
                 plural_form = "other"
             if number == 1 and "1" in compact_format:
                 plural_form = "1"
-            elif number == 0 and "0" in compact_format:
-                plural_form = "0"
             format = compact_format[plural_form][str(magnitude)]
             number = rounded
             break

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -17,6 +17,7 @@
 # TODO:
 #  Padding and rounding increments in pattern:
 #  - https://www.unicode.org/reports/tr35/ (Appendix G.6)
+from __future__ import annotations
 import decimal
 import re
 from datetime import date as date_, datetime as datetime_
@@ -967,7 +968,8 @@ def parse_pattern(pattern):
 class NumberPattern:
 
     def __init__(self, pattern, prefix, suffix, grouping,
-                 int_prec, frac_prec, exp_prec, exp_plus, number_pattern=None):
+                 int_prec, frac_prec, exp_prec, exp_plus,
+                 number_pattern: str | None = None):
         # Metadata of the decomposed parsed pattern.
         self.pattern = pattern
         self.prefix = prefix

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -431,7 +431,7 @@ def format_compact_decimal(number, *, format_type="short", locale=LC_NUMERIC, fr
     u'123万'
     >>> format_compact_decimal(2345678, format_type="long", locale="mk")
     u'2 милиони'
-    >>> format_compact_decimal(21098765, format_type="long", locale="mk")
+    >>> format_compact_decimal(21000000, format_type="long", locale="mk")
     u'21 милион'
 
     :param number: the number to format
@@ -467,11 +467,17 @@ def _get_compact_format(number, compact_format, locale, fraction_digits=0):
             # equal to the number of 0's in the pattern minus 1
             number = number / (magnitude / (10 ** (pattern.count("0") - 1)))
             # round to the number of fraction digits requested
-            number = round(number, fraction_digits)
+            rounded = round(number, fraction_digits)
             # if the remaining number is singular, use the singular format
             plural_form = locale.plural_form(abs(number))
-            plural_form = plural_form if plural_form in compact_format else "other"
+            if plural_form not in compact_format:
+                plural_form = "other"
+            if number == 1 and "1" in compact_format:
+                plural_form = "1"
+            elif number == 0 and "0" in compact_format:
+                plural_form = "0"
             format = compact_format[plural_form][str(magnitude)]
+            number = rounded
             break
     return number, format
 
@@ -957,17 +963,18 @@ def parse_pattern(pattern):
     return NumberPattern(pattern, (pos_prefix, neg_prefix),
                          (pos_suffix, neg_suffix), grouping,
                          int_prec, frac_prec,
-                         exp_prec, exp_plus)
+                         exp_prec, exp_plus, number)
 
 
 class NumberPattern:
 
     def __init__(self, pattern, prefix, suffix, grouping,
-                 int_prec, frac_prec, exp_prec, exp_plus):
+                 int_prec, frac_prec, exp_prec, exp_plus, number_pattern=None):
         # Metadata of the decomposed parsed pattern.
         self.pattern = pattern
         self.prefix = prefix
         self.suffix = suffix
+        self.number_pattern = number_pattern
         self.grouping = grouping
         self.int_prec = int_prec
         self.frac_prec = frac_prec
@@ -1112,7 +1119,7 @@ class NumberPattern:
 
         retval = ''.join([
             self.prefix[is_negative],
-            number,
+            number if self.number_pattern != '' else '',
             self.suffix[is_negative]])
 
         if u'¤' in retval:

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from babel import numbers
+
+x = numbers.format_compact_decimal(21000000, locale='mk', format_type='long')
+
+print(x)

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from babel import numbers
-
-x = numbers.format_compact_decimal(21000000, locale='mk', format_type='long')
-
-print(x)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -153,7 +153,11 @@ class FormatDecimalTestCase(unittest.TestCase):
         assert numbers.format_compact_decimal(-123456789, format_type='short', locale='en_US') == u'-123M'
         assert numbers.format_compact_decimal(-123456789, format_type='long', locale='en_US') == u'-123 million'
         assert numbers.format_compact_decimal(2345678, locale='mk', format_type='long') == u'2 милиони'
-        assert numbers.format_compact_decimal(21098765, locale='mk', format_type='long') == u'21 милион'
+        assert numbers.format_compact_decimal(21000000, locale='mk', format_type='long') == u'21 милион'
+        assert numbers.format_compact_decimal(1000, locale='it', format_type='long') == u'mille'
+        assert numbers.format_compact_decimal(1234, locale='it', format_type='long') == u'1 mila'
+        assert numbers.format_compact_decimal(1000, locale='fr', format_type='long') == u'mille'
+        assert numbers.format_compact_decimal(1234, locale='fr', format_type='long') == u'1 millier'
 
 class NumberParsingTestCase(unittest.TestCase):
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -154,6 +154,7 @@ class FormatDecimalTestCase(unittest.TestCase):
         assert numbers.format_compact_decimal(-123456789, format_type='long', locale='en_US') == u'-123 million'
         assert numbers.format_compact_decimal(2345678, locale='mk', format_type='long') == u'2 милиони'
         assert numbers.format_compact_decimal(21000000, locale='mk', format_type='long') == u'21 милион'
+        assert numbers.format_compact_decimal(21345, locale="gv", format_type="short") == u'21K'
         assert numbers.format_compact_decimal(1000, locale='it', format_type='long') == u'mille'
         assert numbers.format_compact_decimal(1234, locale='it', format_type='long') == u'1 mila'
         assert numbers.format_compact_decimal(1000, locale='fr', format_type='long') == u'mille'


### PR DESCRIPTION
Fixes #931

* Adds support for patterns with no numbers
* In compact format, only uses "one" format if the number pluralizes to "one" *before* rounding
* In compact format, [explicit "1" formats](https://unicode.org/reports/tr35/tr35-numbers.html#Explicit_0_1_rules) can now be applied (there [seem to be none](https://gist.github.com/DenverCoder1/9c34fb012cefdc75f8d53724c24fe260) with explicit "0" formats)

```py
>>> numbers.format_compact_decimal(1000, format_type='long', locale='it')
'mille'  # previously 'mille1'
>>> numbers.format_decimal(1, format="mille")
'mille'  # previously 'mille1'
>>> format_compact_decimal(21098765, format_type="long", locale="mk")
'21 милиони'  # previously '21 милион' (would still be singular if the number were 21000000)
>>> numbers.format_compact_decimal(1000, format_type='long', locale='fr')
'mille'  # previously '1 millier'
```