### PR TITLE
Import `Literal` from the typing module

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import pickle
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from babel import localedata
 from babel.plural import PluralRule
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal, TypeAlias
+    from typing_extensions import TypeAlias
 
     _GLOBAL_KEY: TypeAlias = Literal[
         "all_currencies",

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -21,7 +21,7 @@ import math
 import re
 import warnings
 from functools import lru_cache
-from typing import TYPE_CHECKING, SupportsInt
+from typing import TYPE_CHECKING, Literal, SupportsInt
 
 try:
     import pytz
@@ -37,7 +37,7 @@ from babel.core import Locale, default_locale, get_global
 from babel.localedata import LocaleDataDict
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal, TypeAlias
+    from typing_extensions import TypeAlias
     _Instant: TypeAlias = datetime.date | datetime.time | float | None
     _PredefinedTimeFormat: TypeAlias = Literal['full', 'long', 'medium', 'short']
     _Context: TypeAlias = Literal['format', 'stand-alone']

--- a/babel/lists.py
+++ b/babel/lists.py
@@ -17,14 +17,9 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import Literal
 
 from babel.core import Locale, default_locale
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
-
-
 
 _DEFAULT_LOCALE = default_locale()  # TODO(3.0): Remove this.
 

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -34,7 +34,7 @@ from functools import lru_cache
 from os.path import relpath
 from textwrap import dedent
 from tokenize import COMMENT, NAME, NL, OP, STRING, generate_tokens
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from babel.messages._compat import find_entrypoints
 from babel.util import parse_encoding, parse_future_flags, pathmatch
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from typing import IO, Final, Protocol
 
     from _typeshed import SupportsItems, SupportsRead, SupportsReadline
-    from typing_extensions import TypeAlias, TypedDict
+    from typing_extensions import TypeAlias
 
     class _PyOptions(TypedDict, total=False):
         encoding: str

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from babel.core import Locale
 from babel.messages.catalog import Catalog, Message
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from typing import IO, AnyStr
 
     from _typeshed import SupportsWrite
-    from typing_extensions import Literal
 
 
 def unescape(string: str) -> str:

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -23,13 +23,10 @@ import datetime
 import decimal
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, cast, overload
+from typing import Any, Literal, cast, overload
 
 from babel.core import Locale, default_locale, get_global
 from babel.localedata import LocaleDataDict
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 LC_NUMERIC = default_locale('LC_NUMERIC')
 

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -12,10 +12,7 @@ from __future__ import annotations
 import decimal
 import re
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Any, Callable
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
+from typing import Any, Callable, Literal
 
 _plural_tags = ('zero', 'one', 'two', 'few', 'many', 'other')
 _fallback_tag = 'other'

--- a/babel/support.py
+++ b/babel/support.py
@@ -16,7 +16,7 @@ import gettext
 import locale
 import os
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal
 
 from babel.core import Locale
 from babel.dates import format_date, format_datetime, format_time, format_timedelta
@@ -32,8 +32,6 @@ from babel.numbers import (
 if TYPE_CHECKING:
     import datetime as _datetime
     from decimal import Decimal
-
-    from typing_extensions import Literal
 
     from babel.dates import _PredefinedTimeFormat
 

--- a/babel/units.py
+++ b/babel/units.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import decimal
-from typing import TYPE_CHECKING
+from typing import Literal
 
 from babel.core import Locale
 from babel.numbers import LC_NUMERIC, format_decimal
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 
 class UnknownUnitError(ValueError):


### PR DESCRIPTION
[`typing.Literal`](https://docs.python.org/3/library/typing.html#typing.Literal) was added in 3.8. We can import it directly instead of relying on `typing_extensions`.

Edit: `TypedDict` as well

cc @akx