### PR TITLE
Replace `OrderedDict` with just `dict`

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import datetime
 import re
-from collections import OrderedDict
 from collections.abc import Iterable, Iterator
 from copy import copy
 from difflib import SequenceMatcher
@@ -317,7 +316,7 @@ class Catalog:
         self.domain = domain
         self.locale = locale
         self._header_comment = header_comment
-        self._messages: OrderedDict[str | tuple[str, str], Message] = OrderedDict()
+        self._messages: dict[str | tuple[str, str], Message] = {}
 
         self.project = project or 'PROJECT'
         self.version = version or 'VERSION'
@@ -344,7 +343,7 @@ class Catalog:
         self.fuzzy = fuzzy
 
         # Dictionary of obsolete messages
-        self.obsolete: OrderedDict[str | tuple[str, str], Message] = OrderedDict()
+        self.obsolete: dict[str | tuple[str, str], Message] = {}
         self._num_plurals = None
         self._plural_expr = None
 
@@ -829,7 +828,7 @@ class Catalog:
         """
         messages = self._messages
         remaining = messages.copy()
-        self._messages = OrderedDict()
+        self._messages = {}
 
         # Prepare for fuzzy matching
         fuzzy_candidates = {}

--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -20,7 +20,6 @@ import shutil
 import sys
 import tempfile
 import warnings
-from collections import OrderedDict
 from configparser import RawConfigParser
 from io import StringIO
 from typing import BinaryIO, Iterable, Literal
@@ -1019,7 +1018,6 @@ def parse_mapping_cfg(fileobj, filename=None):
     options_map = {}
 
     parser = RawConfigParser()
-    parser._sections = OrderedDict(parser._sections)  # We need ordered sections
     parser.read_file(fileobj, filename)
 
     for section in parser.sections():

--- a/babel/util.py
+++ b/babel/util.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 import codecs
-import collections
 import datetime
 import os
 import re
@@ -231,7 +230,7 @@ def wraptext(text: str, width: int = 70, initial_indent: str = '', subsequent_in
 
 
 # TODO (Babel 3.x): Remove this re-export
-odict = collections.OrderedDict
+odict = dict
 
 
 class FixedOffsetTimezone(datetime.tzinfo):


### PR DESCRIPTION
Since python 3.7, `dict` preserves insertion order. I think we can safely replace `OrderedDict` with `dict`.