### PR TITLE
Fix of list index out of range error in PoFileParser.add_message when translations is empty

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -249,7 +249,7 @@ class PoFileParser:
         if self.messages:
             if not len(self.translations):
                 self.translations.append([0, _NormalizedString("")])
-                self._invalid_pofile("", self.offset, "invalid PO file provided")
+                self._invalid_pofile("", self.offset, "invalid po file provided")
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -249,7 +249,7 @@ class PoFileParser:
         if self.messages:
             if not len(self.translations):
                 self.translations.append([0, _NormalizedString("")])
-                self._invalid_pofile("", self.offset, "invalid po file provided")
+                self._invalid_pofile("", self.offset, f"missing msgstr for msgid: {self.messages[0].denormalize()}")
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -249,7 +249,7 @@ class PoFileParser:
         if self.messages:
             if not len(self.translations):
                 self.translations.append([0, _NormalizedString("")])
-                self._invalid_pofile("", self.offset, f"missing msgstr for msgid: {self.messages[0].denormalize()}")
+                self._invalid_pofile("", self.offset, f"missing msgstr for msgid: '{self.messages[0].denormalize()}'")
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -247,6 +247,9 @@ class PoFileParser:
 
     def _finish_current_message(self) -> None:
         if self.messages:
+            if not len(self.translations):
+                self.translations.append([0, _NormalizedString("")])
+                self._invalid_pofile("", self.offset, "invalid PO file provided")
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -248,8 +248,8 @@ class PoFileParser:
     def _finish_current_message(self) -> None:
         if self.messages:
             if not self.translations:
-                self.translations.append([0, _NormalizedString("")])
                 self._invalid_pofile("", self.offset, f"missing msgstr for msgid '{self.messages[0].denormalize()}'")
+                self.translations.append([0, _NormalizedString("")])
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -249,7 +249,7 @@ class PoFileParser:
         if self.messages:
             if not self.translations:
                 self.translations.append([0, _NormalizedString("")])
-                self._invalid_pofile("", self.offset, f"missing msgstr for msgid: '{self.messages[0].denormalize()}'")
+                self._invalid_pofile("", self.offset, f"missing msgstr for msgid '{self.messages[0].denormalize()}'")
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1014,3 +1014,8 @@ msgstr ""
 "Language: \n"
 ''')
     assert pofile.read_po(buf).locale is None
+
+def test_issue_1134():
+    buf = StringIO(r'msgid "this is an invalid po file"')
+    with pytest.raises(pofile.PoFileError):
+        pofile.read_po(buf, abort_invalid=True)

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1016,6 +1016,8 @@ msgstr ""
     assert pofile.read_po(buf).locale is None
 
 def test_issue_1134():
-    buf = StringIO(r'msgid "this is an invalid po file"')
+    buf = StringIO('''msgid "this is an invalid po file"
+msgstr "hello world"
+msgid "msgid without str"''')
     with pytest.raises(pofile.PoFileError):
         pofile.read_po(buf, abort_invalid=True)

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1016,8 +1016,8 @@ msgstr ""
     assert pofile.read_po(buf).locale is None
 
 def test_issue_1134():
-    buf = StringIO('''msgid "this is an invalid po file"
-msgstr "hello world"
-msgid "msgid without str"''')
+    buf = StringIO('''
+msgid "foo"
+"''')
     with pytest.raises(pofile.PoFileError):
         pofile.read_po(buf, abort_invalid=True)

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1016,8 +1016,37 @@ msgstr ""
     assert pofile.read_po(buf).locale is None
 
 def test_issue_1134():
+    # creating multiple copies of IO objects so function calls do not effect later calls.
     buf = StringIO('''
 msgid "foo"
 "''')
-    with pytest.raises(pofile.PoFileError):
+
+    # Catalog is created with warning, no abort
+    output = pofile.read_po(buf)
+    assert isinstance(output, Catalog)
+
+    buf = StringIO('''
+msgid "foo"
+"''')
+
+    # Catalog not created, aborted with PoFileError
+    with pytest.raises(pofile.PoFileError) as excinfo:
         pofile.read_po(buf, abort_invalid=True)
+    assert(str(excinfo.value)) == "missing msgstr for msgid 'foo' on 1"
+
+    buf = StringIO('''
+msgid "foo"
+msgid_plural "foos"
+"''')
+
+    # Catalog not created, aborted with PoFileError
+    with pytest.raises(pofile.PoFileError) as e:
+        pofile.read_po(buf, abort_invalid=True)
+    assert(str(e.value)) == "missing msgstr for msgid 'foo' on 1"
+
+
+
+
+
+    
+

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1024,7 +1024,9 @@ msgid "foo"
     # Catalog is created with warning, no abort
     output = pofile.read_po(buf)
     assert isinstance(output, Catalog)
-
+    assert len(output._messages) == 1
+    assert output.messages["foo"].string == ''
+    
     buf = StringIO('''
 msgid "foo"
 "''')

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1043,10 +1043,3 @@ msgid_plural "foos"
     with pytest.raises(pofile.PoFileError) as e:
         pofile.read_po(buf, abort_invalid=True)
     assert(str(e.value)) == "missing msgstr for msgid 'foo' on 1"
-
-
-
-
-
-    
-

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1045,3 +1045,4 @@ msgid_plural "foos"
     with pytest.raises(pofile.PoFileError) as excinfo:
         pofile.read_po(buf, abort_invalid=True)
     assert str(excinfo.value) == "missing msgstr for msgid 'foo' on 1"
+    


### PR DESCRIPTION
Addresses https://github.com/python-babel/babel/issues/1134

Previously, the `add_message` function would try to access the PoFileParser object's translations list without any checks. However, when an invalid po file is provided, this can lead to an index out of range error.

This PR adds a check to the `_finish_current_message` function and raises an `invalid_pofile` exception when the messages list is populated and translations is empty. This also adds a dummy translation to the translations list to avoid the index out of range error when an `invalid_pofile` exception is treated as a warning rather than raised.