### PR TITLE
Use aware UTC datetimes internally

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -112,7 +112,7 @@ def _get_tz_name(dt_or_tzinfo: _DtOrTzinfo) -> str:
     elif hasattr(tzinfo, 'key') and tzinfo.key is not None:  # ZoneInfo object
         return tzinfo.key
     else:
-        return tzinfo.tzname(dt or datetime.datetime.utcnow())
+        return tzinfo.tzname(dt or datetime.datetime.now(UTC))
 
 
 def _get_datetime(instant: _Instant) -> datetime.datetime:
@@ -147,9 +147,9 @@ def _get_datetime(instant: _Instant) -> datetime.datetime:
     :rtype: datetime
     """
     if instant is None:
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(UTC).replace(tzinfo=None)
     elif isinstance(instant, (int, float)):
-        return datetime.datetime.utcfromtimestamp(instant)
+        return datetime.datetime.fromtimestamp(instant, UTC).replace(tzinfo=None)
     elif isinstance(instant, datetime.time):
         return datetime.datetime.combine(datetime.date.today(), instant)
     elif isinstance(instant, datetime.date) and not isinstance(instant, datetime.datetime):
@@ -201,9 +201,9 @@ def _get_time(
     :rtype: time
     """
     if time is None:
-        time = datetime.datetime.utcnow()
+        time = datetime.datetime.now(UTC)
     elif isinstance(time, (int, float)):
-        time = datetime.datetime.utcfromtimestamp(time)
+        time = datetime.datetime.fromtimestamp(time, UTC)
 
     if time.tzinfo is None:
         time = time.replace(tzinfo=UTC)

--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -67,9 +67,9 @@ local time when returning dates to users.  At that point the timezone the
 user has selected can usually be established and Babel can automatically
 rebase the time for you.
 
-To get the current time use the :meth:`~datetime.datetime.utcnow` method
-of the :class:`~datetime.datetime` object.  It will return a naive
-:class:`~datetime.datetime` object in UTC.
+To get the current time use the :meth:`~datetime.datetime.now` method
+of the :class:`~datetime.datetime` object,
+passing :attr:`~datetime.timezone.utc` to it as the timezone.
 
 For more information about timezones see :ref:`timezone-support`.
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -17,7 +17,7 @@ import freezegun
 import pytest
 
 from babel import Locale, dates
-from babel.dates import NO_INHERITANCE_MARKER, _localize
+from babel.dates import NO_INHERITANCE_MARKER, UTC, _localize
 from babel.util import FixedOffsetTimezone
 
 
@@ -542,7 +542,7 @@ def test_get_timezone_name_time_pytz(timezone_getter, tzname, params, expected):
 
 
 def test_get_timezone_name_misc(timezone_getter):
-    localnow = datetime.utcnow().replace(tzinfo=timezone_getter('UTC')).astimezone(dates.LOCALTZ)
+    localnow = datetime.now(timezone_getter('UTC')).astimezone(dates.LOCALTZ)
     assert (dates.get_timezone_name(None, locale='en_US') ==
             dates.get_timezone_name(localnow, locale='en_US'))
 
@@ -703,7 +703,7 @@ def test_zh_TW_format():
 
 
 def test_format_current_moment():
-    frozen_instant = datetime.utcnow()
+    frozen_instant = datetime.now(UTC)
     with freezegun.freeze_time(time_to_freeze=frozen_instant):
         assert dates.format_datetime(locale="en_US") == dates.format_datetime(frozen_instant, locale="en_US")
 


### PR DESCRIPTION
Avoids deprecation warnings on Python 3.12.