### PR TITLE
Fix: Handle None value for locale in format_currency

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -774,6 +774,8 @@ def format_currency(
                                           locale=locale, currency_digits=currency_digits,
                                           decimal_quantization=decimal_quantization, group_separator=group_separator,
                                           numbering_system=numbering_system)
+    if locale is None:
+        locale = default_locale()
     locale = Locale.parse(locale)
     if format:
         pattern = parse_pattern(format)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -485,6 +485,11 @@ def test_format_currency():
     assert (numbers.format_currency(0, 'USD', locale='es_AR')
             == 'US$0,00')          # other
 
+def test_format_currency_with_none_locale():
+    assert (numbers.format_currency(0, "USD", locale=None) 
+            == "0,00\xa0$US")
+    assert (numbers.format_currency(1099.98, "EUR", locale=None) 
+            == "1\u202f099,98\xa0€")
 
 def test_format_currency_format_type():
     assert (numbers.format_currency(1099.98, 'USD', locale='en_US',


### PR DESCRIPTION
### Summary
This PR fixes the issue where passing `None` as the `locale` to `babel.numbers.format_currency` caused a TypeError. The function now defaults to the system's default locale when `locale=None`.

### Related Issue
Closes #1156

### Changes Made
- Updated `format_currency` in `babel/numbers.py` to default to `default_locale()` when `locale=None`.
- Added tests to `tests/test_numbers.py`:
  - `test_format_currency_with_none_locale`