### PR TITLE
Add flag to ignore POT-Creation-Date for updates

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -769,7 +769,7 @@ class Catalog:
         no_fuzzy_matching: bool = False,
         update_header_comment: bool = False,
         keep_user_comments: bool = True,
-        ignore_pot_creation_date: bool = False,
+        update_creation_date: bool = True,
     ) -> None:
         """Update the catalog based on the given template catalog.
 
@@ -908,7 +908,7 @@ class Catalog:
 
         # Make updated catalog's POT-Creation-Date equal to the template
         # used to update the catalog
-        if not ignore_pot_creation_date:
+        if update_creation_date:
             self.creation_date = template.creation_date
 
     def _to_fuzzy_match_key(self, key: tuple[str, str] | str) -> str:

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -769,6 +769,7 @@ class Catalog:
         no_fuzzy_matching: bool = False,
         update_header_comment: bool = False,
         keep_user_comments: bool = True,
+        ignore_pot_creation_date: bool = False,
     ) -> None:
         """Update the catalog based on the given template catalog.
 
@@ -907,7 +908,8 @@ class Catalog:
 
         # Make updated catalog's POT-Creation-Date equal to the template
         # used to update the catalog
-        self.creation_date = template.creation_date
+        if not ignore_pot_creation_date:
+            self.creation_date = template.creation_date
 
     def _to_fuzzy_match_key(self, key: tuple[str, str] | str) -> str:
         """Converts a message key to a string suitable for fuzzy matching."""

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -727,11 +727,13 @@ class update_catalog(Command):
          'don\'t update the catalog, just return the status. Return code 0 '
          'means nothing would change. Return code 1 means that the catalog '
          'would be updated'),
+        ('ignore-pot-creation-date=', None,
+         'ignore changes to POT-Creation-Date when updating or checking'),
     ]
     boolean_options = [
         'omit-header', 'no-wrap', 'ignore-obsolete', 'init-missing',
         'no-fuzzy-matching', 'previous', 'update-header-comment',
-        'check',
+        'check', 'ignore-pot-creation-date',
     ]
 
     def initialize_options(self):
@@ -749,6 +751,7 @@ class update_catalog(Command):
         self.update_header_comment = False
         self.previous = False
         self.check = False
+        self.ignore_pot_creation_date = False
 
     def finalize_options(self):
         if not self.input_file:
@@ -837,7 +840,8 @@ class update_catalog(Command):
 
             catalog.update(
                 template, self.no_fuzzy_matching,
-                update_header_comment=self.update_header_comment
+                update_header_comment=self.update_header_comment,
+                ignore_pot_creation_date=self.ignore_pot_creation_date,
             )
 
             tmpname = os.path.join(os.path.dirname(filename),

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -841,7 +841,7 @@ class update_catalog(Command):
             catalog.update(
                 template, self.no_fuzzy_matching,
                 update_header_comment=self.update_header_comment,
-                ignore_pot_creation_date=self.ignore_pot_creation_date,
+                update_creation_date=not self.ignore_pot_creation_date,
             )
 
             tmpname = os.path.join(os.path.dirname(filename),

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -281,7 +281,7 @@ including versions of Lorem Ipsum."
         assert template.creation_date == localized_catalog.creation_date
         template.creation_date = datetime.datetime.now() - \
             datetime.timedelta(minutes=5)
-        localized_catalog.update(template, ignore_pot_creation_date=True)
+        localized_catalog.update(template, update_creation_date=False)
         assert template.creation_date != localized_catalog.creation_date
 
     def test_update_po_keeps_po_revision_date(self):

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -273,6 +273,17 @@ including versions of Lorem Ipsum."
         localized_catalog.update(template)
         assert template.creation_date == localized_catalog.creation_date
 
+    def test_update_po_ignores_pot_creation_date(self):
+        template = catalog.Catalog()
+        localized_catalog = copy.deepcopy(template)
+        localized_catalog.locale = 'de_DE'
+        assert template.mime_headers != localized_catalog.mime_headers
+        assert template.creation_date == localized_catalog.creation_date
+        template.creation_date = datetime.datetime.now() - \
+            datetime.timedelta(minutes=5)
+        localized_catalog.update(template, ignore_pot_creation_date=True)
+        assert template.creation_date != localized_catalog.creation_date
+
     def test_update_po_keeps_po_revision_date(self):
         template = catalog.Catalog()
         localized_catalog = copy.deepcopy(template)


### PR DESCRIPTION
Adding a flag to ignore changes to POT-Creation-Date when performing updates or checks. 
I use a CI check that ensures my .po files are updated before merging, but there is always a diff on POT-Creation-Date.

Related to https://github.com/python-babel/babel/issues/725 - but solving (my) problem via update instead of extract.