### PR TITLE
Update CI to use python 3.13 and Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
           - "pypy3.10"
-          - "3.13-dev"
     env:
       BABEL_CLDR_NO_DOWNLOAD_PROGRESS: "1"
       BABEL_CLDR_QUIET: "1"
@@ -68,13 +68,13 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: lint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "**/setup.py"
       - run: pip install build -e .

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 isolated_build = true
 envlist =
-    py{38,39,310,311,312}
+    py{38,39,310,311,312,313}
     pypy3
     py{38}-pytz
-    py{311,312}-setuptools
-    py312-jinja
+    py{311,312,313}-setuptools
+    py{312,313}-jinja
 
 [testenv]
 extras =
@@ -37,3 +37,4 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313


### PR DESCRIPTION
- Add py3.13 to the CI/tox config
- Use Ubuntu 24.04 in CI