### PR TITLE
Remove u string prefix from docs

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -839,7 +839,7 @@ class Locale:
         >>> Locale('en', 'US').time_zones['Europe/London']['long']['daylight']
         'British Summer Time'
         >>> Locale('en', 'US').time_zones['America/St_Johns']['city']
-        'St. John\u2019s'
+        'St. John’s'
         """
         return self._data['time_zones']
 
@@ -870,7 +870,7 @@ class Locale:
         >>> Locale('en', 'US').zone_formats['fallback']
         '%(1)s (%(0)s)'
         >>> Locale('pt', 'BR').zone_formats['region']
-        'Hor\\xe1rio %s'
+        'Horário %s'
 
         .. versionadded:: 0.9
         """
@@ -981,7 +981,7 @@ class Locale:
         smallest changing component:
 
         >>> Locale('fi_FI').interval_formats['MEd']['d']
-        ['E d.\u2009\u2013\u2009', 'E d.M.']
+        ['E d.\u2009–\u2009', 'E d.M.']
 
         .. seealso::
 
@@ -1045,7 +1045,7 @@ class Locale:
         """Localized names for various measurement systems.
 
         >>> Locale('fr', 'FR').measurement_systems['US']
-        'am\\xe9ricain'
+        'américain'
         >>> Locale('en', 'US').measurement_systems['US']
         'US'
 

--- a/babel/core.py
+++ b/babel/core.py
@@ -71,9 +71,9 @@ def get_global(key: _GLOBAL_KEY) -> Mapping[str, Any]:
     information independent of individual locales.
 
     >>> get_global('zone_aliases')['UTC']
-    u'Etc/UTC'
+    'Etc/UTC'
     >>> get_global('zone_territories')['Europe/Berlin']
-    u'DE'
+    'DE'
 
     The keys available are:
 
@@ -145,7 +145,7 @@ class Locale:
     >>> repr(locale)
     "Locale('en', territory='US')"
     >>> locale.display_name
-    u'English (United States)'
+    'English (United States)'
 
     A `Locale` object can also be instantiated from a raw locale string:
 
@@ -157,7 +157,7 @@ class Locale:
     territory and language names, number and date format patterns, and more:
 
     >>> locale.number_symbols['latn']['decimal']
-    u'.'
+    '.'
 
     If a locale is requested for which no locale data is available, an
     `UnknownLocaleError` is raised:
@@ -285,7 +285,7 @@ class Locale:
 
         >>> l = Locale.parse('de-DE', sep='-')
         >>> l.display_name
-        u'Deutsch (Deutschland)'
+        'Deutsch (Deutschland)'
 
         If the `identifier` parameter is not a string, but actually a `Locale`
         object, that object is returned:
@@ -471,12 +471,12 @@ class Locale:
         variant, if those are specified.
 
         >>> Locale('zh', 'CN', script='Hans').get_display_name('en')
-        u'Chinese (Simplified, China)'
+        'Chinese (Simplified, China)'
 
         Modifiers are currently passed through verbatim:
 
         >>> Locale('it', 'IT', modifier='euro').get_display_name('en')
-        u'Italian (Italy, euro)'
+        'Italian (Italy, euro)'
 
         :param locale: the locale to use
         """
@@ -503,11 +503,11 @@ class Locale:
         The localized display name of the locale.
 
         >>> Locale('en').display_name
-        u'English'
+        'English'
         >>> Locale('en', 'US').display_name
-        u'English (United States)'
+        'English (United States)'
         >>> Locale('sv').display_name
-        u'svenska'
+        'svenska'
 
         :type: `unicode`
         """)
@@ -516,7 +516,7 @@ class Locale:
         """Return the language of this locale in the given locale.
 
         >>> Locale('zh', 'CN', script='Hans').get_language_name('de')
-        u'Chinesisch'
+        'Chinesisch'
 
         .. versionadded:: 1.0
 
@@ -531,7 +531,7 @@ class Locale:
         The localized language name of the locale.
 
         >>> Locale('en', 'US').language_name
-        u'English'
+        'English'
     """)
 
     def get_territory_name(self, locale: Locale | str | None = None) -> str | None:
@@ -545,7 +545,7 @@ class Locale:
         The localized territory name of the locale if available.
 
         >>> Locale('de', 'DE').territory_name
-        u'Deutschland'
+        'Deutschland'
     """)
 
     def get_script_name(self, locale: Locale | str | None = None) -> str | None:
@@ -559,7 +559,7 @@ class Locale:
         The localized script name of the locale if available.
 
         >>> Locale('sr', 'ME', script='Latn').script_name
-        u'latinica'
+        'latinica'
     """)
 
     @property
@@ -567,9 +567,9 @@ class Locale:
         """The english display name of the locale.
 
         >>> Locale('de').english_name
-        u'German'
+        'German'
         >>> Locale('de', 'DE').english_name
-        u'German (Germany)'
+        'German (Germany)'
 
         :type: `unicode`"""
         return self.get_display_name(Locale('en'))
@@ -581,7 +581,7 @@ class Locale:
         """Mapping of language codes to translated language names.
 
         >>> Locale('de', 'DE').languages['ja']
-        u'Japanisch'
+        'Japanisch'
 
         See `ISO 639 <https://www.loc.gov/standards/iso639-2/>`_ for
         more information.
@@ -593,7 +593,7 @@ class Locale:
         """Mapping of script codes to translated script names.
 
         >>> Locale('en', 'US').scripts['Hira']
-        u'Hiragana'
+        'Hiragana'
 
         See `ISO 15924 <https://www.unicode.org/iso15924/>`_
         for more information.
@@ -605,7 +605,7 @@ class Locale:
         """Mapping of script codes to translated script names.
 
         >>> Locale('es', 'CO').territories['DE']
-        u'Alemania'
+        'Alemania'
 
         See `ISO 3166 <https://en.wikipedia.org/wiki/ISO_3166>`_
         for more information.
@@ -617,7 +617,7 @@ class Locale:
         """Mapping of script codes to translated script names.
 
         >>> Locale('de', 'DE').variants['1901']
-        u'Alte deutsche Rechtschreibung'
+        'Alte deutsche Rechtschreibung'
         """
         return self._data['variants']
 
@@ -631,9 +631,9 @@ class Locale:
         :func:`babel.numbers.get_currency_name` function.
 
         >>> Locale('en').currencies['COP']
-        u'Colombian Peso'
+        'Colombian Peso'
         >>> Locale('de', 'DE').currencies['COP']
-        u'Kolumbianischer Peso'
+        'Kolumbianischer Peso'
         """
         return self._data['currency_names']
 
@@ -642,9 +642,9 @@ class Locale:
         """Mapping of currency codes to symbols.
 
         >>> Locale('en', 'US').currency_symbols['USD']
-        u'$'
+        '$'
         >>> Locale('es', 'CO').currency_symbols['USD']
-        u'US$'
+        'US$'
         """
         return self._data['currency_symbols']
 
@@ -656,11 +656,11 @@ class Locale:
                   Babel versions.
 
         >>> Locale('fr', 'FR').number_symbols["latn"]['decimal']
-        u','
+        ','
         >>> Locale('fa', 'IR').number_symbols["arabext"]['decimal']
-        u'٫'
+        '٫'
         >>> Locale('fa', 'IR').number_symbols["latn"]['decimal']
-        u'.'
+        '.'
         """
         return self._data['number_symbols']
 
@@ -671,7 +671,7 @@ class Locale:
         See: https://www.unicode.org/reports/tr35/tr35-numbers.html#otherNumberingSystems
 
         >>> Locale('el', 'GR').other_numbering_systems['traditional']
-        u'grek'
+        'grek'
 
         .. note:: The format of the value returned may change between
                   Babel versions.
@@ -682,7 +682,7 @@ class Locale:
     def default_numbering_system(self) -> str:
         """The default numbering system used by the locale.
         >>> Locale('el', 'GR').default_numbering_system
-        u'latn'
+        'latn'
         """
         return self._data['default_numbering_system']
 
@@ -694,7 +694,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').decimal_formats[None]
-        <NumberPattern u'#,##0.###'>
+        <NumberPattern '#,##0.###'>
         """
         return self._data['decimal_formats']
 
@@ -706,7 +706,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').compact_decimal_formats["short"]["one"]["1000"]
-        <NumberPattern u'0K'>
+        <NumberPattern '0K'>
         """
         return self._data['compact_decimal_formats']
 
@@ -718,9 +718,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').currency_formats['standard']
-        <NumberPattern u'\\xa4#,##0.00'>
+        <NumberPattern '\\xa4#,##0.00'>
         >>> Locale('en', 'US').currency_formats['accounting']
-        <NumberPattern u'\\xa4#,##0.00;(\\xa4#,##0.00)'>
+        <NumberPattern '\\xa4#,##0.00;(\\xa4#,##0.00)'>
         """
         return self._data['currency_formats']
 
@@ -732,7 +732,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').compact_currency_formats["short"]["one"]["1000"]
-        <NumberPattern u'¤0K'>
+        <NumberPattern '¤0K'>
         """
         return self._data['compact_currency_formats']
 
@@ -744,7 +744,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').percent_formats[None]
-        <NumberPattern u'#,##0%'>
+        <NumberPattern '#,##0%'>
         """
         return self._data['percent_formats']
 
@@ -756,7 +756,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').scientific_formats[None]
-        <NumberPattern u'#E0'>
+        <NumberPattern '#E0'>
         """
         return self._data['scientific_formats']
 
@@ -767,7 +767,7 @@ class Locale:
         """Locale display names for day periods (AM/PM).
 
         >>> Locale('en', 'US').periods['am']
-        u'AM'
+        'AM'
         """
         try:
             return self._data['day_periods']['stand-alone']['wide']
@@ -793,7 +793,7 @@ class Locale:
         """Locale display names for weekdays.
 
         >>> Locale('de', 'DE').days['format']['wide'][3]
-        u'Donnerstag'
+        'Donnerstag'
         """
         return self._data['days']
 
@@ -802,7 +802,7 @@ class Locale:
         """Locale display names for months.
 
         >>> Locale('de', 'DE').months['format']['wide'][10]
-        u'Oktober'
+        'Oktober'
         """
         return self._data['months']
 
@@ -811,7 +811,7 @@ class Locale:
         """Locale display names for quarters.
 
         >>> Locale('de', 'DE').quarters['format']['wide'][1]
-        u'1. Quartal'
+        '1. Quartal'
         """
         return self._data['quarters']
 
@@ -823,9 +823,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').eras['wide'][1]
-        u'Anno Domini'
+        'Anno Domini'
         >>> Locale('en', 'US').eras['abbreviated'][0]
