### PR TITLE
Increase test coverage of the `python_format` checker

### DIFF
--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -65,9 +65,6 @@ def _validate_format(format: str, alternative: str) -> None:
     arguments are not interchangeable as `alternative` may contain less
     placeholders if `format` uses named placeholders.
 
-    The behavior of this function is undefined if the string does not use
-    string formatting.
-
     If the string formatting of `alternative` is compatible to `format` the
     function returns `None`, otherwise a `TranslationError` is raised.
 
@@ -120,6 +117,9 @@ def _validate_format(format: str, alternative: str) -> None:
         return bool(positional)
 
     a, b = map(_parse, (format, alternative))
+
+    if not a:
+        return
 
     # now check if both strings are positional or named
     a_positional, b_positional = map(_check_positional, (a, b))


### PR DESCRIPTION
There a few bugs that I found in the `python_format` checker while working on the linter that I'd like to fix (e.g. one is that it does not validate `msgstr[N]` for `N >= 2`).

Though before I start fixing anything, I want to make sure we have the checker fully covered with tests as it would be pretty easy to accidentally introduce other bugs.

cc @akx 