### PR TITLE
Check pofile string delimiters

### DIFF
--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from typing_extensions import Literal
 
 
+_ESCAPED_CHARACTER_PATTERN = re.compile(r'\\([\\trn"])')
+
 def unescape(string: str) -> str:
     r"""Reverse `escape` the given string.
 
@@ -46,7 +48,7 @@ def unescape(string: str) -> str:
             return '\r'
         # m is \ or "
         return m
-    return re.compile(r'\\([\\trn"])').sub(replace_escapes, string[1:-1])
+    return _ESCAPED_CHARACTER_PATTERN.sub(replace_escapes, string[1:-1])
 
 
 def denormalize(string: str) -> str:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -144,7 +144,8 @@ class _NormalizedString:
             self.append(arg)
 
     def append(self, s: str) -> None:
-        self._strs.append(s.strip())
+        assert s[0] == '"' and s[-1] == '"'
+        self._strs.append(s)
 
     def denormalize(self) -> str:
         return ''.join(map(unescape, self._strs))

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -278,6 +278,17 @@ class PoFileParser:
 
         self.obsolete = obsolete
 
+        def _normalized_string(s):
+            # whole lines are already stripped on both ends
+            s = s.lstrip()
+            if s[0] != '"':
+                self._invalid_pofile(line, lineno, "String must be delimited on the left by double quotes")
+                s = '"' + s
+            if s[-1] != '"':
+                self._invalid_pofile(line, lineno, "String must be delimited on the left by double quotes")
+                s += '"'
+            return _NormalizedString(s)
+
         # The line that has the msgid is stored as the offset of the msg
         # should this be the msgctxt if it has one?
         if keyword == 'msgid':
@@ -286,20 +297,20 @@ class PoFileParser:
         if keyword in ['msgid', 'msgid_plural']:
             self.in_msgctxt = False
             self.in_msgid = True
-            self.messages.append(_NormalizedString(arg))
+            self.messages.append(_normalized_string(arg))
 
         elif keyword == 'msgstr':
             self.in_msgid = False
             self.in_msgstr = True
             if arg.startswith('['):
                 idx, msg = arg[1:].split(']', 1)
-                self.translations.append([int(idx), _NormalizedString(msg)])
+                self.translations.append([int(idx), _normalized_string(msg)])
             else:
-                self.translations.append([0, _NormalizedString(arg)])
+                self.translations.append([0, _normalized_string(arg)])
 
         elif keyword == 'msgctxt':
             self.in_msgctxt = True
-            self.context = _NormalizedString(arg)
+            self.context = _normalized_string(arg)
 
     def _process_string_continuation_line(self, line, lineno) -> None:
         if self.in_msgid:
@@ -311,6 +322,10 @@ class PoFileParser:
         else:
             self._invalid_pofile(line, lineno, "Got line starting with \" but not in msgid, msgstr or msgctxt")
             return
+        assert line[0] == '"'
+        if line[-1] != '"':
+            self._invalid_pofile(line, lineno, "String must be delimited by double quotes")
+            line += '"'
         s.append(line)
 
     def _process_comment(self, line) -> None:

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -251,7 +251,7 @@ class PoFileParser:
         if self.messages:
             if not self.translations:
                 self._invalid_pofile("", self.offset, f"missing msgstr for msgid '{self.messages[0].denormalize()}'")
-                self.translations.append([0, _NormalizedString("")])
+                self.translations.append([0, _NormalizedString('""')])
             self._add_message()
 
     def _process_message_line(self, lineno, line, obsolete=False) -> None:

--- a/tests/messages/test_normalized_string.py
+++ b/tests/messages/test_normalized_string.py
@@ -4,19 +4,14 @@ from babel.messages.pofile import _NormalizedString
 
 
 def test_normalized_string():
-    ab1 = _NormalizedString('"a"', '"b" ')
-    ab2 = _NormalizedString('"a"', ' "b"')
-    ac1 = _NormalizedString('"a"', '"c"')
-    ac2 = _NormalizedString('  "a"', '"c"  ')
+    ab = _NormalizedString('"a"', '"b"')
+    ac = _NormalizedString('"a"', '"c"')
     z = _NormalizedString()
-    assert ab1 == ab2 and ac1 == ac2  # __eq__
-    assert ab1 < ac1  # __lt__
-    assert ac1 > ab2  # __gt__
-    assert ac1 >= ac2  # __ge__
-    assert ab1 <= ab2  # __le__
-    assert ab1 != ac1  # __ne__
+    assert ab < ac  # __lt__
+    assert ac > ab  # __gt__
+    assert ab != ac  # __ne__
     assert not z  # __nonzero__ / __bool__
-    assert sorted([ab1, ab2, ac1]) == [ab1, ab2, ac1] # sorted() is stable
+    assert sorted([ac, ab, z]) == [z, ab, ac] # sorted() is stable
 
 
 @pytest.mark.parametrize(
@@ -38,10 +33,10 @@ def test_denormalized_simple_normalized_string(original, denormalized):
     "originals, denormalized",
     (
         (('"a"', '"b"'), "ab"),
-        (('"a" ', '"b"'), "ab"),
+        (('"a"', '"b"'), "ab"),
         (('"ab"', '""'), "ab"),
         (('"ab"', '"c"'), "abc"),
-        (('"a"', '     "bc"'), "abc"),
+        (('"a"', '"bc"'), "abc"),
     ),
 )
 def test_denormalized_multi_normalized_string(originals, denormalized):

--- a/tests/messages/test_normalized_string.py
+++ b/tests/messages/test_normalized_string.py
@@ -14,4 +14,4 @@ def test_normalized_string():
     assert ab1 <= ab2  # __le__
     assert ab1 != ac1  # __ne__
     assert not z  # __nonzero__ / __bool__
-    assert sorted([ab1, ab2, ac1])  # the sort order is not stable so we can't really check it, just that we can sort
+    assert sorted([ab1, ab2, ac1]) == [ab1, ab2, ac1] # sorted() is stable

--- a/tests/messages/test_normalized_string.py
+++ b/tests/messages/test_normalized_string.py
@@ -1,11 +1,13 @@
+import pytest
+
 from babel.messages.pofile import _NormalizedString
 
 
 def test_normalized_string():
-    ab1 = _NormalizedString('a', 'b ')
-    ab2 = _NormalizedString('a', ' b')
-    ac1 = _NormalizedString('a', 'c')
-    ac2 = _NormalizedString('  a', 'c  ')
+    ab1 = _NormalizedString('"a"', '"b" ')
+    ab2 = _NormalizedString('"a"', ' "b"')
+    ac1 = _NormalizedString('"a"', '"c"')
+    ac2 = _NormalizedString('  "a"', '"c"  ')
     z = _NormalizedString()
     assert ab1 == ab2 and ac1 == ac2  # __eq__
     assert ab1 < ac1  # __lt__
@@ -15,3 +17,32 @@ def test_normalized_string():
     assert ab1 != ac1  # __ne__
     assert not z  # __nonzero__ / __bool__
     assert sorted([ab1, ab2, ac1]) == [ab1, ab2, ac1] # sorted() is stable
+
+
+@pytest.mark.parametrize(
+    "original, denormalized",
+    (
+        ('""', ""),
+        ('"a"', "a"),
+        ('"a\\n"', "a\n"),
+        ('"a\\r"', "a\r"),
+        ('"a\\t"', "a\t"),
+        ('"a\\""', 'a"'),
+        ('"a\\\\"', "a\\"),
+    ),
+)
+def test_denormalized_simple_normalized_string(original, denormalized):
+    assert denormalized == _NormalizedString(original).denormalize()
+
+@pytest.mark.parametrize(
+    "originals, denormalized",
+    (
+        (('"a"', '"b"'), "ab"),
+        (('"a" ', '"b"'), "ab"),
+        (('"ab"', '""'), "ab"),
+        (('"ab"', '"c"'), "abc"),
+        (('"a"', '     "bc"'), "abc"),
+    ),
+)
+def test_denormalized_multi_normalized_string(originals, denormalized):
+    assert denormalized == _NormalizedString(*originals).denormalize()

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -544,11 +544,6 @@ msgstr "bar"
         output = pofile.read_po(buf, locale='fr', abort_invalid=False)
         assert isinstance(output, Catalog)
 
-        # Catalog not created, aborted with PoFileError
-        buf = StringIO(invalid_po_2)
-        with pytest.raises(pofile.PoFileError):
-            pofile.read_po(buf, locale='fr', abort_invalid=True)
-
     def test_invalid_pofile_with_abort_flag(self):
         parser = pofile.PoFileParser(None, abort_invalid=True)
         lineno = 10

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -529,6 +529,22 @@ msgstr "bar"
             Pour toute question, veuillez communiquer avec Fulano a fulano@blah.com
             "
             '''
+        invalid_po_3 = '''
+            msgid *A"
+            msgstr "B"
+        '''
+
+        invalid_po_4 = '''
+            msgid "A"
+            msgstr "B*
+        '''
+
+        invalid_po_5 = '''
+            msgid "A"
+            msgstr ""
+            "*
+        '''
+
         # Catalog not created, throws Unicode Error
         buf = StringIO(invalid_po)
         output = pofile.read_po(buf, locale='fr', abort_invalid=False)
@@ -543,6 +559,12 @@ msgstr "bar"
         buf = StringIO(invalid_po_2)
         output = pofile.read_po(buf, locale='fr', abort_invalid=False)
         assert isinstance(output, Catalog)
+
+        # Catalog not created, aborted with PoFileError
+        for incorrectly_delimited_po_string in (invalid_po_3, invalid_po_4, invalid_po_5):
+            buf = StringIO(incorrectly_delimited_po_string)
+            with pytest.raises(pofile.PoFileError):
+                pofile.read_po(buf, locale='es', abort_invalid=True)
 
     def test_invalid_pofile_with_abort_flag(self):
         parser = pofile.PoFileParser(None, abort_invalid=True)


### PR DESCRIPTION
This PR adds checks to the pofile parser code to validate that message strings are correctly delimited by double quotes. Keeping with the current design, an error is only raised if requested, otherwise a warning is printed, the faulty lines are corrected and parsing goes on.

I found this issue while processing a pofile used in the Spanish translation of the CPython documentation. One of our files was incorrectly written, and from all our tooling only the `msgcat`  tool of GNU's `gettext` package complained, while `babel`, `polib` and others didn't. See https://github.com/python/python-docs-es/pull/2873, https://github.com/izimobil/polib/pull/161 and https://git.afpy.org/AFPy/powrap/pulls/4 for further reference. 

While implementing this change I found that the `_NormalizedString` class not only was used to contain message lines, but also participated in the parsing process (and hid some parsing as well). I thus broke down my changes into three separate commits:
 * I first clarified the usage of the *current* `_NormalizedString` class across the codebase (see details in commit).
 * I then added the double quote delimitation check logic I wanted to add to the parser
 * Now that all strings have the same form, I more formally constrained how `_NormalizedString` behaves

Along the way I also implemented three small quality-of-life changes. They are included as the first three commits of this PR, happy to submit these separately if required:
 * Avoid re-compiling a regular expression
 * Remove a duplicate test assertion
 * Perform a better assertion in a particular test, allegedly what was intended in the first place