### PR TITLE
Unify datetime imports

### DIFF
--- a/babel/localtime/__init__.py
+++ b/babel/localtime/__init__.py
@@ -11,7 +11,7 @@
 
 import sys
 import time
-from datetime import datetime, timedelta, tzinfo
+import datetime
 from threading import RLock
 
 if sys.platform == 'win32':
@@ -23,34 +23,34 @@ else:
 _cached_tz = None
 _cache_lock = RLock()
 
-STDOFFSET = timedelta(seconds=-time.timezone)
+STDOFFSET = datetime.timedelta(seconds=-time.timezone)
 if time.daylight:
-    DSTOFFSET = timedelta(seconds=-time.altzone)
+    DSTOFFSET = datetime.timedelta(seconds=-time.altzone)
 else:
     DSTOFFSET = STDOFFSET
 
 DSTDIFF = DSTOFFSET - STDOFFSET
-ZERO = timedelta(0)
+ZERO = datetime.timedelta(0)
 
 
-class _FallbackLocalTimezone(tzinfo):
+class _FallbackLocalTimezone(datetime.tzinfo):
 
-    def utcoffset(self, dt: datetime) -> timedelta:
+    def utcoffset(self, dt: datetime.datetime) -> datetime.timedelta:
         if self._isdst(dt):
             return DSTOFFSET
         else:
             return STDOFFSET
 
-    def dst(self, dt: datetime) -> timedelta:
+    def dst(self, dt: datetime.datetime) -> datetime.timedelta:
         if self._isdst(dt):
             return DSTDIFF
         else:
             return ZERO
 
-    def tzname(self, dt: datetime) -> str:
+    def tzname(self, dt: datetime.datetime) -> str:
         return time.tzname[self._isdst(dt)]
 
-    def _isdst(self, dt: datetime) -> bool:
+    def _isdst(self, dt: datetime.datetime) -> bool:
         tt = (dt.year, dt.month, dt.day,
               dt.hour, dt.minute, dt.second,
               dt.weekday(), 0, -1)
@@ -59,7 +59,7 @@ class _FallbackLocalTimezone(tzinfo):
         return tt.tm_isdst > 0
 
 
-def get_localzone() -> tzinfo:
+def get_localzone() -> datetime.tzinfo:
     """Returns the current underlying local timezone object.
     Generally this function does not need to be used, it's a
     better idea to use the :data:`LOCALTZ` singleton instead.

--- a/babel/localtime/_unix.py
+++ b/babel/localtime/_unix.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from datetime import tzinfo
+import datetime
 
 from babel.localtime._helpers import (
     _get_tzinfo_from_file,
@@ -9,7 +9,7 @@ from babel.localtime._helpers import (
     _get_tzinfo,
 )
 
-def _tz_from_env(tzenv: str) -> tzinfo:
+def _tz_from_env(tzenv: str) -> datetime.tzinfo:
     if tzenv[0] == ':':
         tzenv = tzenv[1:]
 
@@ -21,7 +21,7 @@ def _tz_from_env(tzenv: str) -> tzinfo:
     return _get_tzinfo_or_raise(tzenv)
 
 
-def _get_localzone(_root: str = '/') -> tzinfo:
+def _get_localzone(_root: str = '/') -> datetime.tzinfo:
     """Tries to find the local timezone configuration.
     This method prefers finding the timezone name and passing that to
     zoneinfo or pytz, over passing in the localtime file, as in the later

--- a/babel/localtime/_win32.py
+++ b/babel/localtime/_win32.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     winreg = None
 
-from datetime import tzinfo
+import datetime
 from babel.core import get_global
 from babel.localtime._helpers import _get_tzinfo_or_raise
 from typing import Any, Dict, cast
@@ -89,7 +89,7 @@ def get_localzone_name() -> str:
     return timezone
 
 
-def _get_localzone() -> tzinfo:
+def _get_localzone() -> datetime.tzinfo:
     if winreg is None:
         raise LookupError(
             'Runtime support not available')

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -13,7 +13,7 @@ import re
 
 from collections import OrderedDict
 from collections.abc import Generator, Iterable, Iterator
