### PR TITLE
Note that `Locale.parse()` does not accept `None`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Deprecations & breaking changes
 
 * Python 3.6 is no longer supported (:gh:`919`) - Aarni Koskela
 * The `get_next_timezone_transition` function is no more (:gh:`958`) - Aarni Koskela
+* `Locale.parse()` will no longer return `None`; it will always return a Locale or raise an exception.
+  Passing in `None`, though technically allowed by the typing, will raise. (:gh:`966`)
 
 New features
 ~~~~~~~~~~~~

--- a/babel/core.py
+++ b/babel/core.py
@@ -279,6 +279,15 @@ class Locale:
         >>> Locale.parse(l)
         Locale('de', territory='DE')
 
+        If the `identifier` parameter is neither of these, such as `None`
+        e.g. because a default locale identifier could not be determined,
+        a `TypeError` is raised:
+
+        >>> Locale.parse(None)
+        Traceback (most recent call last):
+            ...
+        TypeError: ...
+
         This also can perform resolving of likely subtags which it does
         by default.  This is for instance useful to figure out the most
         likely locale for a territory you can use ``'und'`` as the


### PR DESCRIPTION
Refs #977