### PR TITLE
Bump CI/tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       env:
         COVERAGE_XML_PATH: ${{ runner.temp }}
         BABEL_TOX_EXTRA_DEPS: pytest-github-actions-annotate-failures
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v5
       with:
         directory: ${{ runner.temp }}
         flags: ${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-22.04"
+          - "ubuntu-24.04"
           - "windows-2022"
-          - "macos-12"
+          - "macos-14"
         python-version:
           - "3.8"
           - "3.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.1
+    rev: v0.8.2
     hooks:
       - id: ruff
         args:
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -65,7 +65,7 @@ class TranslationsTestCase(unittest.TestCase):
 
     def assertEqualTypeToo(self, expected, result):
         assert expected == result
-        assert type(expected) == type(result), f"instance types do not match: {type(expected)!r}!={type(result)!r}"
+        assert type(expected) is type(result), f"instance types do not match: {type(expected)!r}!={type(result)!r}"
 
     def test_pgettext(self):
         self.assertEqualTypeToo('Voh', self.translations.gettext('foo'))


### PR DESCRIPTION
Follows up on #1153 to use Ubuntu 24.04 for tests too, and bumps to macOS 14 from the [now-deprecated](https://github.com/actions/runner-images/issues/10721) macOS 12 runner.