### PR TITLE
Initial support for reading mapping configuration as TOML

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1052,15 +1052,23 @@ def _parse_config_object(config: dict, *, filename="(unknown)"):
         if not isinstance(entry, dict):
             raise ValueError(f"{filename}: mappings[{idx}]: Expected a dictionary, got {type(entry)!r}")
         entry = entry.copy()
+
         method = entry.pop("method", None)
-        pattern = entry.pop("pattern", None)
         if not isinstance(method, str):
             raise ValueError(f"{filename}: mappings[{idx}]: 'method' must be a string, got {method!r}")
-        if not isinstance(pattern, str):
-            raise ValueError(f"{filename}: mappings[{idx}]: 'pattern' must be a string, got {pattern!r}")
         method = extractors.get(method, method)  # Map the extractor name to the callable now
-        method_map.append((pattern, method))
-        options_map[pattern] = entry
+
+        pattern = entry.pop("pattern", None)
+        if not isinstance(pattern, (list, str)):
+            raise ValueError(f"{filename}: mappings[{idx}]: 'pattern' must be a list or a string, got {pattern!r}")
+        if not isinstance(pattern, list):
+            pattern = [pattern]
+
+        for pat in pattern:
+            if not isinstance(pat, str):
+                raise ValueError(f"{filename}: mappings[{idx}]: 'pattern' elements must be strings, got {pat!r}")
+            method_map.append((pat, method))
+            options_map[pat] = entry
 
     return method_map, options_map
 

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -548,7 +548,7 @@ class ExtractMessages(CommandMixin):
                         if os.path.basename(self.mapping_file) == "pyproject.toml"
                         else "standalone"
                     )