-from datetime import datetime, time as time_
+import datetime
 from difflib import get_close_matches
 from email import message_from_string
 from copy import copy
@@ -45,10 +45,10 @@ PYTHON_FORMAT = re.compile(r'''
 ''', re.VERBOSE)
 
 
-def _parse_datetime_header(value: str) -> datetime:
+def _parse_datetime_header(value: str) -> datetime.datetime:
     match = re.match(r'^(?P<datetime>.*?)(?P<tzoffset>[+-]\d{4})?$', value)
 
-    dt = datetime.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
+    dt = datetime.datetime.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
 
     # Separate the offset into a sign component, hours, and # minutes
     tzoffset = match.group('tzoffset')
@@ -261,8 +261,8 @@ class Catalog:
         version: str | None = None,
         copyright_holder: str | None = None,
         msgid_bugs_address: str | None = None,
-        creation_date: datetime | str | None = None,
-        revision_date: datetime | time_ | float | str | None = None,
+        creation_date: datetime.datetime | str | None = None,
+        revision_date: datetime.datetime | datetime.time | float | str | None = None,
         last_translator: str | None = None,
         language_team: str | None = None,
         charset: str | None = None,
@@ -306,13 +306,13 @@ class Catalog:
         self.charset = charset or 'utf-8'
 
         if creation_date is None:
-            creation_date = datetime.now(LOCALTZ)
-        elif isinstance(creation_date, datetime) and not creation_date.tzinfo:
+            creation_date = datetime.datetime.now(LOCALTZ)
+        elif isinstance(creation_date, datetime.datetime) and not creation_date.tzinfo:
             creation_date = creation_date.replace(tzinfo=LOCALTZ)
         self.creation_date = creation_date
         if revision_date is None:
             revision_date = 'YEAR-MO-DA HO:MI+ZONE'
-        elif isinstance(revision_date, datetime) and not revision_date.tzinfo:
+        elif isinstance(revision_date, datetime.datetime) and not revision_date.tzinfo:
             revision_date = revision_date.replace(tzinfo=LOCALTZ)
         self.revision_date = revision_date
         self.fuzzy = fuzzy
@@ -354,7 +354,7 @@ class Catalog:
 
     def _get_header_comment(self) -> str:
         comment = self._header_comment
-        year = datetime.now(LOCALTZ).strftime('%Y')
+        year = datetime.datetime.now(LOCALTZ).strftime('%Y')
         if hasattr(self.revision_date, 'strftime'):
             year = self.revision_date.strftime('%Y')
         comment = comment.replace('PROJECT', self.project) \
@@ -409,7 +409,7 @@ class Catalog:
         headers.append(('POT-Creation-Date',
                         format_datetime(self.creation_date, 'yyyy-MM-dd HH:mmZ',
                                         locale='en')))
-        if isinstance(self.revision_date, (datetime, time_, int, float)):
+        if isinstance(self.revision_date, (datetime.datetime, datetime.time, int, float)):
             headers.append(('PO-Revision-Date',
                             format_datetime(self.revision_date,
                                             'yyyy-MM-dd HH:mmZ', locale='en')))
@@ -481,6 +481,7 @@ class Catalog:
     Here's an example of the output for such a catalog template:
 
     >>> from babel.dates import UTC
+    >>> from datetime import datetime
     >>> created = datetime(1990, 4, 1, 15, 30, tzinfo=UTC)
     >>> catalog = Catalog(project='Foobar', version='1.0',
     ...                   creation_date=created)

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 from collections import OrderedDict
 from configparser import RawConfigParser
-from datetime import datetime
+import datetime
 from io import StringIO
 
 from babel import __version__ as VERSION
@@ -662,7 +662,7 @@ class init_catalog(Command):
             catalog = read_po(infile, locale=self.locale)
 
         catalog.locale = self._locale
-        catalog.revision_date = datetime.now(LOCALTZ)
+        catalog.revision_date = datetime.datetime.now(LOCALTZ)
         catalog.fuzzy = False
 
         with open(self.output_file, 'wb') as outfile:
