### PR TITLE
Fix deprecation warnings for `datetime.utcnow()`

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -754,5 +754,5 @@ def test_issue_892():
 
 
 def test_issue_1089():
-    assert dates.format_datetime(datetime.utcnow(), locale="ja_JP@mod")
-    assert dates.format_datetime(datetime.utcnow(), locale=Locale.parse("ja_JP@mod"))
+    assert dates.format_datetime(datetime.now(), locale="ja_JP@mod")
+    assert dates.format_datetime(datetime.now(), locale=Locale.parse("ja_JP@mod"))


### PR DESCRIPTION
This shows up when running the tests on 3.12:
```python
~dev/babel/tests/test_dates.py:757: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to rep
resent datetimes in UTC: datetime.datetime.now(datetime.UTC).                                                                                                                                 
    assert dates.format_datetime(datetime.utcnow(), locale="ja_JP@mod")
```

I think there's no harm in using plain `datetime.now()` for these tests.