### PR TITLE
ci: Fix testing dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install tox tox-gh-actions==2.1.0
+        python -m pip install tox<4.0.0 tox-gh-actions==2.12.0
     - name: Run test via Tox
       run: tox --skip-missing-interpreters
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install tox<4.0.0 tox-gh-actions==2.12.0
+        python -m pip install 'tox<4.0.0' 'tox-gh-actions==2.12.0'
     - name: Run test via Tox
       run: tox --skip-missing-interpreters
       env:


### PR DESCRIPTION
`tox-gh-actions` v2 does not support `tox` v4.

Since tox does not have a version specified, this was causing the workflow to fail.

When `tox-gh-actions` v3 is released, `tox` can change to v4.