### PR TITLE
Fix for #990 (updated)

### DIFF
--- a/babel/localtime/_unix.py
+++ b/babel/localtime/_unix.py
@@ -39,7 +39,10 @@ def _get_localzone(_root: str = '/') -> datetime.tzinfo:
     # zone on operating systems like OS X.  On OS X especially this is the
     # only one that actually works.
     try:
-        link_dst = os.readlink('/etc/localtime')
+        # Make sure the path is normalized so that it will be parsed correctly
+        # below, e.g. 'Etc//UTC' is a valid path but not a valid zoneinfo key.
+        # <https://github.com/python-babel/babel/issues/990>
+        link_dst = os.path.realpath('/etc/localtime')
     except OSError:
         pass
     else:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'dev': [
             'pytest>=6.0',
             'pytest-cov',
+            'pyfakefs~=5.0',
             'freezegun~=1.0',
         ],
     },

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1,0 +1,93 @@
+""" Unit tests for the 'localtime' module.
+
+There are separate test cases for Unix and Win32, only one of which will be
+executed.
+
+"""
+import datetime
+import pytest
+import sys
+import os.path
+from pathlib import Path
+
+from babel.localtime import get_localzone, LOCALTZ
+
+
+_timezones = {
+    "Etc/UTC": "UTC",
+    "America/New_York": "EDT",  # DST
+    "Europe/Paris": "CEST",  # DST
+}
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix tests")
+@pytest.mark.usefixtures("fs")  # provided by 'pyfakefs'
+class TestUnixLocaltime:
+    """ Tests for the `localtime` module in a Unix environment.
+
+    Unix relies heavily on files to configure the system time zone, so the
+    'pyfakefs' library is used here to isolate tests from the local file
+    system: <https://pypi.org/project/pyfakefs/>.
+
+    """
+    @pytest.fixture
+    def zoneinfo(self, fs) -> Path:
+        """ Provide access to the system TZ info directory.
+
+        :return: directory path
+        """
+        # Reproducing a working zoneinfo database in the test environment would
+        # be a hassle, so add access to the system database. This assumes the
+        # test system follows the convention of linking `/etc/localtime` to the
+        # system's TZ info file somewhere in a `zoneinfo/` hierarchy.
+        # <https://www.unix.com/man-page/linux/4/zoneinfo>
+        fs.add_real_symlink("/etc/localtime")
+        parts = list(Path("/etc/localtime").readlink().parts)
+        while parts and parts[-1] != "zoneinfo":
+            # Find the 'zoneinfo' root.
+            del parts[-1]
+        zoneinfo = Path(*parts)
+        fs.add_real_directory(zoneinfo)
+        return zoneinfo
+
+    @pytest.fixture(params=_timezones.items())
+    def timezone(self, zoneinfo, request) -> str:
+        """ Set the test time zone.
+
+        :return: time zone name, *i.e..* ZoneInfo.tzname()
+        """
+        # As with the `zoneinfo` fixture, this assumes the test system uses a
+        # standard-ish Unix implementation where `/etc/localtime` can be used
+        # to set the time zone.
+        # <https://www.unix.com/man-page/linux/4/zoneinfo>
+        key, name = request.param
+        os.remove("/etc/localtime")
+        os.symlink(f"{zoneinfo}/{key}", "/etc/localtime")
+        return name
+
+    def test_get_localzone(self, zoneinfo, timezone):
+        """ Test the get_localtime() function.
+
+        """
+        dst = datetime.datetime(2023, 7, 1)  # testing DST time zone names
+        assert get_localzone().tzname(dst) == timezone
+
+    def test_localtz(self, zoneinfo):
+        """ Test the LOCALTZ module attribute.
+
+        """
+        assert LOCALTZ == get_localzone()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Win32 tests")
+class TestWin32Localtime:
+    """ Tests for the `localtime` module in a Windows environment.
+
+    """
+    # This is just a placeholder and basic smoke test for now.
+    # TODO: Add relevant tests.
+    def test_localtz(self):
+        """ Test the LOCALTZ module attribute.
+
+        """
+        assert LOCALTZ == get_localzone()


### PR DESCRIPTION
**This is an update of https://github.com/python-babel/babel/pull/1006 that incorporates upstream fixes to previously-broken tests. It should pass all CI checks now.**

This PR:

- Adds some basic tests for the `localtime` module (developed on macOS, test stub added for Windows)
- Fixes #990

