### PR TITLE
Allow extracting (deeply) nested calls in Python and Javascript

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -721,15 +721,22 @@ def extract_javascript(
     :param lineno: line number offset (for parsing embedded fragments)
     """
     from babel.messages.jslexer import Token, tokenize, unquote_string
-    funcname = message_lineno = None
-    messages = []
-    last_argument = None
-    translator_comments = []
-    concatenate_next = False
+
     encoding = options.get('encoding', 'utf-8')
-    last_token = None
-    call_stack = -1
     dotted = any('.' in kw for kw in keywords)
+    last_token = None
+    # Keep the stack of all function calls and its related contextual variables,
+    # so we can handle nested gettext calls.
+    function_stack: list[FunctionStackItem] = []
+    # Keep track of whether we're in a class or function definition
+    in_def = False
+    # Keep track of whether we're in a block of translator comments
+    in_translator_comments = False
+    # Keep track of the last encountered translator comments
+    translator_comments = []
+    # Keep track of the (split) strings encountered
+    message_buffer = []
+
     for token in tokenize(
         fileobj.read().decode(encoding),
         jsx=options.get("jsx", True),
@@ -737,38 +744,86 @@ def extract_javascript(
         dotted=dotted,
         lineno=lineno,
     ):
-        if (  # Turn keyword`foo` expressions into keyword("foo") calls:
-            funcname and  # have a keyword...
-            (last_token and last_token.type == 'name') and  # we've seen nothing after the keyword...
-            token.type == 'template_string'  # this is a template string
+        if token.type == 'name' and token.value in ('class', 'function'):
+            # We're entering a class or function definition
+            in_def = True
+
+        elif in_def and token.type == 'operator' and token.value in ('(', '{'):
+            # We're in a class or function definition and should not do anything
+            in_def = False
+            continue
+
+        elif (
+            last_token
+            and last_token.type == 'name'
+            and last_token.value in keywords
+            and token.type == 'template_string'
         ):
-            message_lineno = token.lineno
-            messages = [unquote_string(token.value)]
-            call_stack = 0
+            # Turn keyword`foo` expressions into keyword("foo") function calls
+            string_value = unquote_string(token.value)
+            cur_translator_comments = translator_comments
+            if function_stack and function_stack[-1].function_lineno == last_token.lineno:
+                # If our current function call is on the same line as the previous one,
+                # copy their translator comments, since they also apply to us.
+                cur_translator_comments = function_stack[-1].translator_comments
+
+            # We add all information needed later for the current function call
+            function_stack.append(FunctionStackItem(
+                function_lineno=last_token.lineno,
+                function_name=last_token.value,
+                message_lineno=token.lineno,
+                messages=[string_value],
+                translator_comments=cur_translator_comments,
+            ))
+            translator_comments = []
+
+            # We act as if we are closing the function call now
             token = Token('operator', ')', token.lineno)
 
-        if options.get('parse_template_string') and not funcname and token.type == 'template_string':
+        if (
+            options.get('parse_template_string')
+            and (not last_token or last_token.type != 'name' or last_token.value not in keywords)
+            and token.type == 'template_string'
+        ):
             yield from parse_template_string(token.value, keywords, comment_tags, options, token.lineno)
 
         elif token.type == 'operator' and token.value == '(':
-            if funcname:
-                message_lineno = token.lineno
-                call_stack += 1
+            if last_token.type == 'name':
+                # We're entering a function call
+                cur_translator_comments = translator_comments
+                if function_stack and function_stack[-1].function_lineno == token.lineno:
+                    # If our current function call is on the same line as the previous one,
+                    # copy their translator comments, since they also apply to us.
+                    cur_translator_comments = function_stack[-1].translator_comments
 
-        elif call_stack == -1 and token.type == 'linecomment':
+                # We add all information needed later for the current function call
+                function_stack.append(FunctionStackItem(
+                    function_lineno=token.lineno,
+                    function_name=last_token.value,
+                    message_lineno=None,
+                    messages=[],
+                    translator_comments=cur_translator_comments,
+                ))
+                translator_comments = []
+
+        elif token.type == 'linecomment':
+            # Strip the comment token from the line
             value = token.value[2:].strip()
-            if translator_comments and \
-               translator_comments[-1][0] == token.lineno - 1:
+            if in_translator_comments and translator_comments[-1][0] == token.lineno - 1:
+                # We're already inside a translator comment, continue appending
                 translator_comments.append((token.lineno, value))
                 continue
 
             for comment_tag in comment_tags:
                 if value.startswith(comment_tag):
-                    translator_comments.append((token.lineno, value.strip()))
+                    # Comment starts with one of the comment tags,
+                    # so let's start capturing it
+                    in_translator_comments = True
+                    translator_comments.append((token.lineno, value))
                     break
 
         elif token.type == 'multilinecomment':
-            # only one multi-line comment may precede a translation
+            # Only one multi-line comment may precede a translation
             translator_comments = []
             value = token.value[2:-2].strip()
             for comment_tag in comment_tags:
@@ -778,68 +833,67 @@ def extract_javascript(
                         lines[0] = lines[0].strip()
                         lines[1:] = dedent('\n'.join(lines[1:])).splitlines()
                         for offset, line in enumerate(lines):
-                            translator_comments.append((token.lineno + offset,
-                                                        line))
+                            translator_comments.append((token.lineno + offset, line))
                     break
 
-        elif funcname and call_stack == 0:
+        elif function_stack and function_stack[-1].function_name in keywords:
+            # We're inside a translation function call
             if token.type == 'operator' and token.value == ')':
-                if last_argument is not None:
-                    messages.append(last_argument)
-                if len(messages) > 1:
-                    messages = tuple(messages)
-                elif messages:
-                    messages = messages[0]
+                # The call has ended, so we yield the translatable term(s)
+                messages = function_stack[-1].messages
+                lineno = (
+                    function_stack[-1].message_lineno
+                    or function_stack[-1].function_lineno
+                )
+                cur_translator_comments = function_stack[-1].translator_comments
+
+                if message_buffer:
+                    messages.append(''.join(message_buffer))
+                    message_buffer.clear()
                 else:
-                    messages = None
+                    messages.append(None)
 
-                # Comments don't apply unless they immediately precede the
-                # message
-                if translator_comments and \
-                   translator_comments[-1][0] < message_lineno - 1:
-                    translator_comments = []
+                messages = tuple(messages) if len(messages) > 1 else messages[0]
+                if (
+                    cur_translator_comments
+                    and cur_translator_comments[-1][0] < lineno - 1
+                ):
+                    # The translator comments are not immediately preceding the current
+                    # term, so we skip them.
+                    cur_translator_comments = []
 
-                if messages is not None:
-                    yield (message_lineno, funcname, messages,
-                           [comment[1] for comment in translator_comments])
+                yield (
+                    lineno,
+                    function_stack[-1].function_name,
+                    messages,
+                    [comment[1] for comment in cur_translator_comments],
+                )
 
-                funcname = message_lineno = last_argument = None
-                concatenate_next = False
-                translator_comments = []
-                messages = []
-                call_stack = -1
+                function_stack.pop()
 
             elif token.type in ('string', 'template_string'):
-                new_value = unquote_string(token.value)
-                if concatenate_next:
-                    last_argument = (last_argument or '') + new_value
-                    concatenate_next = False
+                # We've encountered a string inside a translation function call
+                string_value = unquote_string(token.value)
+                if not function_stack[-1].message_lineno:
+                    function_stack[-1].message_lineno = token.lineno
+                if string_value is not None:
+                    message_buffer.append(string_value)
+
+            elif token.type == 'operator' and token.value == ',':
+                # End of a function call argument
+                if message_buffer:
+                    function_stack[-1].messages.append(''.join(message_buffer))
+                    message_buffer.clear()
                 else:
-                    last_argument = new_value
+                    function_stack[-1].messages.append(None)
 
-            elif token.type == 'operator':
-                if token.value == ',':
-                    if last_argument is not None:
-                        messages.append(last_argument)
-                        last_argument = None
-                    else:
-                        messages.append(None)
-                    concatenate_next = False
-                elif token.value == '+':
-                    concatenate_next = True
+        elif function_stack and token.type == 'operator' and token.value == ')':
+            function_stack.pop()
 
-        elif call_stack > 0 and token.type == 'operator' \
-                and token.value == ')':
-            call_stack -= 1
-
-        elif funcname and call_stack == -1:
-            funcname = None
-
-        elif call_stack == -1 and token.type == 'name' and \
-            token.value in keywords and \
-            (last_token is None or last_token.type != 'name' or
-             last_token.value != 'function'):
-            funcname = token.value
+        if in_translator_comments and translator_comments[-1][0] < token.lineno:
+            # We have a newline in between the comments, so they don't belong
+            # together anymore
+            in_translator_comments = False
 
         last_token = token
 

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -428,24 +428,34 @@ _(u'Hello, {name1} and {name2}!', name1=_(u'Heungsub'),
 # NOTE: Third
 _(u'Hello, {0} and {1}!', _(u'Heungsub'),
   _(u'Armin'))
+
+# NOTE: Fourth
+_("Hello %(person)s and %(other_person)s", person=random_fn(_("Person 1")), other_person=random_obj["random_fn"](_("Person 2")))
+
+# NOTE: Fifth
+_("Hello %(people)s",
+    people=random_obj.random_fn(
+        ", ".join([_("Person 1"), _("Person 2")]) + ", and everyone else"
+    )
+)
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
-        assert messages[0][2] == ('Hello, {name}!', None)
-        assert messages[0][3] == ['NOTE: First']
-        assert messages[1][2] == 'Foo Bar'
-        assert messages[1][3] == []
-        assert messages[2][2] == ('Hello, {name1} and {name2}!', None)
-        assert messages[2][3] == ['NOTE: Second']
-        assert messages[3][2] == 'Heungsub'
-        assert messages[3][3] == []
-        assert messages[4][2] == 'Armin'
-        assert messages[4][3] == []
-        assert messages[5][2] == ('Hello, {0} and {1}!', None)
-        assert messages[5][3] == ['NOTE: Third']
-        assert messages[6][2] == 'Heungsub'
-        assert messages[6][3] == []
-        assert messages[7][2] == 'Armin'
-        assert messages[7][3] == []
+        assert [(m[2], m[3]) for m in messages] == [
+            ('Foo Bar',                                             ['NOTE: First']),
+            (('Hello, {name}!', None),                              ['NOTE: First']),
+            ('Heungsub',                                            ['NOTE: Second']),
+            ('Armin',                                               []),
+            (('Hello, {name1} and {name2}!', None, None),           ['NOTE: Second']),
+            ('Heungsub',                                            ['NOTE: Third']),
+            ('Armin',                                               []),
+            (('Hello, {0} and {1}!', None, None),                   ['NOTE: Third']),
+            ('Person 1',                                            ['NOTE: Fourth']),
+            ('Person 2',                                            ['NOTE: Fourth']),
+            (('Hello %(person)s and %(other_person)s', None, None), ['NOTE: Fourth']),
+            ('Person 1',                                            []),
+            ('Person 2',                                            []),
+            (('Hello %(people)s', None),                            ['NOTE: Fifth']),
+        ]
 
 
 class ExtractTestCase(unittest.TestCase):


### PR DESCRIPTION
Currently the Python extractor does not support deeply nested gettext calls (deeper than as a direct argument to the top-level gettext call).

e.g.
```py
_("Hello %s", _("Person"))
_("Hello %s",
  random_function(", ".join([_("Person 1"), _("Person 2")])))
```

The extraction code was refactored quite a bit to simplify the flow and support this use-case.

Currently the Javascript extractor does not support nested gettext calls at all.

The extraction code was refactored a bit to resemble the Python code as much as possible and support this use-case.

Fixes https://github.com/python-babel/babel/issues/1125 (meanwhile also fixes https://github.com/python-babel/babel/issues/1123)