### PR TITLE
Allow use of importlib.metadata for finding entrypoints

### DIFF
--- a/babel/messages/_compat.py
+++ b/babel/messages/_compat.py
@@ -1,0 +1,32 @@
+from functools import partial
+
+
+def find_entrypoints(group_name: str):
+    """
+    Find entrypoints of a given group using either `importlib.metadata` or the
+    older `pkg_resources` mechanism.
+
+    Yields tuples of the entrypoint name and a callable function that will
+    load the actual entrypoint.
+    """
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:
+        pass
+    else:
+        eps = entry_points()
+        if isinstance(eps, dict):  # Old structure before Python 3.10
+            group_eps = eps.get(group_name, [])
+        else:  # New structure in Python 3.10+
+            group_eps = (ep for ep in eps if ep.group == group_name)
+        for entry_point in group_eps:
+            yield (entry_point.name, entry_point.load)
+        return
+
+    try:
+        from pkg_resources import working_set
+    except ImportError:
+        pass
+    else:
+        for entry_point in working_set.iter_entry_points(group_name):
+            yield (entry_point.name, partial(entry_point.load, require=True))

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -155,16 +155,11 @@ def _validate_format(format: str, alternative: str) -> None:
 
 
 def _find_checkers() -> list[Callable[[Catalog | None, Message], object]]:
+    from babel.messages._compat import find_entrypoints
     checkers: list[Callable[[Catalog | None, Message], object]] = []
-    try:
-        from pkg_resources import working_set
-    except ImportError:
-        pass
-    else:
-        for entry_point in working_set.iter_entry_points('babel.checkers'):
-            checkers.append(entry_point.load())
+    checkers.extend(load() for (name, load) in find_entrypoints('babel.checkers'))
     if len(checkers) == 0:
-        # if pkg_resources is not available or no usable egg-info was found
+        # if entrypoints are not available or no usable egg-info was found
         # (see #230), just resort to hard-coded checkers
         return [num_plurals, python_format]
     return checkers

--- a/tests/interop/jinja2_data/hello.html
+++ b/tests/interop/jinja2_data/hello.html
@@ -1,0 +1,1 @@
+{% trans %}Hello, {{ name }}!{% endtrans %}

--- a/tests/interop/jinja2_data/mapping.cfg
+++ b/tests/interop/jinja2_data/mapping.cfg
@@ -1,0 +1,1 @@
+[jinja2: *.html]

--- a/tests/interop/test_jinja2_interop.py
+++ b/tests/interop/test_jinja2_interop.py
@@ -1,0 +1,20 @@
+import pathlib
+
+import pytest
+
+from babel.messages import frontend
+
+jinja2 = pytest.importorskip("jinja2")
+
+jinja2_data_path = pathlib.Path(__file__).parent / "jinja2_data"
+
+
+def test_jinja2_interop(monkeypatch, tmp_path):
+    """
+    Test that babel can extract messages from Jinja2 templates.
+    """
+    monkeypatch.chdir(jinja2_data_path)
+    cli = frontend.CommandLineInterface()
+    pot_file = tmp_path / "messages.pot"
+    cli.run(['pybabel', 'extract', '--mapping', 'mapping.cfg', '-o', str(pot_file), '.'])
+    assert '"Hello, %(name)s!"' in pot_file.read_text()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     pypy3
     py{38}-pytz
     py{311,312}-setuptools
+    py312-jinja
 
 [testenv]
 extras =
@@ -15,6 +16,7 @@ deps =
     tzdata;sys_platform == 'win32'
     pytz: pytz
     setuptools: setuptools
+    jinja: jinja2>=3.0
 allowlist_externals = make
 commands = make clean-cldr test
 setenv =


### PR DESCRIPTION
Closes #1093 (supersedes it, based on it).
Refs #861.

This PR makes Babel attempt to use `importlib.metadata` instead of `pkg_resources` where available.

It also adds a test that proves the Jinja2 extractor also works on Python 3.12; this is ran in CI as well.