-        u'BC'
+        'BC'
         """
         return self._data['eras']
 
@@ -837,9 +837,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').time_zones['Europe/London']['long']['daylight']
-        u'British Summer Time'
+        'British Summer Time'
         >>> Locale('en', 'US').time_zones['America/St_Johns']['city']
-        u'St. John\u2019s'
+        'St. John\u2019s'
         """
         return self._data['time_zones']
 
@@ -854,7 +854,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').meta_zones['Europe_Central']['long']['daylight']
-        u'Central European Summer Time'
+        'Central European Summer Time'
 
         .. versionadded:: 0.9
         """
@@ -868,9 +868,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').zone_formats['fallback']
-        u'%(1)s (%(0)s)'
+        '%(1)s (%(0)s)'
         >>> Locale('pt', 'BR').zone_formats['region']
-        u'Hor\\xe1rio %s'
+        'Hor\\xe1rio %s'
 
         .. versionadded:: 0.9
         """
@@ -923,9 +923,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').date_formats['short']
-        <DateTimePattern u'M/d/yy'>
+        <DateTimePattern 'M/d/yy'>
         >>> Locale('fr', 'FR').date_formats['long']
-        <DateTimePattern u'd MMMM y'>
+        <DateTimePattern 'd MMMM y'>
         """
         return self._data['date_formats']
 
@@ -937,9 +937,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').time_formats['short']
-        <DateTimePattern u'h:mm\u202fa'>
+        <DateTimePattern 'h:mm\u202fa'>
         >>> Locale('fr', 'FR').time_formats['long']
-        <DateTimePattern u'HH:mm:ss z'>
+        <DateTimePattern 'HH:mm:ss z'>
         """
         return self._data['time_formats']
 
@@ -951,9 +951,9 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en').datetime_formats['full']
-        u'{1}, {0}'
+        '{1}, {0}'
         >>> Locale('th').datetime_formats['medium']
-        u'{1} {0}'
+        '{1} {0}'
         """
         return self._data['datetime_formats']
 
@@ -962,11 +962,11 @@ class Locale:
         """Locale patterns for formatting parts of a datetime.
 
         >>> Locale('en').datetime_skeletons['MEd']
-        <DateTimePattern u'E, M/d'>
+        <DateTimePattern 'E, M/d'>
         >>> Locale('fr').datetime_skeletons['MEd']
-        <DateTimePattern u'E dd/MM'>
+        <DateTimePattern 'E dd/MM'>
         >>> Locale('fr').datetime_skeletons['H']
-        <DateTimePattern u"HH 'h'">
+        <DateTimePattern "HH 'h'">
         """
         return self._data['datetime_skeletons']
 
@@ -981,7 +981,7 @@ class Locale:
         smallest changing component:
 
         >>> Locale('fi_FI').interval_formats['MEd']['d']
-        [u'E d.\u2009\u2013\u2009', u'E d.M.']
+        ['E d.\u2009\u2013\u2009', 'E d.M.']
 
         .. seealso::
 
@@ -1015,11 +1015,11 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en').list_patterns['standard']['start']
-        u'{0}, {1}'
+        '{0}, {1}'
         >>> Locale('en').list_patterns['standard']['end']
-        u'{0}, and {1}'
+        '{0}, and {1}'
         >>> Locale('en_GB').list_patterns['standard']['end']
-        u'{0} and {1}'
+        '{0} and {1}'
         """
         return self._data['list_patterns']
 
@@ -1045,9 +1045,9 @@ class Locale:
         """Localized names for various measurement systems.
 
         >>> Locale('fr', 'FR').measurement_systems['US']
-        u'am\\xe9ricain'
+        'am\\xe9ricain'
         >>> Locale('en', 'US').measurement_systems['US']
-        u'US'
+        'US'
 
         """
         return self._data['measurement_systems']

--- a/babel/core.py
+++ b/babel/core.py
@@ -937,7 +937,7 @@ class Locale:
                   Babel versions.
 
         >>> Locale('en', 'US').time_formats['short']
-        <DateTimePattern 'h:mm\u202fa'>
+        <DateTimePattern 'h:mm\\u202fa'>
         >>> Locale('fr', 'FR').time_formats['long']
         <DateTimePattern 'HH:mm:ss z'>
         """
@@ -981,7 +981,7 @@ class Locale:
         smallest changing component:
 
         >>> Locale('fi_FI').interval_formats['MEd']['d']
-        ['E d.\u2009–\u2009', 'E d.M.']
+        ['E d.\\u2009–\\u2009', 'E d.M.']
 
         .. seealso::
 

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -398,7 +398,7 @@ def get_time_format(
     format.
 
     >>> get_time_format(locale='en_US')
-    <DateTimePattern 'h:mm:ss\u202fa'>
+    <DateTimePattern 'h:mm:ss\\u202fa'>
     >>> get_time_format('full', locale='de_DE')
     <DateTimePattern 'HH:mm:ss zzzz'>
 
@@ -1055,7 +1055,7 @@ def format_interval(
     '12:12–16:16'
 
     >>> format_interval(time(5, 12), time(16, 16), "hm", locale="en_US")
-    '5:12\u202fAM\u2009–\u20094:16\u202fPM'
+    '5:12\\u202fAM\\u2009–\\u20094:16\\u202fPM'
 
     >>> format_interval(time(16, 18), time(16, 24), "Hm", locale="it")
     '16:18–16:24'
@@ -1074,7 +1074,7 @@ def format_interval(
     '16:18:00～16:24:00'
 
     >>> format_interval(date(2016, 1, 15), date(2016, 1, 17), "xxx", locale="de")
-    '15.01.2016\u2009–\u200917.01.2016'
+    '15.01.2016\\u2009–\\u200917.01.2016'
 
     :param start: First instant (datetime/date/time)
     :param end: Second instant (datetime/date/time)

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -260,7 +260,7 @@ def get_period_names(
     """Return the names for day periods (AM/PM) used by the locale.
 
     >>> get_period_names(locale='en_US')['am']
-    u'AM'
+    'AM'
 
     :param width: the width to use, one of "abbreviated", "narrow", or "wide"
     :param context: the context, either "format" or "stand-alone"
