### PR TITLE
Validate all plurals in python format checker

### DIFF
--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -54,9 +54,12 @@ def python_format(catalog: Catalog | None, message: Message) -> None:
     if not isinstance(msgstrs, (list, tuple)):
         msgstrs = (msgstrs,)
 
-    for msgid, msgstr in zip(msgids, msgstrs):
-        if msgstr:
-            _validate_format(msgid, msgstr)
+    if msgstrs[0]:
+        _validate_format(msgids[0], msgstrs[0])
+    if message.pluralizable:
+        for msgstr in msgstrs[1:]:
+            if msgstr:
+                _validate_format(msgids[1], msgstr)
 
 
 def _validate_format(format: str, alternative: str) -> None:

--- a/tests/messages/test_checkers.py
+++ b/tests/messages/test_checkers.py
@@ -337,6 +337,8 @@ class TestPythonFormat:
         (('foo %s', 'bar'), ('foo', 'bar')),
         (('foo', 'bar %s'), ('foo', 'bar')),
         (('foo %s', 'bar'), ('foo')),
+        (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz')),
+        (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz %d', 'qux')),
     ])
     def test_python_format_invalid(self, msgid, msgstr):
         msg = Message(msgid, msgstr)
@@ -346,9 +348,13 @@ class TestPythonFormat:
     @pytest.mark.parametrize(('msgid', 'msgstr'), [
         ('foo', 'foo'),
         ('foo', 'foo %s'),
+        ('foo %s', ''),
         (('foo %s', 'bar %d'), ('foo %s', 'bar %d')),
-        (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz')),
+        (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz %d')),
         (('foo', 'bar %s'), ('foo')),
+        (('foo', 'bar %s'), ('', '')),
+        (('foo', 'bar %s'), ('foo', '')),
+        (('foo %s', 'bar %d'), ('foo %s', '')),
     ])
     def test_python_format_valid(self, msgid, msgstr):
         msg = Message(msgid, msgstr)


### PR DESCRIPTION
Previously, the format checker would only validate the first 2 plurals. If a locale had more than two plurals, those would not be checked. This PR fixes that.