### PR TITLE
Avoid unnecessary uses of `map()`

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -217,10 +217,17 @@ class Message:
         return self.__dict__ == other.__dict__
 
     def clone(self) -> Message:
-        return Message(*map(copy, (self.id, self.string, self.locations,
-                                   self.flags, self.auto_comments,
-                                   self.user_comments, self.previous_id,
-                                   self.lineno, self.context)))
+        return Message(
+            id=copy(self.id),
+            string=copy(self.string),
+            locations=copy(self.locations),
+            flags=copy(self.flags),
+            auto_comments=copy(self.auto_comments),
+            user_comments=copy(self.user_comments),
+            previous_id=copy(self.previous_id),
+            lineno=self.lineno,  # immutable (str/None)
+            context=self.context,  # immutable (str/None)
+        )
 
     def check(self, catalog: Catalog | None = None) -> list[TranslationError]:
         """Run various validation checks on the message.  Some validations

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -116,13 +116,15 @@ def _validate_format(format: str, alternative: str) -> None:
                                            'and named placeholders')
         return bool(positional)
 
-    a, b = map(_parse, (format, alternative))
+    a = _parse(format)
+    b = _parse(alternative)
 
     if not a:
         return
 
     # now check if both strings are positional or named
-    a_positional, b_positional = map(_check_positional, (a, b))
+    a_positional = _check_positional(a)
+    b_positional = _check_positional(b)
     if a_positional and not b_positional and not b:
         raise TranslationError('placeholders are incompatible')
     elif a_positional != b_positional:

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -108,7 +108,7 @@ def _strip_comment_tags(comments: MutableSequence[str], tags: Iterable[str]):
             if line.startswith(tag):
                 return line[len(tag):].strip()
         return line
-    comments[:] = map(_strip, comments)
+    comments[:] = [_strip(c) for c in comments]
 
 
 def default_directory_filter(dirpath: str | os.PathLike[str]) -> bool:

--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -53,7 +53,7 @@ _rules: list[tuple[str | None, re.Pattern[str]]] = [
         (0x[a-fA-F0-9]+)
     )''', re.VERBOSE)),
     ('jsx_tag', re.compile(r'(?:</?[^>\s]+|/>)', re.I)),  # May be mangled in `get_rules`
-    ('operator', re.compile(r'(%s)' % '|'.join(map(re.escape, operators)))),
+    ('operator', re.compile(r'(%s)' % '|'.join(re.escape(op) for op in operators))),
     ('template_string', re.compile(r'''`(?:[^`\\]*(?:\\.[^`\\]*)*)`''', re.UNICODE)),
     ('string', re.compile(r'''(
         '(?:[^'\\]*(?:\\.[^'\\]*)*)'  |

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -73,8 +73,7 @@ def denormalize(string: str) -> str:
         escaped_lines = string.splitlines()
         if string.startswith('""'):
             escaped_lines = escaped_lines[1:]
-        lines = map(unescape, escaped_lines)
-        return ''.join(lines)
+        return ''.join(unescape(line) for line in escaped_lines)
     else:
         return unescape(string)
 
@@ -144,7 +143,7 @@ class _NormalizedString:
         self._strs.append(s.strip())
 
     def denormalize(self) -> str:
-        return ''.join(map(unescape, self._strs))
+        return ''.join(unescape(s) for s in self._strs)
 
     def __bool__(self) -> bool:
         return bool(self._strs)

--- a/babel/plural.py
+++ b/babel/plural.py
@@ -586,7 +586,8 @@ class _GettextCompiler(_Compiler):
             if item[0] == item[1]:
                 rv.append(f"({expr} == {self.compile(item[0])})")
             else:
-                min, max = map(self.compile, item)
+                min = self.compile(item[0])
+                max = self.compile(item[1])
                 rv.append(f"({expr} >= {min} && {expr} <= {max})")
         return f"({' || '.join(rv)})"
 

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -16,7 +16,6 @@ import random
 import sys
 import tempfile
 import unittest
-from operator import methodcaller
 
 import pytest
 
@@ -94,14 +93,13 @@ def test_unique_ids():
     all_ids = localedata.locale_identifiers()
     assert len(all_ids) == len(set(all_ids))
     # Check locale IDs don't collide after lower-case normalization.
-    lower_case_ids = list(map(methodcaller('lower'), all_ids))
+    lower_case_ids = [id.lower() for id in all_ids]
     assert len(lower_case_ids) == len(set(lower_case_ids))
 
 
 def test_mixedcased_locale():
     for locale in localedata.locale_identifiers():
-        locale_id = ''.join([
-            methodcaller(random.choice(['lower', 'upper']))(c) for c in locale])
+        locale_id = ''.join(c.lower() if random.random() < 0.5 else c.upper() for c in locale)
         assert localedata.exists(locale_id)
 
 


### PR DESCRIPTION
There were some rather legacy or "tricksy" uses of `map()`, which are probably better written out in other ways.