### PR TITLE
Support multiple units in format_timedelta()

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -967,10 +967,10 @@ def format_timedelta(
             if pattern is None:
                 return ''
             if (depth=='shallow'):
-                formatted_string = ' '.join([formatted_string, pattern.replace('{0}', str(value))])
+                formatted_string = ' '.join(filter(None, [formatted_string, pattern.replace('{0}', str(value))]))
                 break
             elif ((depth=='full' and value > 0) or depth == 'fullest'):
-                formatted_string = ' '.join([formatted_string, pattern.replace('{0}', str(value))])
+                formatted_string = ' '.join(filter(None, [formatted_string, pattern.replace('{0}', str(value))]))
                 seconds = seconds - value * secs_per_unit
 
     return formatted_string


### PR DESCRIPTION
Issue #728 describes returning measures for several units when using format_timedelta().

E.g. instead of 

```
10840 seconds
3 hours
```
return for depth=="fullest"

`3 hours 0 minutes 40 seconds`

and for depth=="full"

`3 hours 40 seconds`

Tests are passing, but I haven't tried contributing to babel before, and am not aware of any additional requirements beyond the few lines of source code in this PR. Feedback appreciated.