### PR TITLE
Strip extra leading slashes in `/etc/localtime`

### DIFF
--- a/babel/localtime/_unix.py
+++ b/babel/localtime/_unix.py
@@ -45,7 +45,13 @@ def _get_localzone(_root: str = '/') -> datetime.tzinfo:
     else:
         pos = link_dst.find('/zoneinfo/')
         if pos >= 0:
-            zone_name = link_dst[pos + 10:]
+            # On occasion, the `/etc/localtime` symlink has a double slash, e.g.
+            # "/usr/share/zoneinfo//UTC", which would make `zoneinfo.ZoneInfo`
+            # complain (no absolute paths allowed), and we'd end up returning
+            # `None` (as a fix for #1092).
+            # Instead, let's just "fix" the double slash symlink by stripping
+            # leading slashes before passing the assumed zone name forward.
+            zone_name = link_dst[pos + 10:].lstrip("/")
             tzinfo = _get_tzinfo(zone_name)
             if tzinfo is not None:
                 return tzinfo

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -40,5 +40,5 @@ def test_issue_990(monkeypatch):
     fake_readlink = Mock(return_value="/usr/share/zoneinfo////UTC")  # Double slash, oops!
     monkeypatch.setattr(os, "readlink", fake_readlink)
     from babel.localtime._unix import _get_localzone
-    assert _get_localzone()
+    assert _get_localzone() is not None
     fake_readlink.assert_called_with("/etc/localtime")

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1,4 +1,6 @@
+import os
 import sys
+from unittest.mock import Mock
 
 import pytest
 
@@ -27,3 +29,16 @@ def test_issue_1092_with_pytz(monkeypatch):
     monkeypatch.setenv("TZ", "/UTC")  # Malformed timezone name.
     with pytest.raises(LookupError):
         get_localzone()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Issue 990 is not applicable on Windows",
+)
+def test_issue_990(monkeypatch):
+    monkeypatch.setenv("TZ", "")
+    fake_readlink = Mock(return_value="/usr/share/zoneinfo////UTC")  # Double slash, oops!
+    monkeypatch.setattr(os, "readlink", fake_readlink)
+    from babel.localtime._unix import _get_localzone
+    assert _get_localzone()
+    fake_readlink.assert_called_with("/etc/localtime")


### PR DESCRIPTION
Fixes #990

Closes #1006 (supersedes it)
Closes #1035 (supersedes it)