### PR TITLE
Add `Message.python_brace_format`

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -71,12 +71,16 @@ PYTHON_FORMAT = re.compile(r'''
 
 
 def _has_python_brace_format(string: str) -> bool:
+    if "{" not in string:
+        return False
     fmt = Formatter()
     try:
-        parsed = list(fmt.parse(string))
+        # `fmt.parse` returns 3-or-4-tuples of the form
+        # `(literal_text, field_name, format_spec, conversion)`;
+        # if `field_name` is set, this smells like brace format
+        return any(t[1] is not None for t in fmt.parse(string))
     except ValueError:
         return False
-    return any(True for _, field_name, *_ in parsed if field_name is not None)
 
 
 def _parse_datetime_header(value: str) -> datetime.datetime:

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -78,9 +78,15 @@ def _has_python_brace_format(string: str) -> bool:
         # `fmt.parse` returns 3-or-4-tuples of the form
         # `(literal_text, field_name, format_spec, conversion)`;
         # if `field_name` is set, this smells like brace format
-        return any(t[1] is not None for t in fmt.parse(string))
+        field_name_seen = False
+        for t in fmt.parse(string):
+            if t[1] is not None:
+                field_name_seen = True
+                # We cannot break here, as we need to consume the whole string
+                # to ensure that it is a valid format string.
     except ValueError:
         return False
+    return field_name_seen
 
 
 def _parse_datetime_header(value: str) -> datetime.datetime:

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -39,6 +39,24 @@ class MessageTestCase(unittest.TestCase):
         assert catalog.PYTHON_FORMAT.search('foo %(name)*.*f')
         assert catalog.PYTHON_FORMAT.search('foo %()s')
 
+    def test_python_brace_format(self):
+        assert not catalog._has_python_brace_format('')
+        assert not catalog._has_python_brace_format('foo')
+        assert not catalog._has_python_brace_format('{')
+        assert not catalog._has_python_brace_format('}')
+        assert not catalog._has_python_brace_format('{} {')
+        assert not catalog._has_python_brace_format('{{}}')
+        assert catalog._has_python_brace_format('{}')
+        assert catalog._has_python_brace_format('foo {name}')
+        assert catalog._has_python_brace_format('foo {name!s}')
+        assert catalog._has_python_brace_format('foo {name!r}')
+        assert catalog._has_python_brace_format('foo {name!a}')
+        assert catalog._has_python_brace_format('foo {name!r:10}')
+        assert catalog._has_python_brace_format('foo {name!r:10.2}')
+        assert catalog._has_python_brace_format('foo {name!r:10.2f}')
+        assert catalog._has_python_brace_format('foo {name!r:10.2f} {name!r:10.2f}')
+        assert catalog._has_python_brace_format('foo {name!r:10.2f=}')
+
     def test_translator_comments(self):
         mess = catalog.Message('foo', user_comments=['Comment About `foo`'])
         assert mess.user_comments == ['Comment About `foo`']
@@ -342,8 +360,17 @@ def test_message_pluralizable():
 
 
 def test_message_python_format():
+    assert not catalog.Message('foo').python_format
+    assert not catalog.Message(('foo', 'foo')).python_format
     assert catalog.Message('foo %(name)s bar').python_format
     assert catalog.Message(('foo %(name)s', 'foo %(name)s')).python_format
+
+
+def test_message_python_brace_format():
+    assert not catalog.Message('foo').python_brace_format
+    assert not catalog.Message(('foo', 'foo')).python_brace_format
+    assert catalog.Message('foo {name} bar').python_brace_format
+    assert catalog.Message(('foo {name}', 'foo {name}')).python_brace_format
 
 
 def test_catalog():


### PR DESCRIPTION
Relevant issue: https://github.com/python-babel/babel/issues/333

Part 1 of adding support for checking f-string parameters. This simply adds a new property on the `Message` object analogous to `python_format` which sets the corresponding flag. In a followup PR I'm going to add a checker for the f-string format (reusing my implementation from https://github.com/python-babel/babel/pull/1168)

@akx (I can't ask for a review so I'm tagging you ;))