### PR TITLE
Use CLDR 46

### DIFF
--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -9,10 +9,10 @@ import sys
 import zipfile
 from urllib.request import urlretrieve
 
-URL = 'https://unicode.org/Public/cldr/45/cldr-common-45.0.zip'
-FILENAME = 'cldr-common-45.0.zip'
+URL = 'https://unicode.org/Public/cldr/46/cldr-common-46.0.zip'
+FILENAME = 'cldr-common-46.0.zip'
 # Via https://unicode.org/Public/cldr/45/hashes/SHASUM512.txt
-FILESUM = '638123882bd29911fc9492ec152926572fec48eb6c1f5dd706aee3e59cad8be4963a334bb7a09a645dbedc3356f60ef7ac2ef7ab4ccf2c8926b547782175603c'
+FILESUM = 'e0729de0d7fa8b7db620014ed16129a14f3be2f45191626c1a26778b2aa0eabe488752ff5e39da645c2dc7e8046b25a0eeef8e9ae472d26abe05a0efc8059654'
 BLKSIZE = 131072
 
 

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -12,7 +12,7 @@ from urllib.request import urlretrieve
 URL = 'https://unicode.org/Public/cldr/46/cldr-common-46.0.zip'
 FILENAME = 'cldr-common-46.0.zip'
 # Via https://unicode.org/Public/cldr/45/hashes/SHASUM512.txt
-FILESUM = 'e0729de0d7fa8b7db620014ed16129a14f3be2f45191626c1a26778b2aa0eabe488752ff5e39da645c2dc7e8046b25a0eeef8e9ae472d26abe05a0efc8059654'
+FILESUM = '316d644b79a4976d4da57d59ca57c689b339908fe61bb49110bfe1a9269c94144cb27322a0ea080398e6dc4c54a16752fd1ca837e14c054b3a6806b1ef9d3ec3'
 BLKSIZE = 131072
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -362,3 +362,16 @@ def test_issue_1112():
         Locale.parse('de_DE').territories['TR'] ==
         'Türkei'
     )
+
+
+def test_language_alt_official_not_used():
+    # If there exists an official and customary language name, the customary
+    # name should be used.
+    #
+    # For example, here 'Muscogee' should be used instead of 'Mvskoke':
+    # <language type="mus">Muscogee</language>
+	# <language type="mus" alt="official">Mvskoke</language>
+
+    locale = Locale('mus')
+    assert locale.get_display_name() == 'Mvskoke'
+    assert locale.get_display_name(Locale('en')) == 'Muscogee'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -370,7 +370,7 @@ def test_language_alt_official_not_used():
     #
     # For example, here 'Muscogee' should be used instead of 'Mvskoke':
     # <language type="mus">Muscogee</language>
-	# <language type="mus" alt="official">Mvskoke</language>
+    # <language type="mus" alt="official">Mvskoke</language>
 
     locale = Locale('mus')
     assert locale.get_display_name() == 'Mvskoke'

--- a/tests/test_date_intervals.py
+++ b/tests/test_date_intervals.py
@@ -9,7 +9,7 @@ TEST_DATE = TEST_DT.date()
 
 
 def test_format_interval_same_instant_1():
-    assert dates.format_interval(TEST_DT, TEST_DT, "yMMMd", fuzzy=False, locale="fi") == "8. tammik. 2016"
+    assert dates.format_interval(TEST_DT, TEST_DT, "yMMMd", fuzzy=False, locale="fi") == "8.1.2016"
 
 
 def test_format_interval_same_instant_2():

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -188,7 +188,8 @@ class NumberParsingTestCase(unittest.TestCase):
     def test_can_parse_decimals(self):
         assert decimal.Decimal('1099.98') == numbers.parse_decimal('1,099.98', locale='en_US')
         assert decimal.Decimal('1099.98') == numbers.parse_decimal('1.099,98', locale='de')
-        assert decimal.Decimal('1099.98') == numbers.parse_decimal('1٬099٫98', locale='ar', numbering_system="default")
+        assert decimal.Decimal('1099.98') == numbers.parse_decimal('1,099.98', locale='ar', numbering_system="default")
+        assert decimal.Decimal('1099.98') == numbers.parse_decimal('1٬099٫98', locale='ar_EG', numbering_system="default")
         with pytest.raises(numbers.NumberFormatError):
             numbers.parse_decimal('2,109,998', locale='de')
         with pytest.raises(numbers.UnsupportedNumberingSystemError):
@@ -249,7 +250,7 @@ def test_list_currencies():
 
     assert list_currencies(locale='pa_Arab') == {'PKR', 'INR', 'EUR'}
 
-    assert len(list_currencies()) == 306
+    assert len(list_currencies()) == 307
 
 
 def test_validate_currency():
@@ -300,7 +301,7 @@ def test_get_currency_precision():
 
 def test_get_currency_unit_pattern():
     assert get_currency_unit_pattern('USD', locale='en_US') == '{0} {1}'
-    assert get_currency_unit_pattern('USD', locale='es_GT') == '{1} {0}'
+    assert get_currency_unit_pattern('USD', locale='sw') == '{1} {0}'
 
     # 'ro' locale various pattern according to count
     assert get_currency_unit_pattern('USD', locale='ro', count=1) == '{0} {1}'
@@ -598,7 +599,7 @@ def test_format_currency_long_display_name():
             == '1.00 dola ya Marekani')
     # This tests unicode chars:
     assert (numbers.format_currency(1099.98, 'USD', locale='es_GT', format_type='name')
-            == 'dólares estadounidenses 1,099.98')
+            == '1,099.98 dólares estadounidenses')
     # Test for completely unknown currency, should fallback to currency code
     assert (numbers.format_currency(1099.98, 'XAB', locale='en_US', format_type='name')
             == '1,099.98 XAB')

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,19 @@
+import pytest
+
+from babel.units import format_unit
+
+
+# New units in CLDR 46
+@pytest.mark.parametrize(('unit', 'count', 'expected'), [
+    ('speed-light-speed', 1, '1 světlo'),
+    ('speed-light-speed', 2, '2 světla'),
+    ('speed-light-speed', 5, '5 světel'),
+    ('concentr-portion-per-1e9', 1, '1 částice na miliardu'),
+    ('concentr-portion-per-1e9', 2, '2 částice na miliardu'),
+    ('concentr-portion-per-1e9', 5, '5 částic na miliardu'),
+    ('duration-night', 1, '1 noc'),
+    ('duration-night', 2, '2 noci'),
+    ('duration-night', 5, '5 nocí'),
+])
+def test_new_cldr46_units(unit, count, expected):
+    assert format_unit(count, unit, locale='cs_CZ') == expected


### PR DESCRIPTION
[CLDR 46](https://cldr.unicode.org/downloads/cldr-46) is out now, let's upgrade.

Looking at the release notes, I don't think there's anything we need to update in babel, but another pair of eyes would be nice :)