### PR TITLE
Fix #774: Allow object methods to be used as extraction-keywords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         # higher.
         # Python 3.9 and later include zoneinfo which replaces pytz
         'pytz>=2015.7; python_version<"3.9"',
+        'more-itertools'
     ],
     extras_require={
         'dev': [

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -441,6 +441,19 @@ _(u'Hello, {0} and {1}!', _(u'Heungsub'),
         assert messages[7][2] == 'Armin'
         assert messages[7][3] == []
 
+    def test_dotted_keywords(self):
+        buf = BytesIO(b"""\
+msg0 = self.gettext('Hello there')
+msg1 = self.gettext('Thanks {user}', name=self.gettext('User'))
+msg3 = self.gettext('Can use {both}', both=gettext('gettexts'))
+""")
+        messages = list(extract.extract_python(buf, ('self.gettext', 'gettext'), [], {}))
+        assert messages[0] == (1, 'self.gettext', 'Hello there', [])
+        assert messages[1] == (2, 'self.gettext', ('Thanks {user}', None), [])
+        assert messages[2] == (2, 'self.gettext', 'User', [])
+        assert messages[3] == (3, 'self.gettext', ('Can use {both}', None), [])
+        assert messages[4] == (3, 'gettext', 'gettexts', [])
+
 
 class ExtractTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Proof of concept fix for #774.  I did this quickly using `peekable()` from the more-itertools package, but if adding a new dependency just for this is (understandably) undesirable, it could be fixed just as easily with slight improvements to the generate tokens loop (in fact I had a version of that working earlier, but it gets a bit hairier with the nested case).

This would conflict with #1127, so if this is otherwise acceptable as a feature can rebase on top of that and without using more-itertools.