### PR TITLE
Validate `msgid_plural` against `msgstr[0]` for languages with `nplurals=1`

### DIFF
--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -57,6 +57,8 @@ def python_format(catalog: Catalog | None, message: Message) -> None:
     if msgstrs[0]:
         _validate_format(msgids[0], msgstrs[0])
     if message.pluralizable:
+        if msgstrs[0] and len(msgstrs) == 1:
+            _validate_format(msgids[1], msgstrs[0])
         for msgstr in msgstrs[1:]:
             if msgstr:
                 _validate_format(msgids[1], msgstr)

--- a/tests/messages/test_checkers.py
+++ b/tests/messages/test_checkers.py
@@ -339,6 +339,7 @@ class TestPythonFormat:
         (('foo %s', 'bar'), ('foo')),
         (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz')),
         (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz %d', 'qux')),
+        (('foo', 'bar %s'), ('foo')),
     ])
     def test_python_format_invalid(self, msgid, msgstr):
         msg = Message(msgid, msgstr)
@@ -351,7 +352,6 @@ class TestPythonFormat:
         ('foo %s', ''),
         (('foo %s', 'bar %d'), ('foo %s', 'bar %d')),
         (('foo %s', 'bar %d'), ('foo %s', 'bar %d', 'baz %d')),
-        (('foo', 'bar %s'), ('foo')),
         (('foo', 'bar %s'), ('', '')),
         (('foo', 'bar %s'), ('foo', '')),
         (('foo %s', 'bar %d'), ('foo %s', '')),


### PR DESCRIPTION
The python format checker currently only validates `msgid` against the translation for languages with only one plural form. `msgid_plural` is not checked. For example, this:

```po
msgid "foo"
msgid_plural "foo %s"
msgstr[0] "bar"
```

does not get flagged even though it should (missing `%s` in the translation).

Here's a real-world example:

```po
#, python-format
msgid ""
"There is currently <strong><a href=\"%(url)s\">one active API "
"key</a></strong> in the system."
msgid_plural ""
"There are currently <strong><a href=\"%(url)s\">%(count)s active API "
"keys</a></strong> in the system."
msgstr[0] "系统中当前有 <strong> <a href=\"%(url)s\"> %(count)s 个活动 API 密钥 </a> </strong>。"
```

This translation should get flagged if it was missing the `%(count)s` placeholder since it appears in `msgid_plural`. it's not the case because only `msgid` is checked currently.

(This translation actually produces warnings as is, because the singular does not contain `%(count)s`, so perhaps an even better solution would be to _only_ validate against the plural, but I'm not so sure about that)