### PR TITLE
Allow passthrough of xgettext's plural templates

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -613,7 +613,7 @@ class Catalog:
             num = 2
             if self.locale:
                 num = get_plural(self.locale)[0]
-            self._num_plurals = num
+            return num
         return self._num_plurals
 
     @property
@@ -632,7 +632,7 @@ class Catalog:
             expr = '(n != 1)'
             if self.locale:
                 expr = get_plural(self.locale)[1]
-            self._plural_expr = expr
+            return expr
         return self._plural_expr
 
     @property

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -1096,3 +1096,17 @@ def test_issue_1134(case: str, abort_invalid: bool):
         output = pofile.read_po(buf)
         assert len(output) == 1
         assert output["foo"].string in ((''), ('', ''))
+
+
+def test_issue_1154():
+    # Via `echo 'ngettext("Hello World!", "Hello Worlds!", 3);' | xgettext --output=- - --language=C`,
+    # minimized for reproducing the issue.
+    template = """
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+    """.strip()
+    cat = pofile.read_po(StringIO(template))
+    assert cat.num_plurals == "INTEGER"
+    assert cat.plural_expr == "EXPRESSION"
+    assert cat.plural_forms == "nplurals=INTEGER; plural=EXPRESSION;"


### PR DESCRIPTION
As #1154 reported, Babel would choke trying to parse a plural expression that is but a template.

After this, such templates can be parsed and manipulated, but may have strange interactions with other features.