### PR TITLE
CI: use GitHub output formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       run: tox --skip-missing-interpreters
       env:
         COVERAGE_XML_PATH: ${{ runner.temp }}
+        BABEL_TOX_EXTRA_DEPS: pytest-github-actions-annotate-failures
     - uses: codecov/codecov-action@v3
       with:
         directory: ${{ runner.temp }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pre-commit/action@v3.0.0
+        env:
+          RUFF_OUTPUT_FORMAT: github
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 extras =
     dev
 deps =
+    {env:BABEL_TOX_EXTRA_DEPS:}
     backports.zoneinfo;python_version<"3.9"
     tzdata;sys_platform == 'win32'
     pytz: pytz
@@ -23,6 +24,8 @@ passenv =
     BABEL_*
     PYTEST_*
     PYTHON_*
+    # To let pytest-github-actions-annotate-failures know it's running in GitHub Actions:
+    GITHUB_ACTIONS
 
 [gh-actions]
 python =


### PR DESCRIPTION
Makes it easier to see issues directly in the output.