### PR TITLE
Make pgettext search plurals when translation is not found

### DIFF
--- a/babel/support.py
+++ b/babel/support.py
@@ -466,10 +466,12 @@ class NullTranslations(gettext.NullTranslations):
         missing = object()
         tmsg = self._catalog.get(ctxt_msg_id, missing)
         if tmsg is missing:
-            if self._fallback:
-                return self._fallback.pgettext(context, message)
-            return message
-        return tmsg
+            tmsg = self._catalog.get((ctxt_msg_id, self.plural(1)), missing)
+        if tmsg is not missing:
+            return tmsg
+        if self._fallback:
+            return self._fallback.pgettext(context, message)
+        return message
 
     def lpgettext(self, context: str, message: str) -> str | bytes | object:
         """Equivalent to ``pgettext()``, but the translation is returned in the

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -71,6 +71,8 @@ class TranslationsTestCase(unittest.TestCase):
         self.assertEqualTypeToo('Voh', self.translations.gettext('foo'))
         self.assertEqualTypeToo('VohCTX', self.translations.pgettext('foo',
                                                                      'foo'))
+        self.assertEqualTypeToo('VohCTX1', self.translations.pgettext('foo',
+                                                                      'foo1'))
 
     def test_upgettext(self):
         self.assertEqualTypeToo('Voh', self.translations.ugettext('foo'))

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -74,6 +74,12 @@ class TranslationsTestCase(unittest.TestCase):
         self.assertEqualTypeToo('VohCTX1', self.translations.pgettext('foo',
                                                                       'foo1'))
 
+    def test_pgettext_fallback(self):
+        fallback = self.translations._fallback
+        self.translations._fallback = support.NullTranslations()
+        assert self.translations.pgettext('foo', 'bar') == 'bar'
+        self.translations._fallback = fallback
+
     def test_upgettext(self):
         self.assertEqualTypeToo('Voh', self.translations.ugettext('foo'))
         self.assertEqualTypeToo('VohCTX', self.translations.upgettext('foo',


### PR DESCRIPTION
Given this po file:

```po
msgctxt "ctx"
msgid "foo"
msgid_plural "foos"
msgstr[0] "foo translated"
```

`pgettext` fails to find the singular translation i.e. `pgettext("ctx", "foo") == "foo"` when one would expect to get `foo translated`.

The same issue has already been fixed upstream in `gettext`: 
https://github.com/python/cpython/issues/62519
https://github.com/python/cpython/pull/107118

This PR applies the same patch to babel.