### PR TITLE
Add negative sign after currency names (#937)

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -916,7 +916,7 @@ def parse_pattern(pattern):
         neg_prefix, _, neg_suffix = _match_number(neg_pattern)
     else:
         pos_prefix, number, pos_suffix = _match_number(pos_pattern)
-        neg_prefix = f"-{pos_prefix}"
+        neg_prefix = f"-{pos_prefix}" if '¤' not in pattern else f'{pos_prefix}-'
         neg_suffix = pos_suffix
     if 'E' in number:
         number, exp = number.split('E', 1)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -427,7 +427,7 @@ def test_format_compact_currency():
     assert numbers.format_compact_currency(999, 'USD', locale='en_US', format_type="short") == u'$999'
     assert numbers.format_compact_currency(123456789, 'USD', locale='en_US', format_type="short") == u'$123M'
     assert numbers.format_compact_currency(123456789, 'USD', locale='en_US', fraction_digits=2, format_type="short") == u'$123.46M'
-    assert numbers.format_compact_currency(-123456789, 'USD', locale='en_US', fraction_digits=2, format_type="short") == u'-$123.46M'
+    assert numbers.format_compact_currency(-123456789, 'USD', locale='en_US', fraction_digits=2, format_type="short") == u'$-123.46M'
     assert numbers.format_compact_currency(1, 'JPY', locale='ja_JP', format_type="short") == u'￥1'
     assert numbers.format_compact_currency(1234, 'JPY', locale='ja_JP', format_type="short") == u'￥1234'
     assert numbers.format_compact_currency(123456, 'JPY', locale='ja_JP', format_type="short") == u'￥12万'
@@ -675,7 +675,7 @@ def test_parse_pattern_negative():
 
     # No negative format specified
     np = numbers.parse_pattern(u'¤#,##0.00')
-    assert np.prefix == (u'¤', u'-¤')
+    assert np.prefix == (u'¤', u'¤-')
     assert np.suffix == (u'', u'')
 
     # Negative format is specified


### PR DESCRIPTION
This PR changes `babel.numbers.parse_pattern` to move the negative sign to the end of the prefix if the format string includes a placeholder for a currency name.  It updates some tests.