### PR TITLE
Move pytest config to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,25 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/import_cldr.py" = ["E402"]
+
+[tool.pytest.ini_options]
+norecursedirs = [
+    "venv*",
+    ".*",
+    "_*",
+    "scripts",
+    "{args}"
+]
+doctest_optionflags = [
+    "ELLIPSIS",
+    "NORMALIZE_WHITESPACE",
+    "ALLOW_UNICODE",
+    "IGNORE_EXCEPTION_DETAIL"
+]
+markers = [
+    "all_locales: parameterize test with all locales"
+]
+filterwarnings = [
+    # The doctest for format_number would raise this, but we don't really want to see it.
+    "ignore:babel.numbers.format_decimal:DeprecationWarning"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,2 @@
-[tool:pytest]
-norecursedirs = venv* .* _* scripts {args}
-doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL
-markers =
-    all_locales: parameterize test with all locales
-filterwarnings =
-    # The doctest for format_number would raise this, but we don't really want to see it.
-    ignore:babel.numbers.format_decimal:DeprecationWarning
-
 [metadata]
 license_files = LICENSE


### PR DESCRIPTION
I think it's better to centralize the tool configs in one file rather than have it scattered across multiple files. What do you think?