@@ -818,7 +818,7 @@ class update_catalog(Command):
                     catalog = read_po(infile, locale=self.locale)
 
                 catalog.locale = self._locale
-                catalog.revision_date = datetime.now(LOCALTZ)
+                catalog.revision_date = datetime.datetime.now(LOCALTZ)
                 catalog.fuzzy = False
 
                 with open(filename, 'wb') as outfile:

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -23,7 +23,7 @@ import decimal
 import re
 from typing import TYPE_CHECKING, Any, overload
 import warnings
-from datetime import date as date_, datetime as datetime_
+import datetime
 
 from babel.core import Locale, default_locale, get_global
 from babel.localedata import LocaleDataDict
@@ -200,8 +200,8 @@ def get_currency_unit_pattern(
 @overload
 def get_territory_currencies(
     territory: str,
-    start_date: date_ | None = ...,
-    end_date: date_ | None = ...,
+    start_date: datetime.date | None = ...,
+    end_date: datetime.date | None = ...,
     tender: bool = ...,
     non_tender: bool = ...,
     include_details: Literal[False] = ...,
@@ -212,8 +212,8 @@ def get_territory_currencies(
 @overload
 def get_territory_currencies(
     territory: str,
-    start_date: date_ | None = ...,
-    end_date: date_ | None = ...,
+    start_date: datetime.date | None = ...,
+    end_date: datetime.date | None = ...,
     tender: bool = ...,
     non_tender: bool = ...,
     include_details: Literal[True] = ...,
@@ -223,8 +223,8 @@ def get_territory_currencies(
 
 def get_territory_currencies(
     territory: str,
-    start_date: date_ | None = None,
-    end_date: date_ | None = None,
+    start_date: datetime.date | None = None,
+    end_date: datetime.date | None = None,
     tender: bool = True,
     non_tender: bool = False,
     include_details: bool = False,
@@ -280,12 +280,12 @@ def get_territory_currencies(
     """
     currencies = get_global('territory_currencies')
     if start_date is None:
-        start_date = date_.today()
-    elif isinstance(start_date, datetime_):
+        start_date = datetime.date.today()
+    elif isinstance(start_date, datetime.datetime):
         start_date = start_date.date()
     if end_date is None:
         end_date = start_date
-    elif isinstance(end_date, datetime_):
+    elif isinstance(end_date, datetime.datetime):
         end_date = end_date.date()
 
     curs = currencies.get(territory.upper(), ())
@@ -298,9 +298,9 @@ def get_territory_currencies(
     result = []
     for currency_code, start, end, is_tender in curs:
         if start:
-            start = date_(*start)
+            start = datetime.date(*start)
         if end:
-            end = date_(*end)
+            end = datetime.date(*end)
         if ((is_tender and tender) or
                 (not is_tender and non_tender)) and _is_active(start, end):
             if include_details:

--- a/babel/support.py
+++ b/babel/support.py
@@ -71,7 +71,7 @@ class Format:
 
     def datetime(
         self,
-        datetime: datetime.date | datetime.datetime | None = None,
+        datetime: datetime.date | None = None,
         format: _PredefinedTimeFormat | str = 'medium',
     ) -> str:
         """Return a date and time formatted according to the given pattern.

--- a/babel/support.py
+++ b/babel/support.py
@@ -16,14 +16,8 @@ import decimal
 import gettext
 import locale
 import os
+import datetime
 from collections.abc import Iterator
-from datetime import (
-    date as _date,
-    datetime as _datetime,
-    time as _time,
-    timedelta as _timedelta,
-    tzinfo
-)
 from typing import TYPE_CHECKING, Any, Callable
 
 from babel.core import Locale
@@ -52,7 +46,7 @@ class Format:
     u'1.234'
     """
 
-    def __init__(self, locale: Locale | str, tzinfo: tzinfo | None = None) -> None:
+    def __init__(self, locale: Locale | str, tzinfo: datetime.tzinfo | None = None) -> None:
         """Initialize the formatter.
 
         :param locale: the locale identifier or `Locale` instance
@@ -61,7 +55,11 @@ class Format:
         self.locale = Locale.parse(locale)
         self.tzinfo = tzinfo
 
-    def date(self, date: _date | None = None, format: _PredefinedTimeFormat | str = 'medium') -> str:
+    def date(
+        self,
+        date: datetime.date | None = None,
+        format: _PredefinedTimeFormat | str = 'medium',
+    ) -> str:
         """Return a date formatted according to the given pattern.
 
         >>> from datetime import date
@@ -71,7 +69,11 @@ class Format:
         """
         return format_date(date, format, locale=self.locale)
 
-    def datetime(self, datetime: _date | None = None, format: _PredefinedTimeFormat | str = 'medium') -> str:
+    def datetime(
+        self,
+        datetime: datetime.date | datetime.datetime | None = None,
+        format: _PredefinedTimeFormat | str = 'medium',
+    ) -> str:
         """Return a date and time formatted according to the given pattern.
 
         >>> from datetime import datetime
@@ -79,10 +81,13 @@ class Format:
         >>> fmt.datetime(datetime(2007, 4, 1, 15, 30))
         u'Apr 1, 2007, 11:30:00 AM'
         """
-        return format_datetime(datetime, format, tzinfo=self.tzinfo,
-                               locale=self.locale)
+        return format_datetime(datetime, format, tzinfo=self.tzinfo, locale=self.locale)
 
-    def time(self, time: _time | _datetime | None = None, format: _PredefinedTimeFormat | str = 'medium') -> str:
+    def time(
+        self,
+        time: datetime.time | datetime.datetime | None = None,
+        format: _PredefinedTimeFormat | str = 'medium',
+    ) -> str:
         """Return a time formatted according to the given pattern.
 
         >>> from datetime import datetime
@@ -94,7 +99,7 @@ class Format:
 
     def timedelta(
         self,
-        delta: _timedelta | int,
+        delta: datetime.timedelta | int,
         granularity: Literal["year", "month", "week", "day", "hour", "minute", "second"] = "second",
         threshold: float = 0.85,
         format: Literal["narrow", "short", "medium", "long"] = "long",

--- a/babel/util.py
+++ b/babel/util.py
@@ -17,7 +17,7 @@ import textwrap
 from babel import localtime, dates
 
 from collections.abc import Generator, Iterable
-from datetime import datetime as datetime_, timedelta, tzinfo
+import datetime
 from typing import IO, Any, TypeVar
 
 missing = object()
@@ -225,12 +225,12 @@ def wraptext(text: str, width: int = 70, initial_indent: str = '', subsequent_in
 odict = collections.OrderedDict
 
 
-class FixedOffsetTimezone(tzinfo):
+class FixedOffsetTimezone(datetime.tzinfo):
     """Fixed offset in minutes east from UTC."""
 
     def __init__(self, offset: float, name: str | None = None) -> None:
 
-        self._offset = timedelta(minutes=offset)
+        self._offset = datetime.timedelta(minutes=offset)
         if name is None:
             name = 'Etc/GMT%+d' % offset
         self.zone = name
@@ -241,13 +241,13 @@ class FixedOffsetTimezone(tzinfo):
     def __repr__(self) -> str:
         return f'<FixedOffset "{self.zone}" {self._offset}>'
 
-    def utcoffset(self, dt: datetime_) -> timedelta:
+    def utcoffset(self, dt: datetime.datetime) -> datetime.timedelta:
         return self._offset
 
-    def tzname(self, dt: datetime_) -> str:
+    def tzname(self, dt: datetime.datetime) -> str:
         return self.zone
 
-    def dst(self, dt: datetime_) -> timedelta:
+    def dst(self, dt: datetime.datetime) -> datetime.timedelta:
         return ZERO
 
 


### PR DESCRIPTION
Various modules in Babel imported `datetime` in various ways, sometimes needing aliases and whatnot; this commit unifies everything to `import datetime`.