### PR TITLE
Avoid crashing on importing localtime when TZ is malformed 

### DIFF
--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1,0 +1,29 @@
+import sys
+
+import pytest
+
+from babel.localtime import _helpers, get_localzone
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Issue 1092 is not applicable on Windows",
+)
+def test_issue_1092_without_pytz(monkeypatch):
+    pytest.importorskip("zoneinfo", reason="zoneinfo is not available")
+    monkeypatch.setenv("TZ", "/UTC")  # Malformed timezone name.
+    # In case pytz _is_ also installed, we want to pretend it's not, so patch it out...
+    monkeypatch.setattr(_helpers, "pytz", None)
+    with pytest.raises(LookupError):
+        get_localzone()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Issue 1092 is not applicable on Windows",
+)
+def test_issue_1092_with_pytz(monkeypatch):
+    pytest.importorskip("pytz", reason="pytz is not installed")
+    monkeypatch.setenv("TZ", "/UTC")  # Malformed timezone name.
+    with pytest.raises(LookupError):
+        get_localzone()


### PR DESCRIPTION
Fixes #1092.

When `pytz` is _not_ installed, importing `babel.localtime` could fail (repeatedly) when the `TZ` environment variable is malformed enough to be caught by [`_validate_tzfile_path`](https://github.com/python/cpython/blob/ac0745111/Lib/zoneinfo/_tzpath.py#L85), which might throw a certain `ValueError`.

(When `pytz` is installed, it would raise the same `pytz.exceptions.UnknownTimeZoneError` we already catch and ignore for the same input.)