### PR TITLE
Depend on setuptools since Python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setup(
         # higher.
         # Python 3.9 and later include zoneinfo which replaces pytz
         'pytz>=2015.7; python_version<"3.9"',
+        # https://github.com/python/cpython/issues/95299
+        # https://github.com/python-babel/babel/issues/1031
+        'setuptools; python_version>="3.12"',
     ],
     extras_require={
         'dev': [

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,6 @@ envlist =
 extras =
     dev
 deps =
-    # including setuptools here for CI;
-    #   see https://github.com/python/cpython/issues/95299
-    #   see https://github.com/python-babel/babel/issues/1005#issuecomment-1728105742
-    setuptools;python_version>="3.12"
     backports.zoneinfo;python_version<"3.9"
     tzdata;sys_platform == 'win32'
     pytz: pytz


### PR DESCRIPTION
The dependency was already added specifically for CI, but that is not correct, because it's the package itself that actually depends on setuptools

* Fixes #1031