### PR TITLE
Fix formatting for "Empty locale identifier" exception added in #1164

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -343,7 +343,7 @@ class Locale:
                 f"Empty locale identifier value: {identifier!r}\n\n"
                 f"If you didn't explicitly pass an empty value to a Babel function, "
                 f"this could be caused by there being no suitable locale environment "
-                f"variables for the API you tried to use.",
+                f"variables for the API you tried to use."
             )
             if isinstance(identifier, str):
                 raise ValueError(msg)  # `parse_locale` would raise a ValueError, so let's do that here

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -395,8 +395,9 @@ def test_language_alt_official_not_used():
 
 
 def test_locale_parse_empty():
-    with pytest.raises(ValueError, match="Empty"):
+    with pytest.raises(ValueError, match="Empty") as ei:
         Locale.parse("")
+    assert isinstance(ei.value.args[0], str)
     with pytest.raises(TypeError, match="Empty"):
         Locale.parse(None)
     with pytest.raises(TypeError, match="Empty"):


### PR DESCRIPTION
Refs #1183.

## Before

```
$ env LANG= LC_TIME= uvx --from=babel==2.17.0 --python=3.13 python ~/Desktop/reproducer.py
[...]
TypeError: ("Empty locale identifier value: None\n\nIf you didn't explicitly pass an empty value to a Babel function, this could be caused by there being no suitable locale environment variables for the API you tried to use.",)
```

## After

```
$ env LANG= LC_TIME= python ~/Desktop/reproducer.py
[...]
TypeError: Empty locale identifier value: None

If you didn't explicitly pass an empty value to a Babel function, this could be caused by there being no suitable locale environment variables for the API you tried to use.
```