### PR TITLE
Allow falling back to modifier-less locale data

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -201,7 +201,11 @@ class Locale:
 
         identifier = str(self)
         identifier_without_modifier = identifier.partition('@')[0]
-        if not localedata.exists(identifier_without_modifier):
+        if localedata.exists(identifier):
+            self.__data_identifier = identifier
+        elif localedata.exists(identifier_without_modifier):
+            self.__data_identifier = identifier_without_modifier
+        else:
             raise UnknownLocaleError(identifier)
 
     @classmethod
@@ -436,7 +440,7 @@ class Locale:
     @property
     def _data(self) -> localedata.LocaleDataDict:
         if self.__data is None:
-            self.__data = localedata.LocaleDataDict(localedata.load(str(self)))
+            self.__data = localedata.LocaleDataDict(localedata.load(self.__data_identifier))
         return self.__data
 
     def get_display_name(self, locale: Locale | str | None = None) -> str | None:

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -751,3 +751,8 @@ def test_issue_892():
     assert dates.format_timedelta(timedelta(days=1), format='narrow', locale='pt_BR') == '1 dia'
     assert dates.format_timedelta(timedelta(days=30), format='narrow', locale='pt_BR') == '1 mês'
     assert dates.format_timedelta(timedelta(days=365), format='narrow', locale='pt_BR') == '1 ano'
+
+
+def test_issue_1089():
+    assert dates.format_datetime(datetime.utcnow(), locale="ja_JP@mod")
+    assert dates.format_datetime(datetime.utcnow(), locale=Locale.parse("ja_JP@mod"))


### PR DESCRIPTION
IOW, e.g. the data loaded by `ja_JP@mod` is `ja_JP` in the absence of data that would have the modifier present. We currently have no locale files that would have modifiers.

Fixes #1089.
Follows up on #947.