### PR TITLE
Do not allow substituting alternates or drafts in derived locales

### DIFF
--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -79,7 +79,9 @@ def main():
     subprocess.check_call([
         sys.executable,
         os.path.join(scripts_path, 'import_cldr.py'),
-        common_path])
+        common_path,
+        *sys.argv[1:],
+    ])
 
 
 if __name__ == '__main__':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -348,3 +348,17 @@ def test_issue_814():
     loc = Locale.parse('ca_ES_valencia')
     assert loc.variant == "VALENCIA"
     assert loc.get_display_name() == 'català (Espanya, valencià)'
+
+
+def test_issue_1112():
+    """
+    Test that an alternate spelling of `Türkei` doesn't inadvertently
+    get imported from `de_AT` to replace the parent's non-alternate spelling.
+    """
+    assert (
+        Locale.parse('de').territories['TR'] ==
+        Locale.parse('de_AT').territories['TR'] ==
+        Locale.parse('de_CH').territories['TR'] ==
+        Locale.parse('de_DE').territories['TR'] ==
+        'Türkei'
+    )


### PR DESCRIPTION
For more coverage, we've allowed using alternate or draft values when no officially accepted values have been present.

However, non-global (i.e. e.g. `de_CH` locales) may have an alternate spelling for what would be an alternate in the parent locale (and that alternate hasn't been imported into the parent), and the import would have then accepted the alternate from the child locale as a non-alternate.

Fixes #1112.