### PR TITLE
Fix the way obsolete messages are stored

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -239,7 +239,7 @@ class PoFileParser:
                           context=msgctxt)
         if self.obsolete:
             if not self.ignore_obsolete:
-                self.catalog.obsolete[msgid] = message
+                self.catalog.obsolete[self.catalog._key_for(msgid, msgctxt)] = message
         else:
             self.catalog[msgid] = message
         self.counter += 1

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -330,6 +330,31 @@ msgstr "Bahr"
         assert orange_msg.string == 'Bar'
         assert orange_msg.user_comments == ['This is an obsolete message with the same id but different context']
 
+    def test_obsolete_messages_roundtrip(self):
+        buf = StringIO('''\
+# This message is not obsolete
+#: main.py:1
+msgid "bar"
+msgstr "Bahr"
+
+# This is an obsolete message
+#~ msgid "foo"
+#~ msgstr "Voh"
+
+# This is an obsolete message
+#~ msgctxt "apple"
+#~ msgid "foo"
+#~ msgstr "Foo"
+
+# This is an obsolete message with the same id but different context
+#~ msgctxt "orange"
+#~ msgid "foo"
+#~ msgstr "Bar"
+
+''')
+        generated_po_file = ''.join(pofile.generate_po(pofile.read_po(buf), omit_header=True))
+        assert buf.getvalue() == generated_po_file
+
     def test_multiline_context(self):
         buf = StringIO('''
 msgctxt "a really long "

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -299,9 +299,36 @@ msgstr "Bahr"
         catalog = pofile.read_po(buf)
         assert len(catalog) == 2
         assert len(catalog.obsolete) == 1
-        message = catalog.obsolete["foo"]
+        message = catalog.obsolete[("foo", "other")]
         assert message.context == 'other'
         assert message.string == 'Voh'
+
+    def test_obsolete_messages_with_context(self):
+        buf = StringIO('''
+# This is an obsolete message
+#~ msgctxt "apple"
+#~ msgid "foo"
+#~ msgstr "Foo"
+
+# This is an obsolete message with the same id but different context
+#~ msgctxt "orange"
+#~ msgid "foo"
+#~ msgstr "Bar"
+''')
+        catalog = pofile.read_po(buf)
+        assert len(catalog) == 0
+        assert len(catalog.obsolete) == 2
+        assert 'foo' not in catalog.obsolete
+
+        apple_msg = catalog.obsolete[('foo', 'apple')]
+        assert apple_msg.id == 'foo'
+        assert apple_msg.string == 'Foo'
+        assert apple_msg.user_comments == ['This is an obsolete message']
+
+        orange_msg = catalog.obsolete[('foo', 'orange')]
+        assert orange_msg.id == 'foo'
+        assert orange_msg.string == 'Bar'
+        assert orange_msg.user_comments == ['This is an obsolete message with the same id but different context']
 
     def test_multiline_context(self):
         buf = StringIO('''
@@ -394,7 +421,7 @@ msgstr[1] "Vohs [text]"''')
         assert len(catalog) == 0
         assert len(catalog.obsolete) == 1
         assert catalog.num_plurals == 2
-        message = catalog.obsolete[('foo', 'foos')]
+        message = catalog.obsolete['foo']
         assert len(message.string) == 2
         assert message.string[0] == 'Voh [text]'
         assert message.string[1] == 'Vohs [text]'


### PR DESCRIPTION
Closes #1124 

Previously, the `Catalog.obsolete` dictionary would use the `msgid` as a key to store messages.
When there are two messages with the same id but a different context, the latter one overwrites the former.

The fix is  to use `Catalog._get_key` as the key, same as for `_messages`.

This might be considered a breaking change, however the only documentation for `Catalog.obsolete` is [this](https://babel.pocoo.org/en/latest/api/messages/catalog.html#babel.messages.catalog.Catalog.update):
![image](https://github.com/user-attachments/assets/ab54286b-843b-4041-8784-d71a24f6c6cb)

The docs never say anything about how the keys are computed, so I think it should be safe to make this change (and perhaps document it too?)

