### PR TITLE
Fix `pybabel update --init-missing` not creating parent directory

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -626,8 +626,8 @@ class InitCatalog(CommandMixin):
             self.output_file = os.path.join(self.output_dir, self.locale,
                                             'LC_MESSAGES', f"{self.domain}.po")
 
-        if not os.path.exists(os.path.dirname(self.output_file)):
-            os.makedirs(os.path.dirname(self.output_file))
+        os.makedirs(os.path.dirname(self.output_file),exist_ok=True)
+
         if self.no_wrap and self.width:
             raise OptionError("'--no-wrap' and '--width' are mutually exclusive")
         if not self.no_wrap and not self.width:

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -779,21 +779,17 @@ class UpdateCatalog(CommandMixin):
                 if self.check:
                     check_status[filename] = False
                     continue
-                self.log.info(
-                    'creating catalog %s based on %s', filename, self.input_file,
-                )
 
-                with open(self.input_file, 'rb') as infile:
-                    # Although reading from the catalog template, read_po must
-                    # be fed the locale in order to correctly calculate plurals
-                    catalog = read_po(infile, locale=self.locale)
-
-                catalog.locale = self._locale
-                catalog.revision_date = datetime.datetime.now(LOCALTZ)
-                catalog.fuzzy = False
-
-                with open(filename, 'wb') as outfile:
-                    write_po(outfile, catalog)
+                tmpInitCatalog = InitCatalog(self.distribution)
+                tmpInitCatalog.output_dir = None
+                tmpInitCatalog.output_file = filename
+                tmpInitCatalog.input_file = self.input_file
+                tmpInitCatalog.locale = self.locale
+                tmpInitCatalog.domain = self.domain
+                tmpInitCatalog.no_wrap = self.no_wrap
+                tmpInitCatalog.width = self.width
+                tmpInitCatalog.finalize_options()
+                tmpInitCatalog.run()
 
             self.log.info('updating catalog %s based on %s', filename, self.input_file)
             with open(filename, 'rb') as infile:


### PR DESCRIPTION

Replaced the redundant init logic in `UpdateCatalog.run()` with a temporary `InitCatalog` instance to ensure the parent directory of the output file will be created. (close #1139)