### PR TITLE
fix: check_and_call_extract_file uses the first matching method and options, instead of the first matching method and last matching options

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -276,6 +276,7 @@ def check_and_call_extract_file(
         for opattern, odict in options_map.items():
             if pathmatch(opattern, filename):
                 options = odict
+                break
         if callback:
             callback(filename, method, options)
         for message_tuple in extract_from_file(

--- a/tests/messages/utils.py
+++ b/tests/messages/utils.py
@@ -1,0 +1,7 @@
+CUSTOM_EXTRACTOR_COOKIE = "custom extractor was here"
+
+
+def custom_extractor(fileobj, keywords, comment_tags, options):
+    if "treat" not in options:
+        raise RuntimeError(f"The custom extractor refuses to run without a delicious treat; got {options!r}")
+    return [(1, next(iter(keywords)), (CUSTOM_EXTRACTOR_COOKIE,), [])]


### PR DESCRIPTION
Otherwise, if I want to use a different method for one file AND use options, I can't do, for example:

```ini
[myextractor: path/file.py]
myoption = myvalue

[python: path/**.py]
```

The current code will match `path/file.py` to `myextractor`, but it'll use the empty options from `python`...