### PR TITLE
Allow parsing .po files that have an extant but empty Language header

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -479,7 +479,11 @@ class Catalog:
                 self.last_translator = value
             elif name == 'language':
                 value = value.replace('-', '_')
-                self._set_locale(value)
+                # The `or None` makes sure that the locale is set to None
+                # if the header's value is an empty string, which is what
+                # some tools generate (instead of eliding the empty Language
+                # header altogether).
+                self._set_locale(value or None)
             elif name == 'language-team':
                 self.language_team = value
             elif name == 'content-type':

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -893,3 +893,12 @@ def test_iterable_of_strings():
     catalog = pofile.read_po(['msgid "foo"', b'msgstr "Voh"'], locale="en_US")
     assert catalog.locale == Locale("en", "US")
     assert catalog.get("foo").string == "Voh"
+
+
+def test_issue_1087():
+    buf = StringIO(r'''
+msgid ""
+msgstr ""
+"Language: \n"
+''')
+    assert pofile.read_po(buf).locale is None


### PR DESCRIPTION
Fixes #1087.

Some tools apparently generate somewhat strange `Language` MIME headers, so we'll treat them like the Language was unset.

Trying `catalog.locale = ""` by hand will still happily crash; this only affects MIME parsing.