### PR TITLE
Fix _locales_to_names (Fix for #1037)

### DIFF
--- a/babel/support.py
+++ b/babel/support.py
@@ -705,7 +705,7 @@ def _locales_to_names(
     if locales is None:
         return None
     if isinstance(locales, Locale):
-        return [str(locale)]
+        return [str(locales)]
     if isinstance(locales, str):
         return [locales]
     return [str(locale) for locale in locales]


### PR DESCRIPTION
Call str() on the parameter variable instead of the module object.