### PR TITLE
Update test dependencies (tox v4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install 'tox<4.0.0' 'tox-gh-actions==2.12.0'
+        python -m pip install 'tox~=4.0' 'tox-gh-actions~=3.0'
     - name: Run test via Tox
       run: tox --skip-missing-interpreters
       env:
         COVERAGE_XML_PATH: ${{ runner.temp }}
-    - uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v3
       with:
         directory: ${{ runner.temp }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install 'tox~=4.0' 'tox-gh-actions~=3.0'
+        python -m pip install 'tox~=4.0' 'tox-gh~=1.0'
     - name: Run test via Tox
       run: tox --skip-missing-interpreters
       env:

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     freezegun==0.3.12
     backports.zoneinfo;python_version<"3.9"
     tzdata;sys_platform == 'win32'
-whitelist_externals = make
+allowlist_externals = make
 commands = make clean-cldr test
 setenv =
     PYTEST_FLAGS=--cov=babel --cov-report=xml:{env:COVERAGE_XML_PATH:.coverage_cache}/coverage.{envname}.xml

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,11 @@ passenv =
     PYTEST_*
     PYTHON_*
 
-[gh-actions]
+[gh]
 python =
-    pypy3: pypy3
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
+    pypy3 = pypy3
+    3.7 = py37
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310
+    3.11 = py311


### PR DESCRIPTION
Since tox-gh-actions has a stable release supporting tox v4, both dependencies can be updated.

To test with tox v4, `whitelist_externals` needs to be replaced with `allowlist_externals`.

Also updates codecov/codecov-action from v2 to v3.

* https://tox.wiki/en/latest/upgrading.html
* https://github.com/codecov/codecov-action#migration-from-v1-to-v3