### PR TITLE
Include `py.typed` file in wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     ],
     python_requires='>=3.7',
     packages=['babel', 'babel.messages', 'babel.localtime'],
+    package_data={"babel": ["py.typed"]},
     include_package_data=True,
     install_requires=[
         # This version identifier is currently necessary as


### PR DESCRIPTION
#934 by @DenverCoder1 added inline type annotations and a `py.typed` file, which is great! Unfortunately, however, the `py.typed` file hasn't been included in wheels published to PyPI for v2.12.0. This means that if I `pip install` babel locally, mypy still doesn't recognise `babel` as a typed library. Running mypy on a file with just `import babel` in it results in this output from mypy (unless the typeshed `types-babel` package is installed):

```
test.py:1: error: Library stubs not installed for "babel"  [import]
test.py:1: note: Hint: "python3 -m pip install types-babel"
test.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
test.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

The fix is simple: just a one-line addition to `setup.py`.

Closes #795 (which should maybe have been closed after #934).