@@ -277,13 +277,13 @@ def get_day_names(
     """Return the day names used by the locale for the specified format.
 
     >>> get_day_names('wide', locale='en_US')[1]
-    u'Tuesday'
+    'Tuesday'
     >>> get_day_names('short', locale='en_US')[1]
-    u'Tu'
+    'Tu'
     >>> get_day_names('abbreviated', locale='es')[1]
-    u'mar'
+    'mar'
     >>> get_day_names('narrow', context='stand-alone', locale='de_DE')[1]
-    u'D'
+    'D'
 
     :param width: the width to use, one of "wide", "abbreviated", "short" or "narrow"
     :param context: the context, either "format" or "stand-alone"
@@ -300,11 +300,11 @@ def get_month_names(
     """Return the month names used by the locale for the specified format.
 
     >>> get_month_names('wide', locale='en_US')[1]
-    u'January'
+    'January'
     >>> get_month_names('abbreviated', locale='es')[1]
-    u'ene'
+    'ene'
     >>> get_month_names('narrow', context='stand-alone', locale='de_DE')[1]
-    u'J'
+    'J'
 
     :param width: the width to use, one of "wide", "abbreviated", or "narrow"
     :param context: the context, either "format" or "stand-alone"
@@ -321,11 +321,11 @@ def get_quarter_names(
     """Return the quarter names used by the locale for the specified format.
 
     >>> get_quarter_names('wide', locale='en_US')[1]
-    u'1st quarter'
+    '1st quarter'
     >>> get_quarter_names('abbreviated', locale='de_DE')[1]
-    u'Q1'
+    'Q1'
     >>> get_quarter_names('narrow', locale='de_DE')[1]
-    u'1'
+    '1'
 
     :param width: the width to use, one of "wide", "abbreviated", or "narrow"
     :param context: the context, either "format" or "stand-alone"
@@ -341,9 +341,9 @@ def get_era_names(
     """Return the era names used by the locale for the specified format.
 
     >>> get_era_names('wide', locale='en_US')[1]
-    u'Anno Domini'
+    'Anno Domini'
     >>> get_era_names('abbreviated', locale='de_DE')[1]
-    u'n. Chr.'
+    'n. Chr.'
 
     :param width: the width to use, either "wide", "abbreviated", or "narrow"
     :param locale: the `Locale` object, or a locale string. Defaults to the system time locale.
@@ -359,9 +359,9 @@ def get_date_format(
     format.
 
     >>> get_date_format(locale='en_US')
-    <DateTimePattern u'MMM d, y'>
+    <DateTimePattern 'MMM d, y'>
     >>> get_date_format('full', locale='de_DE')
-    <DateTimePattern u'EEEE, d. MMMM y'>
+    <DateTimePattern 'EEEE, d. MMMM y'>
 
     :param format: the format to use, one of "full", "long", "medium", or
                    "short"
@@ -378,7 +378,7 @@ def get_datetime_format(
     specified format.
 
     >>> get_datetime_format(locale='en_US')
-    u'{1}, {0}'
+    '{1}, {0}'
 
     :param format: the format to use, one of "full", "long", "medium", or
                    "short"
@@ -398,9 +398,9 @@ def get_time_format(
     format.
 
     >>> get_time_format(locale='en_US')
-    <DateTimePattern u'h:mm:ss\u202fa'>
+    <DateTimePattern 'h:mm:ss\u202fa'>
     >>> get_time_format('full', locale='de_DE')
-    <DateTimePattern u'HH:mm:ss zzzz'>
+    <DateTimePattern 'HH:mm:ss zzzz'>
 
     :param format: the format to use, one of "full", "long", "medium", or
                    "short"
@@ -421,25 +421,25 @@ def get_timezone_gmt(
     >>> from datetime import datetime
     >>> dt = datetime(2007, 4, 1, 15, 30)
     >>> get_timezone_gmt(dt, locale='en')
-    u'GMT+00:00'
+    'GMT+00:00'
     >>> get_timezone_gmt(dt, locale='en', return_z=True)
     'Z'
     >>> get_timezone_gmt(dt, locale='en', width='iso8601_short')
-    u'+00'
+    '+00'
     >>> tz = get_timezone('America/Los_Angeles')
     >>> dt = _localize(tz, datetime(2007, 4, 1, 15, 30))
     >>> get_timezone_gmt(dt, locale='en')
-    u'GMT-07:00'
+    'GMT-07:00'
     >>> get_timezone_gmt(dt, 'short', locale='en')
-    u'-0700'
+    '-0700'
     >>> get_timezone_gmt(dt, locale='en', width='iso8601_short')
-    u'-07'
+    '-07'
 
     The long format depends on the locale, for example in France the acronym
     UTC string is used instead of GMT:
 
     >>> get_timezone_gmt(dt, 'long', locale='fr_FR')
-    u'UTC-07:00'
+    'UTC-07:00'
 
     .. versionadded:: 0.9
 
@@ -488,14 +488,14 @@ def get_timezone_location(
     St. John’s
     >>> tz = get_timezone('America/Mexico_City')
     >>> get_timezone_location(tz, locale='de_DE')
-    u'Mexiko (Mexiko-Stadt) (Ortszeit)'
+    'Mexiko (Mexiko-Stadt) (Ortszeit)'
 
     If the timezone is associated with a country that uses only a single
     timezone, just the localized country name is returned:
 
     >>> tz = get_timezone('Europe/Berlin')
     >>> get_timezone_name(tz, locale='de_DE')
-    u'Mitteleurop\\xe4ische Zeit'
+    'Mitteleurop\\xe4ische Zeit'
 
     .. versionadded:: 0.9
 
@@ -563,11 +563,11 @@ def get_timezone_name(
     >>> from datetime import time
     >>> dt = time(15, 30, tzinfo=get_timezone('America/Los_Angeles'))
     >>> get_timezone_name(dt, locale='en_US')  # doctest: +SKIP
-    u'Pacific Standard Time'
+    'Pacific Standard Time'
     >>> get_timezone_name(dt, locale='en_US', return_zone=True)
     'America/Los_Angeles'
     >>> get_timezone_name(dt, width='short', locale='en_US')  # doctest: +SKIP
-    u'PST'
+    'PST'
 
     If this function gets passed only a `tzinfo` object and no concrete
     `datetime`,  the returned display name is independent of daylight savings
@@ -576,9 +576,9 @@ def get_timezone_name(
 
     >>> tz = get_timezone('America/Los_Angeles')
     >>> get_timezone_name(tz, locale='en_US')
-    u'Pacific Time'
+    'Pacific Time'
     >>> get_timezone_name(tz, 'short', locale='en_US')
-    u'PT'
+    'PT'
 
     If no localized display name for the timezone is available, and the timezone
     is associated with a country that uses only a single timezone, the name of
@@ -586,16 +586,16 @@ def get_timezone_name(
 
     >>> tz = get_timezone('Europe/Berlin')
     >>> get_timezone_name(tz, locale='de_DE')
-    u'Mitteleurop\xe4ische Zeit'
+    'Mitteleurop\xe4ische Zeit'
     >>> get_timezone_name(tz, locale='pt_BR')
-    u'Hor\xe1rio da Europa Central'
+    'Hor\xe1rio da Europa Central'
 
     On the other hand, if the country uses multiple timezones, the city is also
     included in the representation:
 
     >>> tz = get_timezone('America/St_Johns')
     >>> get_timezone_name(tz, locale='de_DE')
-    u'Neufundland-Zeit'
+    'Neufundland-Zeit'
 
     Note that short format is currently not supported for all timezones and
     all locales.  This is partially because not every timezone has a short
@@ -681,15 +681,15 @@ def format_date(
     >>> from datetime import date
     >>> d = date(2007, 4, 1)
     >>> format_date(d, locale='en_US')
-    u'Apr 1, 2007'
+    'Apr 1, 2007'
     >>> format_date(d, format='full', locale='de_DE')
-    u'Sonntag, 1. April 2007'
+    'Sonntag, 1. April 2007'
 
     If you don't want to use the locale default formats, you can specify a
     custom date pattern:
 
     >>> format_date(d, "EEE, MMM d, ''yy", locale='en')
-    u"Sun, Apr 1, '07"
+    "Sun, Apr 1, '07"
 
     :param date: the ``date`` or ``datetime`` object; if `None`, the current
                  date is used
@@ -720,7 +720,7 @@ def format_datetime(
     >>> from datetime import datetime
     >>> dt = datetime(2007, 4, 1, 15, 30)
     >>> format_datetime(dt, locale='en_US')
-    u'Apr 1, 2007, 3:30:00\u202fPM'
+    'Apr 1, 2007, 3:30:00\u202fPM'
 
     For any pattern requiring the display of the timezone:
 
@@ -729,7 +729,7 @@ def format_datetime(
     'dimanche 1 avril 2007, 17:30:00 heure d’été d’Europe centrale'
     >>> format_datetime(dt, "yyyy.MM.dd G 'at' HH:mm:ss zzz",
     ...                 tzinfo=get_timezone('US/Eastern'), locale='en')
-    u'2007.04.01 AD at 11:30:00 EDT'
+    '2007.04.01 AD at 11:30:00 EDT'
 
     :param datetime: the `datetime` object; if `None`, the current date and
                      time is used
@@ -762,15 +762,15 @@ def format_time(
     >>> from datetime import datetime, time
     >>> t = time(15, 30)
     >>> format_time(t, locale='en_US')
-    u'3:30:00\u202fPM'
+    '3:30:00\u202fPM'
     >>> format_time(t, format='short', locale='de_DE')
-    u'15:30'
+    '15:30'
 
     If you don't want to use the locale default formats, you can specify a
     custom time pattern:
 
     >>> format_time(t, "hh 'o''clock' a", locale='en')
-    u"03 o'clock PM"
+    "03 o'clock PM"
 
     For any pattern requiring the display of the time-zone a
     timezone has to be specified explicitly:
@@ -782,7 +782,7 @@ def format_time(
     '15:30:00 heure d’été d’Europe centrale'
     >>> format_time(t, "hh 'o''clock' a, zzzz", tzinfo=get_timezone('US/Eastern'),
     ...             locale='en')
-    u"09 o'clock AM, Eastern Daylight Time"
+    "09 o'clock AM, Eastern Daylight Time"
 
     As that example shows, when this function gets passed a
     ``datetime.datetime`` value, the actual time in the formatted string is
@@ -800,10 +800,10 @@ def format_time(
     >>> t = time(15, 30)
     >>> format_time(t, format='full', tzinfo=get_timezone('Europe/Paris'),
     ...             locale='fr_FR')  # doctest: +SKIP
-    u'15:30:00 heure normale d\u2019Europe centrale'
+    '15:30:00 heure normale d\u2019Europe centrale'
     >>> format_time(t, format='full', tzinfo=get_timezone('US/Eastern'),
     ...             locale='en_US')  # doctest: +SKIP
-    u'3:30:00\u202fPM Eastern Standard Time'
+    '3:30:00\u202fPM Eastern Standard Time'
 
     :param time: the ``time`` or ``datetime`` object; if `None`, the current
                  time in UTC is used
@@ -842,11 +842,11 @@ def format_skeleton(
     >>> from datetime import datetime
     >>> t = datetime(2007, 4, 1, 15, 30)
     >>> format_skeleton('MMMEd', t, locale='fr')
-    u'dim. 1 avr.'
+    'dim. 1 avr.'
     >>> format_skeleton('MMMEd', t, locale='en')
-    u'Sun, Apr 1'
+    'Sun, Apr 1'
     >>> format_skeleton('yMMd', t, locale='fi')  # yMMd is not in the Finnish locale; yMd gets used
-    u'1.4.2007'
+    '1.4.2007'
     >>> format_skeleton('yMMd', t, fuzzy=False, locale='fi')  # yMMd is not in the Finnish locale, an error is thrown
     Traceback (most recent call last):
         ...
@@ -898,39 +898,39 @@ def format_timedelta(
 
     >>> from datetime import timedelta
     >>> format_timedelta(timedelta(weeks=12), locale='en_US')
-    u'3 months'
+    '3 months'
     >>> format_timedelta(timedelta(seconds=1), locale='es')
-    u'1 segundo'
+    '1 segundo'
 
     The granularity parameter can be provided to alter the lowest unit
     presented, which defaults to a second.
 
     >>> format_timedelta(timedelta(hours=3), granularity='day', locale='en_US')
-    u'1 day'
+    '1 day'
 
     The threshold parameter can be used to determine at which value the
     presentation switches to the next higher unit. A higher threshold factor
     means the presentation will switch later. For example:
 
     >>> format_timedelta(timedelta(hours=23), threshold=0.9, locale='en_US')
-    u'1 day'
+    '1 day'
     >>> format_timedelta(timedelta(hours=23), threshold=1.1, locale='en_US')
-    u'23 hours'
+    '23 hours'
 
     In addition directional information can be provided that informs
     the user if the date is in the past or in the future:
 
     >>> format_timedelta(timedelta(hours=1), add_direction=True, locale='en')
-    u'in 1 hour'
+    'in 1 hour'
     >>> format_timedelta(timedelta(hours=-1), add_direction=True, locale='en')
-    u'1 hour ago'
+    '1 hour ago'
 
     The format parameter controls how compact or wide the presentation is:
 
     >>> format_timedelta(timedelta(hours=3), format='short', locale='en')
-    u'3 hr'
+    '3 hr'
     >>> format_timedelta(timedelta(hours=3), format='narrow', locale='en')
-    u'3h'
+    '3h'
 
     :param delta: a ``timedelta`` object representing the time difference to
                   format, or the delta in seconds as an `int` value
@@ -1049,7 +1049,7 @@ def format_interval(
 
     >>> from datetime import date, time
     >>> format_interval(date(2016, 1, 15), date(2016, 1, 17), "yMd", locale="fi")
-    u'15.\u201317.1.2016'
+    '15.\u201317.1.2016'
 
     >>> format_interval(time(12, 12), time(16, 16), "Hm", locale="en_GB")
     '12:12\u201316:16'
@@ -1154,13 +1154,13 @@ def get_period_id(
 
     >>> from datetime import time
     >>> get_period_names(locale="de")[get_period_id(time(7, 42), locale="de")]
-    u'Morgen'
+    'Morgen'
 
     >>> get_period_id(time(0), locale="en_US")
-    u'midnight'
+    'midnight'
 
     >>> get_period_id(time(0), type="selection", locale="en_US")
-    u'night1'
+    'night1'
 
     :param time: The time to inspect.
     :param tzinfo: The timezone for the time. See ``format_time``.
@@ -1526,12 +1526,12 @@ class DateTimeFormat:
         >>> from datetime import date
         >>> format = DateTimeFormat(date(2016, 2, 28), Locale.parse('en_US'))
         >>> format.format_weekday()
-        u'Sunday'
+        'Sunday'
 
         'E': Day of week - Use one through three letters for the abbreviated day name, four for the full (wide) name,
              five for the narrow name, or six for the short name.
         >>> format.format_weekday('E',2)
-        u'Sun'
+        'Sun'
 
         'e': Local day of week. Same as E except adds a numeric value that will depend on the local starting day of the
              week, using one or two letters. For this example, Monday is the first day of the week.
@@ -1570,21 +1570,21 @@ class DateTimeFormat:
         >>> from datetime import datetime, time
         >>> format = DateTimeFormat(time(13, 42), 'fi_FI')
         >>> format.format_period('a', 1)
-        u'ip.'
+        'ip.'
         >>> format.format_period('b', 1)
-        u'iltap.'
+        'iltap.'
         >>> format.format_period('b', 4)
-        u'iltapäivä'
+        'iltapäivä'
         >>> format.format_period('B', 4)
-        u'iltapäivällä'
+        'iltapäivällä'
         >>> format.format_period('B', 5)
-        u'ip.'
+        'ip.'
 
         >>> format = DateTimeFormat(datetime(2022, 4, 28, 6, 27), 'zh_Hant')
         >>> format.format_period('a', 1)
-        u'上午'
+        '上午'
         >>> format.format_period('B', 1)
-        u'清晨'
+        '清晨'
 
         :param char: pattern format character ('a', 'b', 'B')
         :param num: count of format character
@@ -1746,20 +1746,20 @@ def parse_pattern(pattern: str | DateTimePattern) -> DateTimePattern:
     """Parse date, time, and datetime format patterns.
 
     >>> parse_pattern("MMMMd").format
-    u'%(MMMM)s%(d)s'
+    '%(MMMM)s%(d)s'
     >>> parse_pattern("MMM d, yyyy").format
-    u'%(MMM)s %(d)s, %(yyyy)s'
+    '%(MMM)s %(d)s, %(yyyy)s'
 
     Pattern can contain literal strings in single quotes:
 
     >>> parse_pattern("H:mm' Uhr 'z").format
-    u'%(H)s:%(mm)s Uhr %(z)s'
+    '%(H)s:%(mm)s Uhr %(z)s'
 
     An actual single quote can be used by using two adjacent single quote
     characters:
 
     >>> parse_pattern("hh' o''clock'").format
-    u"%(hh)s o'clock"
+    "%(hh)s o'clock"
 
     :param pattern: the formatting pattern to parse
     """
@@ -1883,18 +1883,18 @@ def split_interval_pattern(pattern: str) -> list[str]:
     > The pattern is then designed to be broken up into two pieces by determining the first repeating field.
     - https://www.unicode.org/reports/tr35/tr35-dates.html#intervalFormats
 
-    >>> split_interval_pattern(u'E d.M. \u2013 E d.M.')
-    [u'E d.M. \u2013 ', 'E d.M.']
+    >>> split_interval_pattern('E d.M. – E d.M.')
+    ['E d.M. \u2013 ', 'E d.M.']
     >>> split_interval_pattern("Y 'text' Y 'more text'")
     ["Y 'text '", "Y 'more text'"]
-    >>> split_interval_pattern(u"E, MMM d \u2013 E")
-    [u'E, MMM d \u2013 ', u'E']
+    >>> split_interval_pattern('E, MMM d – E')
+    ['E, MMM d \u2013 ', 'E']
     >>> split_interval_pattern("MMM d")
     ['MMM d']
     >>> split_interval_pattern("y G")
     ['y G']
-    >>> split_interval_pattern(u"MMM d \u2013 d")
-    [u'MMM d \u2013 ', u'd']
+    >>> split_interval_pattern('MMM d – d')
+    ['MMM d \u2013 ', 'd']
 
     :param pattern: Interval pattern string
     :return: list of "subpatterns"

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -495,7 +495,7 @@ def get_timezone_location(
 
     >>> tz = get_timezone('Europe/Berlin')
     >>> get_timezone_name(tz, locale='de_DE')
-    'Mitteleurop\\xe4ische Zeit'
+    'Mitteleuropäische Zeit'
 
     .. versionadded:: 0.9
 
@@ -586,9 +586,9 @@ def get_timezone_name(
 
     >>> tz = get_timezone('Europe/Berlin')
     >>> get_timezone_name(tz, locale='de_DE')
-    'Mitteleurop\xe4ische Zeit'
+    'Mitteleuropäische Zeit'
     >>> get_timezone_name(tz, locale='pt_BR')
-    'Hor\xe1rio da Europa Central'
+    'Horário da Europa Central'
 
     On the other hand, if the country uses multiple timezones, the city is also
     included in the representation:
@@ -1049,16 +1049,16 @@ def format_interval(
 
     >>> from datetime import date, time
     >>> format_interval(date(2016, 1, 15), date(2016, 1, 17), "yMd", locale="fi")
-    '15.\u201317.1.2016'
+    '15.–17.1.2016'
 
     >>> format_interval(time(12, 12), time(16, 16), "Hm", locale="en_GB")
-    '12:12\u201316:16'
+    '12:12–16:16'
 
     >>> format_interval(time(5, 12), time(16, 16), "hm", locale="en_US")
     '5:12\u202fAM\u2009–\u20094:16\u202fPM'
 
     >>> format_interval(time(16, 18), time(16, 24), "Hm", locale="it")
-    '16:18\u201316:24'
+    '16:18–16:24'
 
     If the start instant equals the end instant, the interval is formatted like the instant.
 
@@ -1068,10 +1068,10 @@ def format_interval(
     Unknown skeletons fall back to "default" formatting.
 
     >>> format_interval(date(2015, 1, 1), date(2017, 1, 1), "wzq", locale="ja")
-    '2015/01/01\uff5e2017/01/01'
+    '2015/01/01～2017/01/01'
 
     >>> format_interval(time(16, 18), time(16, 24), "xxx", locale="ja")
-    '16:18:00\uff5e16:24:00'
+    '16:18:00～16:24:00'
 
     >>> format_interval(date(2016, 1, 15), date(2016, 1, 17), "xxx", locale="de")
     '15.01.2016\u2009–\u200917.01.2016'
@@ -1884,17 +1884,17 @@ def split_interval_pattern(pattern: str) -> list[str]:
     - https://www.unicode.org/reports/tr35/tr35-dates.html#intervalFormats
 
     >>> split_interval_pattern('E d.M. – E d.M.')
-    ['E d.M. \u2013 ', 'E d.M.']
+    ['E d.M. – ', 'E d.M.']
     >>> split_interval_pattern("Y 'text' Y 'more text'")
     ["Y 'text '", "Y 'more text'"]
     >>> split_interval_pattern('E, MMM d – E')
-    ['E, MMM d \u2013 ', 'E']
+    ['E, MMM d – ', 'E']
     >>> split_interval_pattern("MMM d")
     ['MMM d']
     >>> split_interval_pattern("y G")
     ['y G']
     >>> split_interval_pattern('MMM d – d')
-    ['MMM d \u2013 ', 'd']
+    ['MMM d – ', 'd']
 
     :param pattern: Interval pattern string
     :return: list of "subpatterns"

--- a/babel/lists.py
+++ b/babel/lists.py
@@ -49,11 +49,11 @@ def format_list(
     Format the items in `lst` as a list.
 
     >>> format_list(['apples', 'oranges', 'pears'], locale='en')
-    u'apples, oranges, and pears'
+    'apples, oranges, and pears'
     >>> format_list(['apples', 'oranges', 'pears'], locale='zh')
-    u'apples\u3001oranges\u548cpears'
+    'apples\u3001oranges\u548cpears'
     >>> format_list(['omena', 'peruna', 'aplari'], style='or', locale='fi')
-    u'omena, peruna tai aplari'
+    'omena, peruna tai aplari'
 
     Not all styles are necessarily available in all locales.
     The function will attempt to fall back to replacement styles according to the rules

--- a/babel/lists.py
+++ b/babel/lists.py
@@ -51,7 +51,7 @@ def format_list(
     >>> format_list(['apples', 'oranges', 'pears'], locale='en')
     'apples, oranges, and pears'
     >>> format_list(['apples', 'oranges', 'pears'], locale='zh')
-    'apples\u3001oranges\u548cpears'
+    'apples、oranges和pears'
     >>> format_list(['omena', 'peruna', 'aplari'], style='or', locale='fi')
     'omena, peruna tai aplari'
 

--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -125,7 +125,7 @@ def load(name: os.PathLike[str] | str, merge_inherited: bool = True) -> dict[str
 
     >>> d = load('en_US')
     >>> d['languages']['sv']
-    u'Swedish'
+    'Swedish'
 
     Note that the results are cached, and subsequent requests for the same
     locale return the same dictionary:

--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -654,19 +654,19 @@ class Catalog:
         """Add or update the message with the specified ID.
 
         >>> catalog = Catalog()
-        >>> catalog[u'foo'] = Message(u'foo')
-        >>> catalog[u'foo']
-        <Message u'foo' (flags: [])>
+        >>> catalog['foo'] = Message('foo')
+        >>> catalog['foo']
+        <Message 'foo' (flags: [])>
 
         If a message with that ID is already in the catalog, it is updated
         to include the locations and flags of the new message.
 
         >>> catalog = Catalog()
-        >>> catalog[u'foo'] = Message(u'foo', locations=[('main.py', 1)])
-        >>> catalog[u'foo'].locations
+        >>> catalog['foo'] = Message('foo', locations=[('main.py', 1)])
+        >>> catalog['foo'].locations
         [('main.py', 1)]
-        >>> catalog[u'foo'] = Message(u'foo', locations=[('utils.py', 5)])
-        >>> catalog[u'foo'].locations
+        >>> catalog['foo'] = Message('foo', locations=[('utils.py', 5)])
+        >>> catalog['foo'].locations
         [('main.py', 1), ('utils.py', 5)]
 
         :param id: the message ID
@@ -713,10 +713,10 @@ class Catalog:
         """Add or update the message with the specified ID.
 
         >>> catalog = Catalog()
-        >>> catalog.add(u'foo')
+        >>> catalog.add('foo')
         <Message ...>
-        >>> catalog[u'foo']
-        <Message u'foo' (flags: [])>
+        >>> catalog['foo']
+        <Message 'foo' (flags: [])>
 
         This method simply constructs a `Message` object with the given
         arguments and invokes `__setitem__` with that object.
@@ -792,11 +792,11 @@ class Catalog:
         >>> template.add(('salad', 'salads'), locations=[('util.py', 42)])
         <Message ...>
         >>> catalog = Catalog(locale='de_DE')
-        >>> catalog.add('blue', u'blau', locations=[('main.py', 98)])
+        >>> catalog.add('blue', 'blau', locations=[('main.py', 98)])
         <Message ...>
-        >>> catalog.add('head', u'Kopf', locations=[('util.py', 33)])
+        >>> catalog.add('head', 'Kopf', locations=[('util.py', 33)])
         <Message ...>
-        >>> catalog.add(('salad', 'salads'), (u'Salat', u'Salate'),
+        >>> catalog.add(('salad', 'salads'), ('Salat', 'Salate'),
         ...             locations=[('util.py', 38)])
         <Message ...>
 
@@ -811,13 +811,13 @@ class Catalog:
 
         >>> msg2 = catalog['blue']
         >>> msg2.string
-        u'blau'
+        'blau'
         >>> msg2.locations
         [('main.py', 100)]
 
         >>> msg3 = catalog['salad']
         >>> msg3.string
-        (u'Salat', u'Salate')
+        ('Salat', 'Salate')
         >>> msg3.locations
         [('util.py', 42)]
 

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -403,7 +403,7 @@ def extract(
     >>> from io import BytesIO
     >>> for message in extract('python', BytesIO(source)):
     ...     print(message)
-    (3, u'Hello, world!', [], None)
+    (3, 'Hello, world!', [], None)
 
     :param method: an extraction method (a callable), or
                    a string specifying the extraction method (.e.g. "python");

--- a/babel/messages/mofile.py
+++ b/babel/messages/mofile.py
@@ -116,7 +116,7 @@ def write_mo(fileobj: SupportsWrite[bytes], catalog: Catalog, use_fuzzy: bool = 
     >>> catalog = Catalog(locale='en_US')
     >>> catalog.add('foo', 'Voh')
     <Message ...>
-    >>> catalog.add((u'bar', u'baz'), (u'Bahr', u'Batz'))
+    >>> catalog.add(('bar', 'baz'), ('Bahr', 'Batz'))
     <Message ...>
     >>> catalog.add('fuz', 'Futz', flags=['fuzzy'])
     <Message ...>
@@ -133,19 +133,19 @@ def write_mo(fileobj: SupportsWrite[bytes], catalog: Catalog, use_fuzzy: bool = 
     ...     translations.ugettext = translations.gettext
     ...     translations.ungettext = translations.ngettext
     >>> translations.ugettext('foo')
-    u'Voh'
+    'Voh'
     >>> translations.ungettext('bar', 'baz', 1)
-    u'Bahr'
+    'Bahr'
     >>> translations.ungettext('bar', 'baz', 2)
-    u'Batz'
+    'Batz'
     >>> translations.ugettext('fuz')
-    u'fuz'
+    'fuz'
     >>> translations.ugettext('Fizz')
-    u'Fizz'
+    'Fizz'
     >>> translations.ugettext('Fuzz')
-    u'Fuzz'
+    'Fuzz'
     >>> translations.ugettext('Fuzzes')
-    u'Fuzzes'
+    'Fuzzes'
 
     :param fileobj: the file-like object to write to
     :param catalog: the `Catalog` instance

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -413,12 +413,12 @@ def read_po(
     ...         print((message.id, message.string))
     ...         print(' ', (message.locations, sorted(list(message.flags))))
     ...         print(' ', (message.user_comments, message.auto_comments))
-    (u'foo %(name)s', u'quux %(name)s')
-      ([(u'main.py', 1)], [u'fuzzy', u'python-format'])
+    ('foo %(name)s', 'quux %(name)s')
+      ([('main.py', 1)], ['fuzzy', 'python-format'])
       ([], [])
-    ((u'bar', u'baz'), (u'bar', u'baaz'))
-      ([(u'main.py', 3)], [])
-      ([u'A user comment'], [u'An auto comment'])
+    (('bar', 'baz'), ('bar', 'baaz'))
+      ([('main.py', 3)], [])
+      (['A user comment'], ['An auto comment'])
 
     .. versionadded:: 1.0
        Added support for explicit charset argument.
@@ -557,10 +557,10 @@ def write_po(
     message catalog to the provided file-like object.
 
     >>> catalog = Catalog()
-    >>> catalog.add(u'foo %(name)s', locations=[('main.py', 1)],
+    >>> catalog.add('foo %(name)s', locations=[('main.py', 1)],
     ...             flags=('fuzzy',))
     <Message...>
-    >>> catalog.add((u'bar', u'baz'), locations=[('main.py', 3)])
+    >>> catalog.add(('bar', 'baz'), locations=[('main.py', 3)])
     <Message...>
     >>> from io import BytesIO
     >>> buf = BytesIO()

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -917,7 +917,7 @@ def format_percent(
     The format pattern can also be specified explicitly:
 
     >>> format_percent(25.1234, '#,##0\u2030', locale='en_US')
-    '25,123\u2030'
+    '25,123‰'
 
     By default the locale is allowed to truncate and round a high-precision
     number by forcing its format pattern onto the decimal part. You can bypass

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -374,9 +374,9 @@ def get_plus_sign_symbol(
     >>> get_plus_sign_symbol('en_US')
     '+'
     >>> get_plus_sign_symbol('ar_EG', numbering_system='default')
-    '\u061c+'
+    '\\u061c+'
     >>> get_plus_sign_symbol('ar_EG', numbering_system='latn')
-    '\u200e+'
+    '\\u200e+'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -397,9 +397,9 @@ def get_minus_sign_symbol(
     >>> get_minus_sign_symbol('en_US')
     '-'
     >>> get_minus_sign_symbol('ar_EG', numbering_system='default')
-    '\u061c-'
+    '\\u061c-'
     >>> get_minus_sign_symbol('ar_EG', numbering_system='latn')
-    '\u200e-'
+    '\\u200e-'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -607,7 +607,7 @@ def format_compact_decimal(
     >>> format_compact_decimal(21000000, format_type="long", locale="mk")
     '21 милион'
     >>> format_compact_decimal(12345, format_type="short", locale='ar_EG', fraction_digits=2, numbering_system='default')
-    '12٫34\xa0ألف'
+    '12٫34\\xa0ألف'
 
     :param number: the number to format
     :param format_type: Compact format to use ("short" or "long")
@@ -692,16 +692,16 @@ def format_currency(
     >>> format_currency(1099.98, 'EUR', locale='de_DE')
     '1.099,98\\xa0\\u20ac'
     >>> format_currency(1099.98, 'EGP', locale='ar_EG', numbering_system='default')
-    '\u200f1٬099٫98\xa0ج.م.\u200f'
+    '\\u200f1٬099٫98\\xa0ج.م.\\u200f'
 
     The format can also be specified explicitly.  The currency is
     placed with the '¤' sign.  As the sign gets repeated the format
     expands (¤ being the symbol, ¤¤ is the currency abbreviation and
     ¤¤¤ is the full name of the currency):
 
-    >>> format_currency(1099.98, 'EUR', '\xa4\xa4 #,##0.00', locale='en_US')
+    >>> format_currency(1099.98, 'EUR', '\\xa4\\xa4 #,##0.00', locale='en_US')
     'EUR 1,099.98'
-    >>> format_currency(1099.98, 'EUR', '#,##0.00 \xa4\xa4\xa4', locale='en_US')
+    >>> format_currency(1099.98, 'EUR', '#,##0.00 \\xa4\\xa4\\xa4', locale='en_US')
     '1,099.98 euros'
 
     Currencies usually have a specific number of decimal digits. This function
@@ -858,7 +858,7 @@ def format_compact_currency(
     >>> format_compact_currency(123456789, 'USD', locale='en_US', fraction_digits=2)
     '$123.46M'
     >>> format_compact_currency(123456789, 'EUR', locale='de_DE', fraction_digits=1)
-    '123,5\xa0Mio.\xa0€'
+    '123,5\\xa0Mio.\\xa0€'
 
     :param number: the number to format
     :param currency: the currency code
@@ -916,7 +916,7 @@ def format_percent(
 
     The format pattern can also be specified explicitly:
 
-    >>> format_percent(25.1234, '#,##0\u2030', locale='en_US')
+    >>> format_percent(25.1234, '#,##0\\u2030', locale='en_US')
     '25,123‰'
 
     By default the locale is allowed to truncate and round a high-precision

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -113,7 +113,7 @@ def get_currency_name(
     """Return the name used by the locale for the specified currency.
 
     >>> get_currency_name('USD', locale='en_US')
-    u'US Dollar'
+    'US Dollar'
 
     .. versionadded:: 0.9.4
 
@@ -142,7 +142,7 @@ def get_currency_symbol(currency: str, locale: Locale | str | None = None) -> st
     """Return the symbol used by the locale for the specified currency.
 
     >>> get_currency_symbol('USD', locale='en_US')
-    u'$'
+    '$'
 
     :param currency: the currency code.
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
@@ -177,7 +177,7 @@ def get_currency_unit_pattern(
     name should be substituted.
 
     >>> get_currency_unit_pattern('USD', locale='en_US', count=10)
-    u'{0} {1}'
+    '{0} {1}'
 
     .. versionadded:: 2.7.0
 
@@ -349,11 +349,11 @@ def get_decimal_symbol(
     """Return the symbol used by the locale to separate decimal fractions.
 
     >>> get_decimal_symbol('en_US')
-    u'.'
+    '.'
     >>> get_decimal_symbol('ar_EG', numbering_system='default')
-    u'٫'
+    '٫'
     >>> get_decimal_symbol('ar_EG', numbering_system='latn')
-    u'.'
+    '.'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -372,11 +372,11 @@ def get_plus_sign_symbol(
     """Return the plus sign symbol used by the current locale.
 
     >>> get_plus_sign_symbol('en_US')
-    u'+'
+    '+'
     >>> get_plus_sign_symbol('ar_EG', numbering_system='default')
-    u'\u061c+'
+    '\u061c+'
     >>> get_plus_sign_symbol('ar_EG', numbering_system='latn')
-    u'\u200e+'
+    '\u200e+'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -395,11 +395,11 @@ def get_minus_sign_symbol(
     """Return the plus sign symbol used by the current locale.
 
     >>> get_minus_sign_symbol('en_US')
-    u'-'
+    '-'
     >>> get_minus_sign_symbol('ar_EG', numbering_system='default')
-    u'\u061c-'
+    '\u061c-'
     >>> get_minus_sign_symbol('ar_EG', numbering_system='latn')
-    u'\u200e-'
+    '\u200e-'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -418,11 +418,11 @@ def get_exponential_symbol(
     """Return the symbol used by the locale to separate mantissa and exponent.
 
     >>> get_exponential_symbol('en_US')
-    u'E'
+    'E'
     >>> get_exponential_symbol('ar_EG', numbering_system='default')
-    u'أس'
+    'أس'
     >>> get_exponential_symbol('ar_EG', numbering_system='latn')
-    u'E'
+    'E'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -441,11 +441,11 @@ def get_group_symbol(
     """Return the symbol used by the locale to separate groups of thousands.
 
     >>> get_group_symbol('en_US')
-    u','
+    ','
     >>> get_group_symbol('ar_EG', numbering_system='default')
-    u'٬'
+    '٬'
     >>> get_group_symbol('ar_EG', numbering_system='latn')
-    u','
+    ','
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -464,11 +464,11 @@ def get_infinity_symbol(
     """Return the symbol used by the locale to represent infinity.
 
     >>> get_infinity_symbol('en_US')
-    u'∞'
+    '∞'
     >>> get_infinity_symbol('ar_EG', numbering_system='default')
-    u'∞'
+    '∞'
     >>> get_infinity_symbol('ar_EG', numbering_system='latn')
-    u'∞'
+    '∞'
 
     :param locale: the `Locale` object or locale identifier. Defaults to the system numeric locale.
     :param numbering_system: The numbering system used for fetching the symbol. Defaults to "latn".
@@ -483,9 +483,9 @@ def format_number(number: float | decimal.Decimal | str, locale: Locale | str | 
     """Return the given number formatted for a specific locale.
 
     >>> format_number(1099, locale='en_US')  # doctest: +SKIP
-    u'1,099'
+    '1,099'
     >>> format_number(1099, locale='de_DE')  # doctest: +SKIP
-    u'1.099'
+    '1.099'
 
     .. deprecated:: 2.6.0
 
@@ -532,38 +532,38 @@ def format_decimal(
     """Return the given decimal number formatted for a specific locale.
 
     >>> format_decimal(1.2345, locale='en_US')
-    u'1.234'
+    '1.234'
     >>> format_decimal(1.2346, locale='en_US')
-    u'1.235'
+    '1.235'
     >>> format_decimal(-1.2346, locale='en_US')
-    u'-1.235'
+    '-1.235'
     >>> format_decimal(1.2345, locale='sv_SE')
-    u'1,234'
+    '1,234'
     >>> format_decimal(1.2345, locale='de')
-    u'1,234'
+    '1,234'
     >>> format_decimal(1.2345, locale='ar_EG', numbering_system='default')
-    u'1٫234'
+    '1٫234'
     >>> format_decimal(1.2345, locale='ar_EG', numbering_system='latn')
-    u'1.234'
+    '1.234'
 
     The appropriate thousands grouping and the decimal separator are used for
     each locale:
 
     >>> format_decimal(12345.5, locale='en_US')
-    u'12,345.5'
+    '12,345.5'
 
     By default the locale is allowed to truncate and round a high-precision
     number by forcing its format pattern onto the decimal part. You can bypass
     this behavior with the `decimal_quantization` parameter:
 
     >>> format_decimal(1.2346, locale='en_US')
-    u'1.235'
+    '1.235'
     >>> format_decimal(1.2346, locale='en_US', decimal_quantization=False)
-    u'1.2346'
+    '1.2346'
     >>> format_decimal(12345.67, locale='fr_CA', group_separator=False)
-    u'12345,67'
+    '12345,67'
     >>> format_decimal(12345.67, locale='en_US', group_separator=True)
-    u'12,345.67'
+    '12,345.67'
 
     :param number: the number to format
     :param format:
@@ -595,19 +595,19 @@ def format_compact_decimal(
     """Return the given decimal number formatted for a specific locale in compact form.
 
     >>> format_compact_decimal(12345, format_type="short", locale='en_US')
-    u'12K'
+    '12K'
     >>> format_compact_decimal(12345, format_type="long", locale='en_US')
-    u'12 thousand'
+    '12 thousand'
     >>> format_compact_decimal(12345, format_type="short", locale='en_US', fraction_digits=2)
-    u'12.34K'
+    '12.34K'
     >>> format_compact_decimal(1234567, format_type="short", locale="ja_JP")
-    u'123万'
+    '123万'
     >>> format_compact_decimal(2345678, format_type="long", locale="mk")
-    u'2 милиони'
+    '2 милиони'
     >>> format_compact_decimal(21000000, format_type="long", locale="mk")
-    u'21 милион'
+    '21 милион'
     >>> format_compact_decimal(12345, format_type="short", locale='ar_EG', fraction_digits=2, numbering_system='default')
-    u'12٫34\xa0ألف'
+    '12٫34\xa0ألف'
 
     :param number: the number to format
     :param format_type: Compact format to use ("short" or "long")
@@ -688,43 +688,43 @@ def format_currency(
     >>> format_currency(1099.98, 'USD', locale='en_US')
     '$1,099.98'
     >>> format_currency(1099.98, 'USD', locale='es_CO')
-    u'US$1.099,98'
+    'US$1.099,98'
     >>> format_currency(1099.98, 'EUR', locale='de_DE')
-    u'1.099,98\\xa0\\u20ac'
+    '1.099,98\\xa0\\u20ac'
     >>> format_currency(1099.98, 'EGP', locale='ar_EG', numbering_system='default')
-    u'\u200f1٬099٫98\xa0ج.م.\u200f'
+    '\u200f1٬099٫98\xa0ج.م.\u200f'
 
     The format can also be specified explicitly.  The currency is
     placed with the '¤' sign.  As the sign gets repeated the format
     expands (¤ being the symbol, ¤¤ is the currency abbreviation and
     ¤¤¤ is the full name of the currency):
 
-    >>> format_currency(1099.98, 'EUR', u'\xa4\xa4 #,##0.00', locale='en_US')
-    u'EUR 1,099.98'
-    >>> format_currency(1099.98, 'EUR', u'#,##0.00 \xa4\xa4\xa4', locale='en_US')
-    u'1,099.98 euros'
+    >>> format_currency(1099.98, 'EUR', '\xa4\xa4 #,##0.00', locale='en_US')
+    'EUR 1,099.98'
+    >>> format_currency(1099.98, 'EUR', '#,##0.00 \xa4\xa4\xa4', locale='en_US')
+    '1,099.98 euros'
 
     Currencies usually have a specific number of decimal digits. This function
     favours that information over the given format:
 
     >>> format_currency(1099.98, 'JPY', locale='en_US')
-    u'\\xa51,100'
-    >>> format_currency(1099.98, 'COP', u'#,##0.00', locale='es_ES')
-    u'1.099,98'
+    '\\xa51,100'
+    >>> format_currency(1099.98, 'COP', '#,##0.00', locale='es_ES')
+    '1.099,98'
 
     However, the number of decimal digits can be overridden from the currency
     information, by setting the last parameter to ``False``:
 
     >>> format_currency(1099.98, 'JPY', locale='en_US', currency_digits=False)
-    u'\\xa51,099.98'
-    >>> format_currency(1099.98, 'COP', u'#,##0.00', locale='es_ES', currency_digits=False)
-    u'1.099,98'
+    '\\xa51,099.98'
+    >>> format_currency(1099.98, 'COP', '#,##0.00', locale='es_ES', currency_digits=False)
+    '1.099,98'
 
     If a format is not specified the type of currency format to use
     from the locale can be specified:
 
     >>> format_currency(1099.98, 'EUR', locale='en_US', format_type='standard')
-    u'\\u20ac1,099.98'
+    '\\u20ac1,099.98'
 
     When the given currency format type is not available, an exception is
     raised:
@@ -735,30 +735,30 @@ def format_currency(
     UnknownCurrencyFormatError: "'unknown' is not a known currency format type"
 
     >>> format_currency(101299.98, 'USD', locale='en_US', group_separator=False)
-    u'$101299.98'
+    '$101299.98'
 
     >>> format_currency(101299.98, 'USD', locale='en_US', group_separator=True)
-    u'$101,299.98'
+    '$101,299.98'
 
     You can also pass format_type='name' to use long display names. The order of
     the number and currency name, along with the correct localized plural form
     of the currency name, is chosen according to locale:
 
     >>> format_currency(1, 'USD', locale='en_US', format_type='name')
-    u'1.00 US dollar'
+    '1.00 US dollar'
     >>> format_currency(1099.98, 'USD', locale='en_US', format_type='name')
-    u'1,099.98 US dollars'
+    '1,099.98 US dollars'
     >>> format_currency(1099.98, 'USD', locale='ee', format_type='name')
-    u'us ga dollar 1,099.98'
+    'us ga dollar 1,099.98'
 
     By default the locale is allowed to truncate and round a high-precision
     number by forcing its format pattern onto the decimal part. You can bypass
     this behavior with the `decimal_quantization` parameter:
 
     >>> format_currency(1099.9876, 'USD', locale='en_US')
-    u'$1,099.99'
+    '$1,099.99'
     >>> format_currency(1099.9876, 'USD', locale='en_US', decimal_quantization=False)
-    u'$1,099.9876'
+    '$1,099.9876'
 
     :param number: the number to format
     :param currency: the currency code
@@ -854,9 +854,9 @@ def format_compact_currency(
     """Format a number as a currency value in compact form.
 
     >>> format_compact_currency(12345, 'USD', locale='en_US')
-    u'$12K'
+    '$12K'
     >>> format_compact_currency(123456789, 'USD', locale='en_US', fraction_digits=2)
-    u'$123.46M'
+    '$123.46M'
     >>> format_compact_currency(123456789, 'EUR', locale='de_DE', fraction_digits=1)
     '123,5\xa0Mio.\xa0€'
 
@@ -906,33 +906,33 @@ def format_percent(
     """Return formatted percent value for a specific locale.
 
     >>> format_percent(0.34, locale='en_US')
-    u'34%'
+    '34%'
     >>> format_percent(25.1234, locale='en_US')
-    u'2,512%'
+    '2,512%'
     >>> format_percent(25.1234, locale='sv_SE')
-    u'2\\xa0512\\xa0%'
+    '2\\xa0512\\xa0%'
     >>> format_percent(25.1234, locale='ar_EG', numbering_system='default')
-    u'2٬512%'
+    '2٬512%'
 
     The format pattern can also be specified explicitly:
 
-    >>> format_percent(25.1234, u'#,##0\u2030', locale='en_US')
-    u'25,123\u2030'
+    >>> format_percent(25.1234, '#,##0\u2030', locale='en_US')
+    '25,123\u2030'
 
     By default the locale is allowed to truncate and round a high-precision
     number by forcing its format pattern onto the decimal part. You can bypass
     this behavior with the `decimal_quantization` parameter:
 
     >>> format_percent(23.9876, locale='en_US')
-    u'2,399%'
+    '2,399%'
     >>> format_percent(23.9876, locale='en_US', decimal_quantization=False)
-    u'2,398.76%'
+    '2,398.76%'
 
     >>> format_percent(229291.1234, locale='pt_BR', group_separator=False)
-    u'22929112%'
+    '22929112%'
 
     >>> format_percent(229291.1234, locale='pt_BR', group_separator=True)
-    u'22.929.112%'
+    '22.929.112%'
 
     :param number: the percent number to format
     :param format:
@@ -966,23 +966,23 @@ def format_scientific(
     """Return value formatted in scientific notation for a specific locale.
 
     >>> format_scientific(10000, locale='en_US')
-    u'1E4'
+    '1E4'
     >>> format_scientific(10000, locale='ar_EG', numbering_system='default')
-    u'1أس4'
+    '1أس4'
 
     The format pattern can also be specified explicitly:
 
-    >>> format_scientific(1234567, u'##0.##E00', locale='en_US')
-    u'1.23E06'
+    >>> format_scientific(1234567, '##0.##E00', locale='en_US')
+    '1.23E06'
 
     By default the locale is allowed to truncate and round a high-precision
     number by forcing its format pattern onto the decimal part. You can bypass
     this behavior with the `decimal_quantization` parameter:
 
-    >>> format_scientific(1234.9876, u'#.##E0', locale='en_US')
-    u'1.23E3'
-    >>> format_scientific(1234.9876, u'#.##E0', locale='en_US', decimal_quantization=False)
-    u'1.2349876E3'
+    >>> format_scientific(1234.9876, '#.##E0', locale='en_US')
+    '1.23E3'
+    >>> format_scientific(1234.9876, '#.##E0', locale='en_US', decimal_quantization=False)
+    '1.2349876E3'
 
     :param number: the number to format
     :param format:

--- a/babel/support.py
+++ b/babel/support.py
@@ -94,7 +94,7 @@ class Format:
         >>> from babel.dates import get_timezone
         >>> fmt = Format('en_US', tzinfo=get_timezone('US/Eastern'))
         >>> fmt.datetime(datetime(2007, 4, 1, 15, 30))
-        'Apr 1, 2007, 11:30:00\u202fAM'
+        'Apr 1, 2007, 11:30:00\\u202fAM'
         """
         return format_datetime(datetime, format, tzinfo=self.tzinfo, locale=self.locale)
 
@@ -109,7 +109,7 @@ class Format:
         >>> from babel.dates import get_timezone
         >>> fmt = Format('en_US', tzinfo=get_timezone('US/Eastern'))
         >>> fmt.time(datetime(2007, 4, 1, 15, 30))
-        '11:30:00\u202fAM'
+        '11:30:00\\u202fAM'
         """
         return format_time(time, format, tzinfo=self.tzinfo, locale=self.locale)
 

--- a/babel/support.py
+++ b/babel/support.py
@@ -46,9 +46,9 @@ class Format:
     >>> from datetime import date
     >>> fmt = Format('en_US', UTC)
     >>> fmt.date(date(2007, 4, 1))
-    u'Apr 1, 2007'
+    'Apr 1, 2007'
     >>> fmt.decimal(1.2345)
-    u'1.234'
+    '1.234'
     """
 
     def __init__(
@@ -79,7 +79,7 @@ class Format:
         >>> from datetime import date
         >>> fmt = Format('en_US')
         >>> fmt.date(date(2007, 4, 1))
-        u'Apr 1, 2007'
+        'Apr 1, 2007'
         """
         return format_date(date, format, locale=self.locale)
 
@@ -94,7 +94,7 @@ class Format:
         >>> from babel.dates import get_timezone
         >>> fmt = Format('en_US', tzinfo=get_timezone('US/Eastern'))
         >>> fmt.datetime(datetime(2007, 4, 1, 15, 30))
-        u'Apr 1, 2007, 11:30:00\u202fAM'
+        'Apr 1, 2007, 11:30:00\u202fAM'
         """
         return format_datetime(datetime, format, tzinfo=self.tzinfo, locale=self.locale)
 
@@ -109,7 +109,7 @@ class Format:
         >>> from babel.dates import get_timezone
         >>> fmt = Format('en_US', tzinfo=get_timezone('US/Eastern'))
         >>> fmt.time(datetime(2007, 4, 1, 15, 30))
-        u'11:30:00\u202fAM'
+        '11:30:00\u202fAM'
         """
         return format_time(time, format, tzinfo=self.tzinfo, locale=self.locale)
 
@@ -126,7 +126,7 @@ class Format:
         >>> from datetime import timedelta
         >>> fmt = Format('en_US')
         >>> fmt.timedelta(timedelta(weeks=11))
-        u'3 months'
+        '3 months'
         """
         return format_timedelta(delta, granularity=granularity,
                                 threshold=threshold,
@@ -138,7 +138,7 @@ class Format:
 
         >>> fmt = Format('en_US')
         >>> fmt.number(1099)
-        u'1,099'
+        '1,099'
         """
         return format_decimal(number, locale=self.locale, numbering_system=self.numbering_system)
 
@@ -147,7 +147,7 @@ class Format:
 
         >>> fmt = Format('en_US')
         >>> fmt.decimal(1.2345)
-        u'1.234'
+        '1.234'
         """
         return format_decimal(number, format, locale=self.locale, numbering_system=self.numbering_system)
 
@@ -161,7 +161,7 @@ class Format:
 
         >>> fmt = Format('en_US')
         >>> fmt.compact_decimal(123456789)
-        u'123M'
+        '123M'
         >>> fmt.compact_decimal(1234567, format_type='long', fraction_digits=2)
         '1.23 million'
         """
@@ -199,7 +199,7 @@ class Format:
 
         >>> fmt = Format('en_US')
         >>> fmt.percent(0.34)
-        u'34%'
+        '34%'
         """
         return format_percent(number, format, locale=self.locale, numbering_system=self.numbering_system)
 
@@ -218,10 +218,10 @@ class LazyProxy:
     >>> lazy_greeting = LazyProxy(greeting, name='Joe')
     >>> print(lazy_greeting)
     Hello, Joe!
-    >>> u'  ' + lazy_greeting
-    u'  Hello, Joe!'
-    >>> u'(%s)' % lazy_greeting
-    u'(Hello, Joe!)'
+    >>> '  ' + lazy_greeting
+    '  Hello, Joe!'
+    >>> '(%s)' % lazy_greeting
+    '(Hello, Joe!)'
 
     This can be used, for example, to implement lazy translation functions that
     delay the actual translation until the string is actually used. The

--- a/babel/units.py
+++ b/babel/units.py
@@ -90,32 +90,32 @@ def format_unit(
     and number formats.
 
     >>> format_unit(12, 'length-meter', locale='ro_RO')
-    u'12 metri'
+    '12 metri'
     >>> format_unit(15.5, 'length-mile', locale='fi_FI')
-    u'15,5 mailia'
+    '15,5 mailia'
     >>> format_unit(1200, 'pressure-millimeter-ofhg', locale='nb')
-    u'1\\xa0200 millimeter kvikks\\xf8lv'
+    '1\\xa0200 millimeter kvikks\\xf8lv'
     >>> format_unit(270, 'ton', locale='en')
-    u'270 tons'
+    '270 tons'
     >>> format_unit(1234.5, 'kilogram', locale='ar_EG', numbering_system='default')
-    u'1٬234٫5 كيلوغرام'
+    '1٬234٫5 كيلوغرام'
 
     Number formats may be overridden with the ``format`` parameter.
 
     >>> import decimal
     >>> format_unit(decimal.Decimal("-42.774"), 'temperature-celsius', 'short', format='#.0', locale='fr')
-    u'-42,8\\u202f\\xb0C'
+    '-42,8\\u202f\\xb0C'
 
     The locale's usual pluralization rules are respected.
 
     >>> format_unit(1, 'length-meter', locale='ro_RO')
-    u'1 metru'
+    '1 metru'
     >>> format_unit(0, 'length-mile', locale='cy')
-    u'0 mi'
+    '0 mi'
     >>> format_unit(1, 'length-mile', locale='cy')
-    u'1 filltir'
+    '1 filltir'
     >>> format_unit(3, 'length-mile', locale='cy')
-    u'3 milltir'
+    '3 milltir'
 
     >>> format_unit(15, 'length-horse', locale='fi')
     Traceback (most recent call last):

--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -354,6 +354,6 @@ display a list of time-zones to the user.
 
     >>> dt = _localize(tz, datetime(2007, 8, 15))
     >>> get_timezone_name(dt, locale=Locale.parse('de_DE'))
-    'Mitteleurop\xe4ische Sommerzeit'
+    'Mitteleuropäische Sommerzeit'
     >>> get_timezone_name(tz, locale=Locale.parse('de_DE'))
-    'Mitteleurop\xe4ische Zeit'
+    'Mitteleuropäische Zeit'

--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -19,9 +19,9 @@ Babel provides functions for locale-specific formatting of those objects in its
 
     >>> d = date(2007, 4, 1)
     >>> format_date(d, locale='en')
-    u'Apr 1, 2007'
+    'Apr 1, 2007'
     >>> format_date(d, locale='de_DE')
-    u'01.04.2007'
+    '01.04.2007'
 
 As this example demonstrates, Babel will automatically choose a date format
 that is appropriate for the requested locale.
@@ -39,11 +39,11 @@ For example:
 .. code-block:: pycon
 
     >>> format_date(d, format='short', locale='en')
-    u'4/1/07'
+    '4/1/07'
     >>> format_date(d, format='long', locale='en')
-    u'April 1, 2007'
+    'April 1, 2007'
     >>> format_date(d, format='full', locale='en')
-    u'Sunday, April 1, 2007'
+    'Sunday, April 1, 2007'
 
 Core Time Concepts
 ==================
@@ -105,19 +105,19 @@ For example:
 
     >>> d = date(2007, 4, 1)
     >>> format_date(d, "EEE, MMM d, ''yy", locale='en')
-    u"Sun, Apr 1, '07"
+    "Sun, Apr 1, '07"
     >>> format_date(d, "EEEE, d.M.yyyy", locale='de')
-    u'Sonntag, 1.4.2007'
+    'Sonntag, 1.4.2007'
 
     >>> t = time(15, 30)
     >>> format_time(t, "hh 'o''clock' a", locale='en')
-    u"03 o'clock PM"
+    "03 o'clock PM"
     >>> format_time(t, 'H:mm a', locale='de')
-    u'15:30 nachm.'
+    '15:30 nachm.'
 
     >>> dt = datetime(2007, 4, 1, 15, 30)
     >>> format_datetime(dt, "yyyyy.MMMM.dd GGG hh:mm a", locale='en')
-    u'02007.April.01 AD 03:30 PM'
+    '02007.April.01 AD 03:30 PM'
 
 The syntax for custom datetime format patterns is described in detail in the
 the `Locale Data Markup Language specification`_. The following table is just a
@@ -245,7 +245,7 @@ difference, and displays that:
     >>> from babel.dates import format_timedelta
     >>> delta = timedelta(days=6)
     >>> format_timedelta(delta, locale='en_US')
-    u'1 week'
+    '1 week'
 
 The resulting strings are based from the CLDR data, and are properly
 pluralized depending on the plural rules of the locale and the calculated
@@ -260,9 +260,9 @@ can limit the smallest unit to display:
 
     >>> delta = timedelta(days=6)
     >>> format_timedelta(delta, threshold=1.2, locale='en_US')
-    u'6 days'
+    '6 days'
     >>> format_timedelta(delta, granularity='month', locale='en_US')
-    u'1 month'
+    '1 month'
 
 .. _timezone-support:
 
@@ -287,7 +287,7 @@ You can directly interface with either of these modules from within Babel:
     >>> dt = datetime(2007, 4, 1, 15, 30, tzinfo=UTC)
     >>> eastern = get_timezone('US/Eastern')
     >>> format_datetime(dt, 'H:mm Z', tzinfo=eastern, locale='en_US')
-    u'11:30 -0400'
+    '11:30 -0400'
 
 The recommended approach to deal with different time-zones in a Python
 application is to always use UTC internally, and only convert from/to the users
@@ -300,7 +300,7 @@ information unchanged:
 
     >>> british = get_timezone('Europe/London')
     >>> format_datetime(dt, 'H:mm zzzz', tzinfo=british, locale='en_US')
-    u'16:30 British Summer Time'
+    '16:30 British Summer Time'
 
 Here, the given UTC time is adjusted to the "Europe/London" time-zone, and
 daylight savings time is taken into account. Daylight savings time is also
@@ -317,7 +317,7 @@ your operating system.  It's provided through the ``LOCALTZ`` constant:
     >>> LOCALTZ
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
     >>> get_timezone_name(LOCALTZ)
-    u'Central European Time'
+    'Central European Time'
 
 .. _pytz: https://pythonhosted.org/pytz/
 
@@ -338,7 +338,7 @@ functions in the ``babel.dates`` module, most importantly the
 
     >>> tz = get_timezone('Europe/Berlin')
     >>> get_timezone_name(tz, locale=Locale.parse('pt_PT'))
-    u'Hora da Europa Central'
+    'Hora da Europa Central'
 
 You can pass the function either a ``datetime.tzinfo`` object, or a
 ``datetime.date`` or ``datetime.datetime`` object. If you pass an actual date,
@@ -354,6 +354,6 @@ display a list of time-zones to the user.
 
     >>> dt = _localize(tz, datetime(2007, 8, 15))
     >>> get_timezone_name(dt, locale=Locale.parse('de_DE'))
-    u'Mitteleurop\xe4ische Sommerzeit'
+    'Mitteleurop\xe4ische Sommerzeit'
     >>> get_timezone_name(tz, locale=Locale.parse('de_DE'))
-    u'Mitteleurop\xe4ische Zeit'
+    'Mitteleurop\xe4ische Zeit'

--- a/docs/locale.rst
+++ b/docs/locale.rst
@@ -30,10 +30,10 @@ You normally access such locale data through the
     >>> from babel import Locale
     >>> locale = Locale('en', 'US')
     >>> locale.territories['US']
-    u'United States'
+    'United States'
     >>> locale = Locale('es', 'MX')
     >>> locale.territories['US']
-    u'Estados Unidos'
+    'Estados Unidos'
 
 In addition to country/territory names, the locale data also provides access to
 names of languages, scripts, variants, time zones, and more. Some of the data
@@ -89,9 +89,9 @@ language supported by the CLDR:
 
     >>> l = Locale.parse('de_DE')
     >>> l.get_display_name('en_US')
-    u'German (Germany)'
+    'German (Germany)'
     >>> l.get_display_name('fr_FR')
-    u'allemand (Allemagne)'
+    'allemand (Allemagne)'
 
 Display names include all the information to uniquely identify a locale
 (language, territory, script and variant) which is often not what you
@@ -100,13 +100,13 @@ want.  You can also ask for the information in parts:
 .. code-block:: pycon
 
     >>> l.get_language_name('de_DE')
-    u'Deutsch'
+    'Deutsch'
     >>> l.get_language_name('it_IT')
-    u'tedesco'
+    'tedesco'
     >>> l.get_territory_name('it_IT')
-    u'Germania'
+    'Germania'
     >>> l.get_territory_name('pt_PT')
-    u'Alemanha'
+    'Alemanha'
 
 
 Calendar Display Names

--- a/docs/numbers.rst
+++ b/docs/numbers.rst
@@ -20,14 +20,14 @@ Examples:
 
     # Numbers with decimal places
     >>> format_decimal(1.2345, locale='en_US')
-    u'1.234'
+    '1.234'
     >>> format_decimal(1.2345, locale='sv_SE')
-    u'1,234'
+    '1,234'
     # Integers with thousand grouping
     >>> format_decimal(12345, locale='de_DE')
-    u'12.345'
+    '12.345'
     >>> format_decimal(12345678, locale='de_DE')
-    u'12.345.678'
+    '12.345.678'
 
 Pattern Syntax
 ==============
@@ -42,9 +42,9 @@ Examples:
 .. code-block:: pycon
 
     >>> format_decimal(-1.2345, format='#,##0.##;-#', locale='en')
-    u'-1.23'
+    '-1.23'
     >>> format_decimal(-1.2345, format='#,##0.##;(#)', locale='en')
-    u'(1.23)'
+    '(1.23)'
 
 The syntax for custom number format patterns is described in detail in the
 the specification. The following table is just a relatively brief overview.
@@ -106,7 +106,7 @@ current context before formatting a number or currency:
     >>> with decimal.localcontext(decimal.Context(rounding=decimal.ROUND_DOWN)):
     >>>    txt = format_decimal(123.99, format='#', locale='en_US')
     >>> txt
-    u'123'
+    '123'
 
 It is also possible to use ``decimal.setcontext`` or directly modifying the
 instance returned by ``decimal.getcontext``.  However, using a context manager
@@ -129,7 +129,7 @@ unexpected results on Python 2.7, with the `cdecimal`_ module installed:
     >>> with localcontext(Context(rounding=ROUND_DOWN)):
     >>>    txt = format_decimal(123.99, format='#', locale='en_US')
     >>> txt
-    u'124'
+    '124'
 
 Changing other parameters such as the precision may also alter the results of
 the number formatting functions.  Remember to test your code to make sure it
@@ -176,7 +176,7 @@ Examples:
     1099
     >>> parse_number('1.099.024', locale='de')
     1099024
-    >>> parse_number('123' + u'\xa0' + '4567', locale='ru')
+    >>> parse_number('123' + '\xa0' + '4567', locale='ru')
     1234567
     >>> parse_number('123 4567', locale='ru')
       ...

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -110,7 +110,7 @@ class CatalogTestCase(unittest.TestCase):
         cat['foo'] = catalog.Message('foo', locations=[('main.py', 5)])
         assert cat['foo'].auto_comments == []
         assert cat['foo'].user_comments == []
-        # Update cat[u'foo'] with a new location and a comment
+        # Update cat['foo'] with a new location and a comment
         cat['foo'] = catalog.Message('foo', locations=[('main.py', 7)],
                                      user_comments=['Foo Bar comment 1'])
         assert cat['foo'].user_comments == ['Foo Bar comment 1']

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -207,14 +207,14 @@ foobar = _('foo' 'bar')
         assert messages[0][2] == 'foobar'
 
     def test_unicode_string_arg(self):
-        buf = BytesIO(b"msg = _(u'Foo Bar')")
+        buf = BytesIO(b"msg = _('Foo Bar')")
         messages = list(extract.extract_python(buf, ('_',), [], {}))
         assert messages[0][2] == 'Foo Bar'
 
     def test_comment_tag(self):
         buf = BytesIO(b"""
 # NOTE: A translation comment
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -224,7 +224,7 @@ msg = _(u'Foo Bar')
         buf = BytesIO(b"""
 # NOTE: A translation comment
 # with a second line
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -236,7 +236,7 @@ msg = _(u'Foo Bar')
 # because it didn't start with a comment tag
 # NOTE: A translation comment
 # with a second line
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -248,7 +248,7 @@ msg = _(u'Foo Bar')
 # because it didn't start with a comment tag
 # do NOTE: this will not be a translation comment
 # NOTE: This one will be
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -258,10 +258,10 @@ msg = _(u'Foo Bar')
         buf = BytesIO(b"""
 # NOTE1: A translation comment for tag1
 # with a second line
-msg = _(u'Foo Bar1')
+msg = _('Foo Bar1')
 
 # NOTE2: A translation comment for tag2
-msg = _(u'Foo Bar2')
+msg = _('Foo Bar2')
 """)
         messages = list(extract.extract_python(buf, ('_',),
                                                ['NOTE1:', 'NOTE2:'], {}))
@@ -274,7 +274,7 @@ msg = _(u'Foo Bar2')
         buf = BytesIO(b"""
 # NOTE: one
 # NOTE: two
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -285,7 +285,7 @@ msg = _(u'Foo Bar')
 # NOTE: this shouldn't apply to any messages
 hello = 'there'
 
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -323,7 +323,7 @@ hithere = _('Hi there!')
         buf = BytesIO(b"""
   #: A translation comment
   #: with leading spaces
-msg = _(u'Foo Bar')
+msg = _('Foo Bar')
 """)
         messages = list(extract.extract_python(buf, ('_',), [':'], {}))
         assert messages[0][2] == 'Foo Bar'
@@ -394,7 +394,7 @@ msg = _('Bonjour à tous')
     def test_utf8_raw_strings_match_unicode_strings(self):
         buf = BytesIO(codecs.BOM_UTF8 + """
 msg = _('Bonjour à tous')
-msgu = _(u'Bonjour à tous')
+msgu = _('Bonjour à tous')
 """.encode('utf-8'))
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == 'Bonjour à tous'
@@ -419,15 +419,15 @@ _('Babatschi')""")
     def test_nested_messages(self):
         buf = BytesIO(b"""
 # NOTE: First
-_(u'Hello, {name}!', name=_(u'Foo Bar'))
+_('Hello, {name}!', name=_('Foo Bar'))
 
 # NOTE: Second
-_(u'Hello, {name1} and {name2}!', name1=_(u'Heungsub'),
-  name2=_(u'Armin'))
+_('Hello, {name1} and {name2}!', name1=_('Heungsub'),
+  name2=_('Armin'))
 
 # NOTE: Third
-_(u'Hello, {0} and {1}!', _(u'Heungsub'),
-  _(u'Armin'))
+_('Hello, {0} and {1}!', _('Heungsub'),
+  _('Armin'))
 """)
         messages = list(extract.extract_python(buf, ('_',), ['NOTE:'], {}))
         assert messages[0][2] == ('Hello, {name}!', None)

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1639,8 +1639,7 @@ def test_extract_error_code(monkeypatch, capsys):
     assert cmdinst.run() == 1
     out, err = capsys.readouterr()
     if err:
-        # replace hack below for py2/py3 compatibility
-        assert "unknown named placeholder 'merkki'" in err.replace("u'", "'")
+        assert "unknown named placeholder 'merkki'" in err
 
 
 @pytest.mark.parametrize("with_underscore_ignore", (False, True))


### PR DESCRIPTION
I did a search and replace for `u"` and `(?<!')u'` and checked each case. I also update some strings to include the character instead of `\u` literals and I also noticed some literals in docstrings were not escaped correctly (you need to escape the backslash unless it's a `r"""` docstring, otherwise the docstring will contain the actual character instead of the literal)