### PR TITLE
Changed get_week_number() to fix a problem with the locale en_AU

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1659,7 +1659,7 @@ class DateTimeFormat:
             # weeks, thus the weeknumber must be 53-52=1.
             max_weeks = datetime.date(year=self.value.year, day=28, month=12).isocalendar()[1]
             if week_number > max_weeks:
-                week_number -= max_weeks
+                week_number -= 1
 
         return week_number
 

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1656,7 +1656,7 @@ class DateTimeFormat:
             # If the weeknumber exceeds the maximum number of weeks for the given year
             # we must count from zero.For example the above calculation gives week 53
             # for 2018-12-31. By iso-calender definition 2018 has a max of 52
-            # weeks, thus the weeknumber must be 53-52=1.
+            # weeks, thus the weeknumber must be 53-1=52.
             max_weeks = datetime.date(year=self.value.year, day=28, month=12).isocalendar()[1]
             if week_number > max_weeks:
                 week_number -= 1


### PR DESCRIPTION
This is my first pull-request ever, so don't hesitate to give me feedback on anything

If my analysis is correct, get_week_number() made it impossible for iso-calendar to show their last week, because the week_number was fixed from 53 to 1, while it should be fixed to 52.
That's why the year wasn't updated and the result was "W1 2023", it should be "W52 2023".

Hope this helps !

Fixes [#1133 ](https://github.com/python-babel/babel/issues/1133#issue-2544396234)