### PR TITLE
Fix for PyBabel Compatibility with Python 3.12 and Third-Party Extractors

### DIFF
--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -171,9 +171,17 @@ def _find_checkers() -> list[Callable[[Catalog | None, Message], object]]:
     except ImportError:
         pass
     else:
-        for entry_point in entry_points():
-            if entry_point.group=='babel.checkers':
+        eps = entry_points()
+        if isinstance(eps, dict):
+            # Old structure before Python 3.10
+            group_entries = eps.get('babel.checkers', [])
+            for entry_point in group_entries:
                 checkers.append(entry_point.load())
+        else:
+            # New structure in Python 3.10+
+            for entry_point in eps:
+                if entry_point.group == 'babel.checkers':
+                    checkers.append(entry_point.load())
         if checkers:
             return checkers
 

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -157,14 +157,15 @@ def _validate_format(format: str, alternative: str) -> None:
 def _find_checkers() -> list[Callable[[Catalog | None, Message], object]]:
     checkers: list[Callable[[Catalog | None, Message], object]] = []
     try:
-        from pkg_resources import working_set
+        from importlib.metadata import entry_points
     except ImportError:
         pass
     else:
-        for entry_point in working_set.iter_entry_points('babel.checkers'):
+        eps = entry_points(group='babel.checkers')
+        for entry_point in eps:
             checkers.append(entry_point.load())
     if len(checkers) == 0:
-        # if pkg_resources is not available or no usable egg-info was found
+        # if importlib.metadata is not available or no usable entry point was found
         # (see #230), just resort to hard-coded checkers
         return [num_plurals, python_format]
     return checkers

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -422,16 +422,15 @@ def extract(
         func = getattr(__import__(module, {}, {}, [attrname]), attrname)
     else:
         try:
-            from pkg_resources import working_set
+            from importlib.metadata import entry_points
         except ImportError:
             pass
         else:
-            for entry_point in working_set.iter_entry_points(GROUP_NAME,
-                                                             method):
-                func = entry_point.load(require=True)
+            for entry_point in entry_points(group=GROUP_NAME, name=method):
+                func = entry_point.load()
                 break
         if func is None:
-            # if pkg_resources is not available or no usable egg-info was found
+            # if importlib.metadata is not available or no usable entry point was found
             # (see #230), we resort to looking up the builtin extractors
             # directly
             builtin = {

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -436,10 +436,23 @@ def extract(
             except ImportError:
                 pass
             else:
-                for entry_point in entry_points():
-                    if entry_point.group == GROUP_NAME and entry_point.name == method:
-                        func = entry_point.load()
-                        break
+                eps = entry_points()
+                if isinstance(eps, dict):
+                    # Old structure before Python 3.10
+                    group_entries = eps.get(GROUP_NAME, [])
+                    for entry_point in group_entries:
+                        if entry_point.name == method:
+                            func = entry_point.load()
+                            break
+                else:
+                    # New structure in Python 3.10+
+                    for entry_point in eps:
+                        if (
+                            entry_point.group == GROUP_NAME
+                            and entry_point.name == method
+                        ):
+                            func = entry_point.load()
+                            break
 
         if func is None:
             # if importlib.metadata and pkg_resources is not available


### PR DESCRIPTION
PyBabel currently fails to work with Python 3.12 when using third-party extractors. Specifically, the extraction method for Jinja2 templates throws a ValueError:

```
[python: **.py]
[jinja2: templates/**.html]
ValueError: Unknown extraction method 'jinja2'
```

This issue does not occur with Python 3.11, where the same setup functions correctly.

Issue: https://github.com/python-babel/babel/issues/861