### PR TITLE
Fix unbound `exc` in babel.dates

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -243,18 +243,17 @@ def get_timezone(zone: str | datetime.tzinfo | None = None) -> datetime.tzinfo:
     if not isinstance(zone, str):
         return zone
 
-    exc = None
     if pytz:
         try:
             return pytz.timezone(zone)
-        except pytz.UnknownTimeZoneError as exc:  # noqa: F841
-            pass
+        except pytz.UnknownTimeZoneError as e:
+            exc = e
     else:
         assert zoneinfo
         try:
             return zoneinfo.ZoneInfo(zone)
-        except zoneinfo.ZoneInfoNotFoundError as exc:  # noqa: F841
-            pass
+        except zoneinfo.ZoneInfoNotFoundError as e:
+            exc = e
 
     raise LookupError(f"Unknown timezone {zone}") from exc
 


### PR DESCRIPTION
See https://stackoverflow.com/a/24271786/51685

My bad! I had remembered the behavior to be like with Python 2...