-                    method_map, options_map = parse_mapping_toml(
+                    method_map, options_map = _parse_mapping_toml(
                         fileobj,
                         filename=self.mapping_file,
                         style=file_style,
@@ -1086,12 +1086,14 @@ def _parse_config_object(config: dict, *, filename="(unknown)"):
     return method_map, options_map
 
 
-def parse_mapping_toml(
+def _parse_mapping_toml(
     fileobj: BinaryIO,
     filename: str = "(unknown)",
     style: Literal["standalone", "pyproject.toml"] = "standalone",
 ):
     """Parse an extraction method mapping from a binary file-like object.
+
+    .. warning: As of this version of Babel, this is a private API subject to changes.
 
     :param fileobj: a readable binary file-like object containing the configuration TOML to parse
     :param filename: the name of the file being parsed, for error messages

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1013,7 +1013,6 @@ def parse_mapping_cfg(fileobj, filename=None):
 
     :param fileobj: a readable file-like object containing the configuration
                     text to parse
-    :see: `extract_from_directory`
     """
     extractors = {}
     method_map = []
@@ -1097,7 +1096,6 @@ def parse_mapping_toml(
     :param fileobj: a readable binary file-like object containing the configuration TOML to parse
     :param filename: the name of the file being parsed, for error messages
     :param style: whether the file is in the style of a `pyproject.toml` file, i.e. whether to look for `tool.babel`.
-    :see: `extract_from_directory`
     """
     try:
         import tomllib

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1052,7 +1052,7 @@ def _parse_config_object(config: dict, *, filename="(unknown)"):
     if "mapping" in config:
         raise ValueError(f"{filename}: 'mapping' is not a valid key, did you mean 'mappings'?")
 
-    mappings_read = config.get("mappings") or []
+    mappings_read = config.get("mappings", [])
     if not isinstance(mappings_read, list):
         raise ValueError(f"{filename}: mappings: Expected a list, got {type(mappings_read)!r}")
     for idx, entry in enumerate(mappings_read):

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1087,10 +1087,10 @@ def parse_mapping_toml(
     :see: `extract_from_directory`
     """
     try:
-        import tomli as tomllib
+        import tomllib
     except ImportError:
         try:
-            import tomllib
+            import tomli as tomllib
         except ImportError as ie:
             raise ImportError("tomli or tomllib is required to parse TOML files") from ie
 

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -992,48 +992,6 @@ def parse_mapping(fileobj, filename=None):
 def parse_mapping_cfg(fileobj, filename=None):
     """Parse an extraction method mapping from a file-like object.
 
-    >>> buf = StringIO('''
-    ... [extractors]
-    ... custom = mypackage.module:myfunc
-    ...
-    ... # Python source files
-    ... [python: **.py]
-    ...
-    ... # Genshi templates
-    ... [genshi: **/templates/**.html]
-    ... include_attrs =
-    ... [genshi: **/templates/**.txt]
-    ... template_class = genshi.template:TextTemplate
-    ... encoding = latin-1
-    ...
-    ... # Some custom extractor
-    ... [custom: **/custom/*.*]
-    ... ''')
-
-    >>> method_map, options_map = parse_mapping_cfg(buf)
-    >>> len(method_map)
-    4
-
-    >>> method_map[0]
-    ('**.py', 'python')
-    >>> options_map['**.py']
-    {}
-    >>> method_map[1]
-    ('**/templates/**.html', 'genshi')
-    >>> options_map['**/templates/**.html']['include_attrs']
-    ''
-    >>> method_map[2]
-    ('**/templates/**.txt', 'genshi')
-    >>> options_map['**/templates/**.txt']['template_class']
-    'genshi.template:TextTemplate'
-    >>> options_map['**/templates/**.txt']['encoding']
-    'latin-1'
-
-    >>> method_map[3]
-    ('**/custom/*.*', 'mypackage.module:myfunc')
-    >>> options_map['**/custom/*.*']
-    {}
-
     :param fileobj: a readable file-like object containing the configuration
                     text to parse
     :see: `extract_from_directory`

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import sys
 import tempfile
+import warnings
 from collections import OrderedDict
 from configparser import RawConfigParser
 from io import StringIO
@@ -535,7 +536,7 @@ class ExtractMessages(CommandMixin):
 
         if self.mapping_file:
             with open(self.mapping_file) as fileobj:
-                method_map, options_map = parse_mapping(fileobj)
+                method_map, options_map = parse_mapping_cfg(fileobj)
             for path in self.input_paths:
                 mappings.append((path, method_map, options_map))
 
@@ -543,7 +544,7 @@ class ExtractMessages(CommandMixin):
             message_extractors = self.distribution.message_extractors
             for path, mapping in message_extractors.items():
                 if isinstance(mapping, str):
-                    method_map, options_map = parse_mapping(StringIO(mapping))
+                    method_map, options_map = parse_mapping_cfg(StringIO(mapping))
                 else:
                     method_map, options_map = [], {}
                     for pattern, method, options in mapping:
@@ -980,6 +981,15 @@ def main():
 
 
 def parse_mapping(fileobj, filename=None):
+    warnings.warn(
+        "parse_mapping is deprecated, use parse_mapping_cfg instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return parse_mapping_cfg(fileobj, filename)
+
+
+def parse_mapping_cfg(fileobj, filename=None):
     """Parse an extraction method mapping from a file-like object.
 
     >>> buf = StringIO('''
@@ -1000,7 +1010,7 @@ def parse_mapping(fileobj, filename=None):
     ... [custom: **/custom/*.*]
     ... ''')
 
-    >>> method_map, options_map = parse_mapping(buf)
+    >>> method_map, options_map = parse_mapping_cfg(buf)
     >>> len(method_map)
     4
 

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1044,6 +1044,8 @@ def _parse_config_object(config: dict, *, filename="(unknown)"):
             raise ValueError(f"{filename}: extractors: Callable specification must be a string, got {callable_spec!r}")
         extractors[method] = callable_spec
 
+    if "mapping" in config:
+        raise ValueError(f"{filename}: 'mapping' is not a valid key, did you mean 'mappings'?")
 
     mappings_read = config.get("mappings") or []
     if not isinstance(mappings_read, list):

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -1097,7 +1097,7 @@ def parse_mapping_toml(
     except ImportError:
         try:
             import tomli as tomllib
-        except ImportError as ie:
+        except ImportError as ie:  # pragma: no cover
             raise ImportError("tomli or tomllib is required to parse TOML files") from ie
 
     parsed_data = tomllib.load(fileobj)

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1406,7 +1406,7 @@ def test_parse_mapping():
         '# Some custom extractor\n'
         '[custom: **/custom/*.*]\n')
 
-    method_map, options_map = frontend.parse_mapping(buf)
+    method_map, options_map = frontend.parse_mapping_cfg(buf)
     assert len(method_map) == 4
 
     assert method_map[0] == ('**.py', 'python')

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1448,13 +1448,13 @@ pattern = "**/custom/*.*"
         ),
         (
             mapping_toml,
-            frontend.parse_mapping_toml,
+            frontend._parse_mapping_toml,
             None,
             True,
         ),
         (
             mapping_toml,
-            partial(frontend.parse_mapping_toml, style="pyproject.toml"),
+            partial(frontend._parse_mapping_toml, style="pyproject.toml"),
             lambda s: re.sub(r"^(\[+)", r"\1tool.babel.", s, flags=re.MULTILINE),
             True,
         ),

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -17,6 +17,7 @@ import sys
 import time
 import unittest
 from datetime import datetime, timedelta
+from functools import partial
 from io import BytesIO, StringIO
 from typing import List
 
@@ -1437,11 +1438,23 @@ pattern = "**/custom/*.*"
 @pytest.mark.parametrize(
     ("data", "parser", "preprocess"),
     [
-        (mapping_cfg, frontend.parse_mapping_cfg, None),
-        (mapping_toml, frontend.parse_mapping_toml, None),
-        (mapping_toml, frontend.parse_mapping_toml, lambda s: s.replace("[babel", "[tool.babel")),
+        (
+            mapping_cfg,
+            frontend.parse_mapping_cfg,
+            None,
+        ),
+        (
+            mapping_toml,
+            frontend.parse_mapping_toml,
+            None,
+        ),
+        (
+            mapping_toml,
+            partial(frontend.parse_mapping_toml, pyproject_toml_style=True),
+            lambda s: s.replace("[babel", "[tool.babel"),
+        ),
     ],
-    ids=("cfg", "toml", "toml-with-tool"),
+    ids=("cfg", "toml", "pyproject-toml"),
 )
 def test_parse_mapping(data: str, parser, preprocess):
     if preprocess:

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1480,6 +1480,21 @@ def test_parse_mapping(data: str, parser, preprocess):
     assert options_map['**/custom/*.*'] == {}
 
 
+def test_toml_mapping_multiple_patterns():
+    """
+    Test that patterns may be specified as a list in TOML,
+    and are expanded to multiple entries in the method map.
+    """
+    method_map, options_map = frontend.parse_mapping_toml(BytesIO(b"""
+[[babel.mappings]]
+method = "python"
+pattern = ["xyz/**.py", "foo/**.py"]
+"""))
+    assert len(method_map) == 2
+    assert method_map[0] == ('xyz/**.py', 'python')
+    assert method_map[1] == ('foo/**.py', 'python')
+
+
 def test_parse_keywords():
     kw = frontend.parse_keywords(['_', 'dgettext:2',
                                   'dngettext:2,3', 'pgettext:1c,2'])

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1485,21 +1485,6 @@ def test_parse_mapping(data: str, parser, preprocess, is_toml):
     assert options_map['**/custom/*.*'] == {}
 
 
-def test_toml_mapping_multiple_patterns():
-    """
-    Test that patterns may be specified as a list in TOML,
-    and are expanded to multiple entries in the method map.
-    """
-    method_map, options_map = frontend.parse_mapping_toml(BytesIO(b"""
-[[mappings]]
-method = "python"
-pattern = ["xyz/**.py", "foo/**.py"]
-"""))
-    assert len(method_map) == 2
-    assert method_map[0] == ('xyz/**.py', 'python')
-    assert method_map[1] == ('foo/**.py', 'python')
-
-
 def test_parse_keywords():
     kw = frontend.parse_keywords(['_', 'dgettext:2',
                                   'dngettext:2,3', 'pgettext:1c,2'])

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1389,22 +1389,24 @@ msgstr[2] ""
 
 
 def test_parse_mapping():
-    buf = StringIO(
-        '[extractors]\n'
-        'custom = mypackage.module:myfunc\n'
-        '\n'
-        '# Python source files\n'
-        '[python: **.py]\n'
-        '\n'
-        '# Genshi templates\n'
-        '[genshi: **/templates/**.html]\n'
-        'include_attrs =\n'
-        '[genshi: **/templates/**.txt]\n'
-        'template_class = genshi.template:TextTemplate\n'
-        'encoding = latin-1\n'
-        '\n'
-        '# Some custom extractor\n'
-        '[custom: **/custom/*.*]\n')
+    buf = StringIO("""
+[extractors]
+custom = mypackage.module:myfunc
+
+# Python source files
+[python: **.py]
+
+# Genshi templates
+[genshi: **/templates/**.html]
+include_attrs =
+
+[genshi: **/templates/**.txt]
+template_class = genshi.template:TextTemplate
+encoding = latin-1
+
+# Some custom extractor
+[custom: **/custom/*.*]
+""")
 
     method_map, options_map = frontend.parse_mapping_cfg(buf)
     assert len(method_map) == 4

--- a/tests/messages/test_toml_config.py
+++ b/tests/messages/test_toml_config.py
@@ -1,0 +1,38 @@
+import pathlib
+from io import BytesIO
+
+import pytest
+
+from babel.messages import frontend
+
+toml_test_cases_path = pathlib.Path(__file__).parent / "toml-test-cases"
+assert toml_test_cases_path.is_dir(), "toml-test-cases directory not found"
+
+
+def test_toml_mapping_multiple_patterns():
+    """
+    Test that patterns may be specified as a list in TOML,
+    and are expanded to multiple entries in the method map.
+    """
+    method_map, options_map = frontend.parse_mapping_toml(BytesIO(b"""
+[[mappings]]
+method = "python"
+pattern = ["xyz/**.py", "foo/**.py"]
+"""))
+    assert len(method_map) == 2
+    assert method_map[0] == ('xyz/**.py', 'python')
+    assert method_map[1] == ('foo/**.py', 'python')
+
+
+@pytest.mark.parametrize("test_case", toml_test_cases_path.glob("bad.*.toml"), ids=lambda p: p.name)
+def test_bad_toml_test_case(test_case: pathlib.Path):
+    """
+    Test that bad TOML files raise a ValueError.
+    """
+    with pytest.raises(ValueError):
+        with test_case.open("rb") as f:
+            frontend.parse_mapping_toml(
+                f,
+                filename=test_case.name,
+                style="pyproject.toml" if "pyproject" in test_case.name else "standalone",
+            )

--- a/tests/messages/test_toml_config.py
+++ b/tests/messages/test_toml_config.py
@@ -14,7 +14,7 @@ def test_toml_mapping_multiple_patterns():
     Test that patterns may be specified as a list in TOML,
     and are expanded to multiple entries in the method map.
     """
-    method_map, options_map = frontend.parse_mapping_toml(BytesIO(b"""
+    method_map, options_map = frontend._parse_mapping_toml(BytesIO(b"""
 [[mappings]]
 method = "python"
 pattern = ["xyz/**.py", "foo/**.py"]
@@ -31,7 +31,7 @@ def test_bad_toml_test_case(test_case: pathlib.Path):
     """
     with pytest.raises(frontend.ConfigurationError):
         with test_case.open("rb") as f:
-            frontend.parse_mapping_toml(
+            frontend._parse_mapping_toml(
                 f,
                 filename=test_case.name,
                 style="pyproject.toml" if "pyproject" in test_case.name else "standalone",

--- a/tests/messages/test_toml_config.py
+++ b/tests/messages/test_toml_config.py
@@ -29,7 +29,7 @@ def test_bad_toml_test_case(test_case: pathlib.Path):
     """
     Test that bad TOML files raise a ValueError.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(frontend.ConfigurationError):
         with test_case.open("rb") as f:
             frontend.parse_mapping_toml(
                 f,

--- a/tests/messages/toml-test-cases/bad.extractor.toml
+++ b/tests/messages/toml-test-cases/bad.extractor.toml
@@ -1,0 +1,2 @@
+[extractors]
+custom = { module = "mypackage.module", func = "myfunc" }

--- a/tests/messages/toml-test-cases/bad.extractors-not-a-dict.toml
+++ b/tests/messages/toml-test-cases/bad.extractors-not-a-dict.toml
@@ -1,0 +1,1 @@
+[[extractors]]

--- a/tests/messages/toml-test-cases/bad.just-a-mapping.toml
+++ b/tests/messages/toml-test-cases/bad.just-a-mapping.toml
@@ -1,0 +1,3 @@
+[mapping]
+method = "jinja2"
+pattern = "**.html"

--- a/tests/messages/toml-test-cases/bad.mapping-not-a-dict.toml
+++ b/tests/messages/toml-test-cases/bad.mapping-not-a-dict.toml
@@ -1,0 +1,1 @@
+mappings = [8]

--- a/tests/messages/toml-test-cases/bad.mappings-not-a-list.toml
+++ b/tests/messages/toml-test-cases/bad.mappings-not-a-list.toml
@@ -1,0 +1,1 @@
+mappings = "python"

--- a/tests/messages/toml-test-cases/bad.missing-extraction-method.toml
+++ b/tests/messages/toml-test-cases/bad.missing-extraction-method.toml
@@ -1,0 +1,2 @@
+[[mappings]]
+pattern = ["xyz/**.py", "foo/**.py"]

--- a/tests/messages/toml-test-cases/bad.multiple-mappings-not-a-list.toml
+++ b/tests/messages/toml-test-cases/bad.multiple-mappings-not-a-list.toml
@@ -1,0 +1,10 @@
+[mappings]
+method = "genshi"
+pattern = "**/templates/**.html"
+include_attrs = ""
+
+[mappings]
+method = "genshi"
+pattern = "**/templates/**.txt"
+template_class = "genshi.template:TextTemplate"
+encoding = "latin-1"

--- a/tests/messages/toml-test-cases/bad.non-string-extraction-method.toml
+++ b/tests/messages/toml-test-cases/bad.non-string-extraction-method.toml
@@ -1,0 +1,2 @@
+[[mappings]]
+method = 42

--- a/tests/messages/toml-test-cases/bad.pattern-type-2.toml
+++ b/tests/messages/toml-test-cases/bad.pattern-type-2.toml
@@ -1,0 +1,3 @@
+[[mappings]]
+method = "big snake"
+pattern = [42]

--- a/tests/messages/toml-test-cases/bad.pattern-type.toml
+++ b/tests/messages/toml-test-cases/bad.pattern-type.toml
@@ -1,0 +1,3 @@
+[[mappings]]
+method = "big snake"
+pattern = 2048

--- a/tests/messages/toml-test-cases/bad.pyproject-without-tool-babel.toml
+++ b/tests/messages/toml-test-cases/bad.pyproject-without-tool-babel.toml
@@ -1,0 +1,3 @@
+[[mappings]]
+method = "big snake"
+pattern = 2048

--- a/tests/messages/toml-test-cases/bad.standalone-with-babel-prefix.toml
+++ b/tests/messages/toml-test-cases/bad.standalone-with-babel-prefix.toml
@@ -1,0 +1,2 @@
+[babel.extractors]
+custom = "mypackage.module:myfunc"


### PR DESCRIPTION
This PR offers to implement part of https://github.com/python-babel/babel/issues/777.

Namely, following this PR you would be able to run `pybabel extract -F babel.toml` – or even `pybabel extract -F pyproject.toml`, as we already will support `tool.babel` as well as `babel` for the namespace. (Auto-detecting a `pyproject.toml` instead of `setup.cfg` or `babel.cfg` is not implemented in this PR.)

I'm **requesting comments** on the proposed TOML format, which borrows the idea of [mappings-as-lists from Mypy's overrides configuration](https://mypy.readthedocs.io/en/latest/config_file.html#example-pyproject-toml).

```toml
[babel.extractors]
custom = "mypackage.module:myfunc"

# Python source files
[[babel.mappings]]
method = "python"
pattern = "**.py"

# Genshi templates
[[babel.mappings]]
method = "genshi"
pattern = "**/templates/**.html"
include_attrs = ""

[[babel.mappings]]
method = "genshi"
pattern = "**/templates/**.txt"
template_class = "genshi.template:TextTemplate"
encoding = "latin-1"

# Some custom extractor
[[babel.mappings]]
method = "custom"
pattern = "**/custom/*.*"
```
