### PR TITLE
Prevent wrapping file locations containing white space

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -637,8 +637,8 @@ def generate_po(
     # provide the same behaviour
     comment_width = width if width and width > 0 else 76
 
-    comment_wrapper = TextWrapper(width=comment_width)
-    header_wrapper = TextWrapper(width=width, subsequent_indent="# ")
+    comment_wrapper = TextWrapper(width=comment_width, break_long_words=False)
+    header_wrapper = TextWrapper(width=width, subsequent_indent="# ", break_long_words=False)
 
     def _format_comment(comment, prefix=''):
         for line in comment_wrapper.wrap(comment):

--- a/babel/util.py
+++ b/babel/util.py
@@ -218,11 +218,13 @@ class TextWrapper(textwrap.TextWrapper):
             # There are no file names which contain spaces, fallback to the default implementation
             return super()._split(text)
 
-        super_ = super() #  Python 3.9 fix, super() does not work in list comprehension
-        chunks = re.split(self._enclosed_filename_re, text)
-        chunks = [[c] if c.startswith(enclosed_filename_start) else super_._split(c) for c in chunks]
-        chunks = [c for c in chain.from_iterable(chunks) if c]
-        return chunks
+        chunks = []
+        for chunk in re.split(self._enclosed_filename_re, text):
+            if chunk.startswith(enclosed_filename_start):
+                chunks.append(chunk)
+            else:
+                chunks.extend(super()._split(chunk))
+        return [c for c in chunks if c]
 
 
 def wraptext(text: str, width: int = 70, initial_indent: str = '', subsequent_indent: str = '') -> list[str]:

--- a/babel/util.py
+++ b/babel/util.py
@@ -16,7 +16,6 @@ import re
 import textwrap
 import warnings
 from collections.abc import Generator, Iterable
-from itertools import chain
 from typing import IO, Any, TypeVar
 
 from babel import dates, localtime

--- a/babel/util.py
+++ b/babel/util.py
@@ -218,8 +218,9 @@ class TextWrapper(textwrap.TextWrapper):
             # There are no file names which contain spaces, fallback to the default implementation
             return super()._split(text)
 
+        super_ = super() #  Python 3.9 fix, super() does not work in list comprehension
         chunks = re.split(self._enclosed_filename_re, text)
-        chunks = [[c] if c.startswith(enclosed_filename_start) else super()._split(c) for c in chunks]
+        chunks = [[c] if c.startswith(enclosed_filename_start) else super_._split(c) for c in chunks]
         chunks = [c for c in chain.from_iterable(chunks) if c]
         return chunks
 

--- a/babel/util.py
+++ b/babel/util.py
@@ -227,7 +227,8 @@ class TextWrapper(textwrap.TextWrapper):
 
 def wraptext(text: str, width: int = 70, initial_indent: str = '', subsequent_indent: str = '') -> list[str]:
     """Simple wrapper around the ``textwrap.wrap`` function in the standard
-    library. This version does not wrap lines on hyphens in words.
+    library. This version does not wrap lines on hyphens in words. It also
+    does not wrap PO file locations containing spaces.
 
     :param text: the text to wrap
     :param width: the maximum line width

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -948,6 +948,19 @@ msgid "foo"
 msgstr ""'''
 
 
+    def test_wrap_with_enclosed_file_locations(self):
+        # Ensure that file names containing white space are not wrapped regardless of the --width parameter
+        catalog = Catalog()
+        catalog.add('foo', locations=[('\u2068test utils.py\u2069', 1)])
+        catalog.add('foo', locations=[('\u2068test utils.py\u2069', 3)])
+        buf = BytesIO()
+        pofile.write_po(buf, catalog, omit_header=True, include_lineno=True, width=1)
+        assert buf.getvalue().strip() == b'''#: \xe2\x81\xa8test utils.py\xe2\x81\xa9:1
+#: \xe2\x81\xa8test utils.py\xe2\x81\xa9:3
+msgid "foo"
+msgstr ""'''
+
+
 class RoundtripPoTestCase(unittest.TestCase):
 
     def test_enclosed_filenames_in_location_comment(self):


### PR DESCRIPTION
Closes #1078 
~~Depends on #1105 (To see only the changes in this PR, look at the last two commits)~~

Since #1105 wraps file names containing white space in special unicode markers, we look out for them when
wrapping comments.

The fix overrides the `_split` method of `TextWrapper` where we manually generate the indivisible chunks, taking into
account enclosed file names.

I test the the wrapping behavior with gettext 0.22.5 (which includes the enclosing logic) to make sure it's consistent