### PR TITLE
Allow alternative space characters as group separator when parsing numbers

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -998,6 +998,15 @@ class NumberFormatError(ValueError):
         self.suggestions = suggestions
 
 
+SPACE_CHARS = {
+    ' ',  # space
+    '\xa0',  # no-break space
+    '\u202f',  # narrow no-break space
+}
+
+SPACE_CHARS_RE = re.compile('|'.join(SPACE_CHARS))
+
+
 def parse_number(
     string: str,
     locale: Locale | str | None = LC_NUMERIC,
@@ -1029,12 +1038,12 @@ def parse_number(
     group_symbol = get_group_symbol(locale, numbering_system=numbering_system)
 
     if (
-        re.match(r'\s', group_symbol) and  # if the grouping symbol is a kind of space,
+        group_symbol in SPACE_CHARS and  # if the grouping symbol is a kind of space,
         group_symbol not in string and  # and the string to be parsed does not contain it,
-        re.search(r'\s', string)  # but it does contain any other kind of space instead,
+        SPACE_CHARS_RE.search(string)  # but it does contain any other kind of space instead,
     ):
         # ... it's reasonable to assume it is taking the place of the grouping symbol.
-        string = re.sub(r'\s', group_symbol, string)
+        string = SPACE_CHARS_RE.sub(group_symbol, string)
 
     try:
         return int(string.replace(group_symbol, ''))
@@ -1095,12 +1104,12 @@ def parse_decimal(
     decimal_symbol = get_decimal_symbol(locale, numbering_system=numbering_system)
 
     if not strict and (
-        re.match(r'\s', group_symbol) and  # if the grouping symbol is a kind of space,
+        group_symbol in SPACE_CHARS and  # if the grouping symbol is a kind of space,
         group_symbol not in string and  # and the string to be parsed does not contain it,
-        re.search(r'\s', string)  # but it does contain any other kind of space instead,
+        SPACE_CHARS_RE.search(string)  # but it does contain any other kind of space instead,
     ):
         # ... it's reasonable to assume it is taking the place of the grouping symbol.
-        string = re.sub(r'\s', group_symbol, string)
+        string = SPACE_CHARS_RE.sub(group_symbol, string)
 
     try:
         parsed = decimal.Decimal(string.replace(group_symbol, '')

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -751,6 +751,15 @@ def test_parse_number():
     with pytest.raises(numbers.UnsupportedNumberingSystemError):
         numbers.parse_number('1.099,98', locale='en', numbering_system="unsupported")
 
+@pytest.mark.parametrize('string', [
+    '1 099',
+    '1\xa0099',
+    '1\u202f099',
+])
+def test_parse_number_group_separator_can_be_any_space(string):
+    assert numbers.parse_number(string, locale='fr') == 1099
+
+
 def test_parse_decimal():
     assert (numbers.parse_decimal('1,099.98', locale='en_US')
             == decimal.Decimal('1099.98'))
@@ -759,6 +768,15 @@ def test_parse_decimal():
     with pytest.raises(numbers.NumberFormatError) as excinfo:
         numbers.parse_decimal('2,109,998', locale='de')
     assert excinfo.value.args[0] == "'2,109,998' is not a valid decimal number"
+
+
+@pytest.mark.parametrize('string', [
+    '1 099,98',
+    '1\xa0099,98',
+    '1\u202f099,98',
+])
+def test_parse_decimal_group_separator_can_be_any_space(string):
+    assert decimal.Decimal('1099.98') == numbers.parse_decimal(string, locale='fr')
 
 
 def test_parse_grouping():


### PR DESCRIPTION
## Context

The French group separator is `"\u202f"` (narrow non-breaking space), but when parsing numbers in the real world, you will most often encounter either a regular space character (`" "`) or a non-breaking space character (`"\xa0"`).

The issue was partially adressed earlier in https://github.com/python-babel/babel/issues/637, but only to allow regular spaces instead of non-breaking spaces `"\xa0"` in `parse_decimal`.
 
## Contents

This PR goes further by changing both `parse_number` and `parse_decimal` to allow ~~any other space character (using the `\s` character class of regular expressions)~~ any of those 3 space characters when the expected group symbol is itself one such space character, but is not present in the string to parse.

Unit tests are included.
