### PR TITLE
pybabel extract: Support multiple keywords with the same name/arity

### DIFF
--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -493,6 +493,42 @@ n = ngettext('foo')
         assert messages[0][1] == 'foo'
         assert messages[1][1] == ('hello', 'there')
 
+        def test_multiple_keywords(self):
+            buf = BytesIO(b"""
+        msg1 = _('foo')
+        msg2 = _('bar', 'bars', len(bars))
+        """)
+            keywords = {
+                '_': ((1,), (1, 2))
+            }
+            messages = \
+                list(extract.extract('python', buf, keywords, [], {}))
+
+            assert len(messages) == 3
+            assert messages[0][0] == 'foo'
+            assert messages[1][0] == 'bar'
+            assert messages[2][1] == 'bars'
+
+        def test_multiple_keywords_with_multiple_arities(self):
+            buf = BytesIO(b"""
+msg1 = _('foo')
+msg2 = _('bar', 'bars', len(bars))
+""")
+            keywords = {
+                '_': {
+                    1: (1,),
+                    3: ((1,), (2,)),
+                }
+            }
+            messages = \
+                list(extract.extract('python', buf, keywords, [], {}))
+
+            assert len(messages) == 3
+            assert messages[0][0] == 'foo'
+            assert messages[1][0] == 'bar'
+            assert messages[2][1] == 'bars'
+
+
     def test_empty_string_msgid(self):
         buf = BytesIO(b"""\
 msg = _('')

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1496,6 +1496,17 @@ def test_parse_keywords():
     }
 
 
+def test_parse_duplicate_keywords():
+    kw = frontend.parse_keywords(['_', '_:1,2', '_:3,4', 'dgettext:1', 'dgettext:1,2',
+                                 'pgettext:1,2'])
+
+    assert kw == {
+        '_': (None, (1, 2), (3, 4)),
+        'dgettext': ((1,), (1, 2)),
+        'pgettext': (1, 2),
+    }
+
+
 def test_parse_keywords_with_t():
     kw = frontend.parse_keywords(['_:1', '_:2,2t', '_:2c,3,3t'])
 
@@ -1505,6 +1516,17 @@ def test_parse_keywords_with_t():
             2: (2,),
             3: ((2, 'c'), 3),
         },
+    }
+
+
+def test_parse_duplicate_keywords_with_t():
+    kw = frontend.parse_keywords(['_:1', '_:1,2', '_:2,3t', '_:3,3t'])
+
+    assert kw == {
+        '_': {
+            None: ((1,), (1,2)),
+            3: ((2,), (3,)),
+        }
     }
 
 


### PR DESCRIPTION
Extend pybabel extract's keywords dict format to support multiple keywords with same function name and number of arguments.

Fixes #1067 : pybabel extract command from CLI only respects the first argument passed into keywords

I've been working on a fix for this and I have it working. I've had to extend the keywords dict format to allow for multiple specs per number of arguments, but I've made sure the old format is still accepted (and generated by default, if the extended format isn't required), and all existing unit tests still pass without changes. However I feel my code isn't the most elegant so I would welcome feedback.

The main issue as I see it is that I've used tuples to contain the multiple specs. This creates a situation where we can have several nested tuples and it's difficult to distinguish a tuple for an individual spec from a tuple enclosing (potentially) multiple specs. Would it be more suitable to use a list instead when we need to store multiple specs in the dictionary, or would this introduce too much overhead/potential errors?