### PR TITLE
Support for formatting NaN, Infinity

### DIFF
--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -118,6 +118,8 @@ class FormatDecimalTestCase(unittest.TestCase):
         assert numbers.format_compact_decimal(decimal.Decimal('Infinity'), locale='en_US', format_type="short") == '∞'
         assert numbers.format_compact_decimal(decimal.Decimal('-Infinity'), locale='en_US', format_type="short") == '-∞'
         assert numbers.format_compact_decimal(decimal.Decimal('NaN'), locale='en_US', format_type="short") == 'NaN'
+        assert numbers.format_currency(decimal.Decimal('Infinity'), 'USD', locale='en_US') == '$∞'
+        assert numbers.format_currency(decimal.Decimal('-Infinity'), 'USD', locale='en_US') == '-$∞'
 
     def test_group_separator(self):
         assert numbers.format_decimal(29567.12, locale='en_US', group_separator=False) == '29567.12'

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -111,6 +111,14 @@ class FormatDecimalTestCase(unittest.TestCase):
         number = decimal.Decimal("7E-7")
         assert numbers.format_decimal(number, format="@@@", locale='en_US') == '0.000000700'
 
+    def test_nan_and_infinity(self):
+        assert numbers.format_decimal(decimal.Decimal('Infinity'), locale='en_US') == '∞'
+        assert numbers.format_decimal(decimal.Decimal('-Infinity'), locale='en_US') == '-∞'
+        assert numbers.format_decimal(decimal.Decimal('NaN'), locale='en_US') == 'NaN'
+        assert numbers.format_compact_decimal(decimal.Decimal('Infinity'), locale='en_US', format_type="short") == '∞'
+        assert numbers.format_compact_decimal(decimal.Decimal('-Infinity'), locale='en_US', format_type="short") == '-∞'
+        assert numbers.format_compact_decimal(decimal.Decimal('NaN'), locale='en_US', format_type="short") == 'NaN'
+
     def test_group_separator(self):
         assert numbers.format_decimal(29567.12, locale='en_US', group_separator=False) == '29567.12'
         assert numbers.format_decimal(29567.12, locale='fr_CA', group_separator=False) == '29567,12'


### PR DESCRIPTION
This came up while I was looking for ways to improve type-safety - specifically that the type of `decimal_tuple.exponent` in `get_decimal_precision()` is `int | Literal['n', 'N', 'F']` and can't be compared with 0 or taken the absolute value of if it is not an int.

This fixes that type issue but I'm making this a separate PR since it also fixes NaN and Infinity cases in other areas, so it won't raise exceptions when formatting.

Fixes #132 

```py
>>> format_decimal(decimal.Decimal('Infinity'))
'∞'
>>> format_decimal(decimal.Decimal('-Infinity'))
'-∞'
>>> format_decimal(decimal.Decimal('NaN'))
'NaN'
```