### PR TITLE
Mark `wraptext` deprecated; use `TextWrapper` directly in `write_po`

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from babel.core import Locale
 from babel.messages.catalog import Catalog, Message
-from babel.util import _cmp, wraptext
+from babel.util import TextWrapper, _cmp
 
 if TYPE_CHECKING:
     from typing import IO, AnyStr
@@ -634,8 +634,11 @@ def generate_po(
     # provide the same behaviour
     comment_width = width if width and width > 0 else 76
 
+    comment_wrapper = TextWrapper(width=comment_width)
+    header_wrapper = TextWrapper(width=width, subsequent_indent="# ")
+
     def _format_comment(comment, prefix=''):
-        for line in wraptext(comment, comment_width):
+        for line in comment_wrapper.wrap(comment):
             yield f"#{prefix} {line.strip()}\n"
 
     def _format_message(message, prefix=''):
@@ -665,8 +668,7 @@ def generate_po(
             if width and width > 0:
                 lines = []
                 for line in comment_header.splitlines():
-                    lines += wraptext(line, width=width,
-                                      subsequent_indent='# ')
+                    lines += header_wrapper.wrap(line)
                 comment_header = '\n'.join(lines)
             yield f"{comment_header}\n"
 

--- a/babel/util.py
+++ b/babel/util.py
@@ -15,6 +15,7 @@ import datetime
 import os
 import re
 import textwrap
+import warnings
 from collections.abc import Generator, Iterable
 from typing import IO, Any, TypeVar
 
@@ -217,6 +218,12 @@ def wraptext(text: str, width: int = 70, initial_indent: str = '', subsequent_in
     :param subsequent_indent: string that will be prepended to all lines save
                               the first of wrapped output
     """
+    warnings.warn(
+        "babel.util.wraptext is deprecated and will be removed in a future version of Babel. "
+        "If you need this functionality, use the `babel.util.TextWrapper` class directly.",
+        PendingDeprecationWarning,
+        stacklevel=2,
+    )
     wrapper = TextWrapper(width=width, initial_indent=initial_indent,
                           subsequent_indent=subsequent_indent,
                           break_long_words=False)

--- a/babel/util.py
+++ b/babel/util.py
@@ -219,9 +219,9 @@ def wraptext(text: str, width: int = 70, initial_indent: str = '', subsequent_in
                               the first of wrapped output
     """
     warnings.warn(
-        "babel.util.wraptext is deprecated and will be removed in a future version of Babel. "
+        "`babel.util.wraptext` is deprecated and will be removed in a future version of Babel. "
         "If you need this functionality, use the `babel.util.TextWrapper` class directly.",
-        PendingDeprecationWarning,
+        DeprecationWarning,
         stacklevel=2,
     )
     wrapper = TextWrapper(width=width, initial_indent=initial_indent,


### PR DESCRIPTION
Related to #1120.