### PR TITLE
Keep @modifiers when parsing locales

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -1245,6 +1245,9 @@ def get_locale_identifier(tup: tuple[str, str | None, str | None, str | None, st
 
     >>> get_locale_identifier(('de', 'DE', None, '1999', 'custom'))
     'de_DE_1999@custom'
+    >>> get_locale_identifier(('fi', None, None, None, 'custom'))
+    'fi@custom'
+
 
     .. versionadded:: 1.0
 

--- a/babel/core.py
+++ b/babel/core.py
@@ -182,7 +182,7 @@ class Locale:
         :param territory: the territory (country or region) code
         :param script: the script code
         :param variant: the variant code
-        :param modifier: a modifier ('@variant')
+        :param modifier: a modifier (following the '@' symbol, sometimes called '@variant')
         :raise `UnknownLocaleError`: if no locale data is available for the
                                      requested locale
         """

--- a/babel/core.py
+++ b/babel/core.py
@@ -457,7 +457,7 @@ class Locale:
             if self.variant:
                 details.append(locale.variants.get(self.variant))
             if self.modifier:
-                details.append(locale.modifiers.get(self.modifier))
+                details.append(self.modifier)
             details = filter(None, details)
             if details:
                 retval += f" ({', '.join(details)})"
@@ -584,24 +584,6 @@ class Locale:
         u'Alte deutsche Rechtschreibung'
         """
         return self._data['variants']
-
-    @property
-    def modifiers(self) -> localedata.LocaleDataDict:
-        """Identity mapping of modifiers with "@" prefixed (Temporary implementation)
-
-        TODO: This is not yet implemented, as it would need modification of the
-        locale_data files, so instead it just returns the key for now, with "@"
-        prefixed.
-
-        >>> Locale('de', 'DE').modifiers['euro']
-        u'@euro'
-        """
-
-        class IdentityDict(localedata.LocaleDataDict):
-            def __getitem__(self, key: str) -> Any:
-                return f'@{key!s}'
-
-        return IdentityDict(self._data)
 
     # { Number Formatting
 

--- a/babel/core.py
+++ b/babel/core.py
@@ -1174,6 +1174,8 @@ def parse_locale(
     ('it', 'IT', None, None, 'euro')
     >>> parse_locale('it_IT@custom')
     ('it', 'IT', None, None, 'custom')
+    >>> parse_locale('it_IT@')
+    ('it', 'IT', None, None, None)
 
     The default component separator is "_", but a different separator can be
     specified using the `sep` parameter. Note that an optional modifier is
@@ -1206,10 +1208,7 @@ def parse_locale(
     :raise `ValueError`: if the string does not appear to be a valid locale
                          identifier
     """
-    modifier = None
-    if '@' in identifier:
-        identifier, modifier = identifier.split('@', 1)
-
+    identifier, _, modifier = identifier.partition('@')
     if '.' in identifier:
         # this is probably the charset/encoding, which we don't care about
         identifier = identifier.split('.', 1)[0]
@@ -1238,7 +1237,7 @@ def parse_locale(
     if parts:
         raise ValueError(f"{identifier!r} is not a valid locale identifier")
 
-    return lang, territory, script, variant, modifier
+    return lang, territory, script, variant, (modifier or None)
 
 
 def get_locale_identifier(tup: tuple[str, str | None, str | None, str | None, str | None], sep: str = '_') -> str:

--- a/babel/core.py
+++ b/babel/core.py
@@ -1257,6 +1257,6 @@ def get_locale_identifier(tup: tuple[str, str | None, str | None, str | None, st
     :param sep: the separator for the identifier.
     """
     tup = tuple(tup[:5])
-    lang, territory, script, variant, modifier = tup + (None,) * (4 - len(tup))
+    lang, territory, script, variant, modifier = tup + (None,) * (5 - len(tup))
     ret = sep.join(filter(None, (lang, script, territory, variant)))
     return f'{ret}@{modifier}' if modifier else ret

--- a/babel/core.py
+++ b/babel/core.py
@@ -1238,7 +1238,14 @@ def parse_locale(
         return lang, territory, script, variant
 
 
-def get_locale_identifier(tup: tuple[str, str | None, str | None, str | None, str | None], sep: str = '_') -> str:
+def get_locale_identifier(
+    tup: tuple[str]
+    | tuple[str, str | None]
+    | tuple[str, str | None, str | None]
+    | tuple[str, str | None, str | None, str | None]
+    | tuple[str, str | None, str | None, str | None, str | None],
+    sep: str = "_",
+) -> str:
     """The reverse of :func:`parse_locale`.  It creates a locale identifier out
     of a ``(language, territory, script, variant, modifier)`` tuple.  Items can be set to
     ``None`` and trailing ``None``\\s can also be left out of the tuple.

--- a/babel/core.py
+++ b/babel/core.py
@@ -1184,6 +1184,8 @@ def parse_locale(
 
     >>> parse_locale('zh-CN', sep='-')
     ('zh', 'CN', None, None, None)
+    >>> parse_locale('zh-CN@custom', sep='-')
+    ('zh', 'CN', None, None, 'custom')
 
     If the identifier cannot be parsed into a locale, a `ValueError` exception
     is raised:

--- a/babel/core.py
+++ b/babel/core.py
@@ -1178,8 +1178,9 @@ def parse_locale(
     ('it', 'IT', None, None, None)
 
     The default component separator is "_", but a different separator can be
-    specified using the `sep` parameter. Note that an optional modifier is
-    always appended and separated with "@":
+    specified using the `sep` parameter.
+
+    The optional modifier is always separated with "@" and at the end:
 
     >>> parse_locale('zh-CN', sep='-')
     ('zh', 'CN', None, None, None)

--- a/babel/core.py
+++ b/babel/core.py
@@ -199,8 +199,8 @@ class Locale:
         self.__data = None
 
         identifier = str(self)
-        withoutmodifier = identifier.split('@', 1)[0]
-        if not localedata.exists(withoutmodifier):
+        identifier_without_modifier = identifier.partition('@')[0]
+        if not localedata.exists(identifier_without_modifier):
             raise UnknownLocaleError(identifier)
 
     @classmethod

--- a/babel/core.py
+++ b/babel/core.py
@@ -1153,8 +1153,10 @@ def negotiate_locale(preferred: Iterable[str], available: Iterable[str], sep: st
     return None
 
 
-def parse_locale(identifier: str, sep: str = '_') \
-        -> tuple[str, str | None, str | None, str | None, str | None]:
+def parse_locale(
+    identifier: str,
+    sep: str = '_'
+) -> tuple[str, str | None, str | None, str | None, str | None]:
     """Parse a locale identifier into a tuple of the form ``(language,
     territory, script, variant, modifier)``.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -274,9 +274,9 @@ def test_negotiate_locale():
 
 
 def test_parse_locale():
-    assert core.parse_locale('zh_CN') == ('zh', 'CN', None, None, None)
-    assert core.parse_locale('zh_Hans_CN') == ('zh', 'CN', 'Hans', None, None)
-    assert core.parse_locale('zh-CN', sep='-') == ('zh', 'CN', None, None, None)
+    assert core.parse_locale('zh_CN') == ('zh', 'CN', None, None)
+    assert core.parse_locale('zh_Hans_CN') == ('zh', 'CN', 'Hans', None)
+    assert core.parse_locale('zh-CN', sep='-') == ('zh', 'CN', None, None)
 
     with pytest.raises(ValueError) as excinfo:
         core.parse_locale('not_a_LOCALE_String')
@@ -286,7 +286,7 @@ def test_parse_locale():
     assert core.parse_locale('it_IT@euro') == ('it', 'IT', None, None, 'euro')
     assert core.parse_locale('it_IT@something') == ('it', 'IT', None, None, 'something')
 
-    assert core.parse_locale('en_US.UTF-8') == ('en', 'US', None, None, None)
+    assert core.parse_locale('en_US.UTF-8') == ('en', 'US', None, None)
     assert (core.parse_locale('de_DE.iso885915@euro') ==
             ('de', 'DE', None, None, 'euro'))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -274,19 +274,21 @@ def test_negotiate_locale():
 
 
 def test_parse_locale():
-    assert core.parse_locale('zh_CN') == ('zh', 'CN', None, None)
-    assert core.parse_locale('zh_Hans_CN') == ('zh', 'CN', 'Hans', None)
-    assert core.parse_locale('zh-CN', sep='-') == ('zh', 'CN', None, None)
+    assert core.parse_locale('zh_CN') == ('zh', 'CN', None, None, None)
+    assert core.parse_locale('zh_Hans_CN') == ('zh', 'CN', 'Hans', None, None)
+    assert core.parse_locale('zh-CN', sep='-') == ('zh', 'CN', None, None, None)
 
     with pytest.raises(ValueError) as excinfo:
         core.parse_locale('not_a_LOCALE_String')
     assert (excinfo.value.args[0] ==
             "'not_a_LOCALE_String' is not a valid locale identifier")
 
-    assert core.parse_locale('it_IT@euro') == ('it', 'IT', None, None)
-    assert core.parse_locale('en_US.UTF-8') == ('en', 'US', None, None)
+    assert core.parse_locale('it_IT@euro') == ('it', 'IT', None, None, 'euro')
+    assert core.parse_locale('it_IT@something') == ('it', 'IT', None, None, 'something')
+
+    assert core.parse_locale('en_US.UTF-8') == ('en', 'US', None, None, None)
     assert (core.parse_locale('de_DE.iso885915@euro') ==
-            ('de', 'DE', None, None))
+            ('de', 'DE', None, None, 'euro'))
 
 
 @pytest.mark.parametrize('filename', [


### PR DESCRIPTION
Locale modifiers ("@variants") are described in the GNU gettext documentation like this:

> The ‘@variant’ can denote any kind of characteristics that is not
> already implied by the language ll and the country CC. […] It can also
> denote a dialect of the language, …

Wherein Babel previously would discard these, this patch stores the modifier information in the `Locale` objects, handling string representation accordingly.

Not implemented is the lookup of a meaningful description of modifiers, but instead — for now — an identity mapping is provided.

All tests pass. Furthermore, integration with `flask-babel` has been verified to work.

Resolves: #946
Signed-off-by: martin f. krafft <madduck@madduck.net>