### PR TITLE
Redesign load_po to use Lex/Yacc state transitions style, to ease 

### DIFF
--- a/babel/messages/block_utils.py
+++ b/babel/messages/block_utils.py
@@ -1,0 +1,57 @@
+"""
+babel.messages.block_utils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Utility functions for splitting PO file content into blocks.
+This module provides a function to split the content of a PO file into individual
+blocks representing separate message entries. Each block is separated by one or more
+blank lines and is returned as a tuple containing the starting line number and the block text.
+
+:copyright: (c) 2025 by the Babel Team.
+:license: BSD, see LICENSE for more details.
+"""
+
+
+def split_into_blocks(content: str):
+    """
+    Splits the given content into blocks separated by blank lines.
+
+    Each block is returned as a tuple (start_line, block_text), where:
+      - start_line: The line number in the original content where the block begins.
+      - block_text: The complete text of the block, with original line breaks preserved.
+
+    The function processes the content line by line:
+      1. It splits the content into individual lines.
+      2. It accumulates consecutive non-blank lines into a current block.
+      3. When a blank line is encountered (or at the end of the content), the current block
+         is finished and stored along with its starting line number.
+      4. The starting line number for the next block is updated.
+
+    This function is shared between the Catalog parser and the Messages parser.
+
+    :param content: The complete text content of a PO file.
+    :return: A list of tuples, each tuple containing (start_line, block_text) for a block.
+    """
+    lines = content.splitlines()  # Split the content into individual lines.
+    blocks = []  # List to store the resulting blocks.
+    current_block = []  # List to accumulate lines for the current block.
+    current_start_line = 1  # Line number where the current block starts.
+    line_number = 1  # Counter for the current line number.
+
+    for line in lines:
+        if line.strip() == "":  # Check if the line is blank.
+            if current_block:
+                # If the current block has content, join it into a single string and add to blocks.
+                blocks.append((current_start_line, "\n".join(current_block)))
+                current_block = []  # Reset the current block.
+            # Update the start line for the next block (line after the blank line).
+            current_start_line = line_number + 1
+        else:
+            # Add non-blank lines to the current block.
+            current_block.append(line)
+        line_number += 1
+
+    # If there is any remaining content in the current block, add it as the final block.
+    if current_block:
+        blocks.append((current_start_line, "\n".join(current_block)))
+    return blocks

--- a/babel/messages/catalog_parser.py
+++ b/babel/messages/catalog_parser.py
@@ -23,13 +23,14 @@ DEFAULT_CAT_STRINGS = {
     'Last-Translator': 'FULL NAME <EMAIL@ADDRESS>',
     'Language-Team': 'LANGUAGE <LL@li.org>',
     'Language': 'en',
-    'Language': 'en',
     'Plural-Forms': 'nplurals=1; plural=0;',
     'MIME-Version': '1.0',
     'Content-Type': 'text/plain; charset=utf-8',
     'Content-Transfer-Encoding': '8bit',
     'Generated-By': f'Babel {VERSION}\n',
+    'X-Generator': 'Poedit 3.5\n',
 }
+
 DEFAULT_CAT_STRING_LIST=list(DEFAULT_CAT_STRINGS.keys())
 HEADER_SEPARATOR = ':'
 

--- a/babel/messages/catalog_parser.py
+++ b/babel/messages/catalog_parser.py
@@ -6,7 +6,7 @@ Parsing of gettext PO file header blocks to construct a Babel Catalog instance.
 This module provides a function to parse only the header block (first block)
 of a pre-split PO file and extract metadata to initialize a Catalog.
 
-:copyright: (c) 2013-2024 by the Babel Team.
+:copyright: (c) 2025 by the Babel Team.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/babel/messages/catalog_parser.py
+++ b/babel/messages/catalog_parser.py
@@ -11,28 +11,8 @@ of a pre-split PO file and extract metadata to initialize a Catalog.
 """
 
 from babel.messages import Catalog
-from babel.messages.catalog import VERSION
 from babel.messages.msg_parser import process_block, parse_header_msgstr, printErrors
-from babel.messages.parse_utils import get_char_set
-
-DEFAULT_CAT_STRINGS = {
-    'Project-Id-Version': 'Foobar 1.0',
-    'Report-Msgid-Bugs-To': 'EMAIL@ADDRESS',
-    'POT-Creation-Date': '1990-04-01 15:30+0000',
-    'PO-Revision-Date': 'YEAR-MO-DA HO:MI+ZONE',
-    'Last-Translator': 'FULL NAME <EMAIL@ADDRESS>',
-    'Language-Team': 'LANGUAGE <LL@li.org>',
-    'Language': 'en',
-    'Plural-Forms': 'nplurals=1; plural=0;',
-    'MIME-Version': '1.0',
-    'Content-Type': 'text/plain; charset=utf-8',
-    'Content-Transfer-Encoding': '8bit',
-    'Generated-By': f'Babel {VERSION}\n',
-    'X-Generator': 'Poedit 3.5\n',
-}
-
-DEFAULT_CAT_STRING_LIST=list(DEFAULT_CAT_STRINGS.keys())
-HEADER_SEPARATOR = ':'
+from babel.messages.gvar import gv  # Import the global variables class (named gv)
 
 def parse_catalog(blocks: list,
                   default_catalog: Catalog,
@@ -54,14 +34,14 @@ def parse_catalog(blocks: list,
 
     # Use only the first block (the header block).
     first_block_start, first_block = blocks[0]
-    header_msg = process_block(first_block,
-                               first_block_start,
-                               is_catalog_header=True,
-                               valid_catalog_string_list=DEFAULT_CAT_STRING_LIST,
-                               header_separator = HEADER_SEPARATOR,
-                               )
+    header_msg = process_block(
+        first_block,
+        first_block_start,
+        is_catalog_header=True,
+        valid_catalog_string_list=gv.DEFAULT_CAT_STRING_LIST,
+        header_separator=gv.HEADER_SEPARATOR,
+    )
     if not header_msg:
-        # print errors if any
         printErrors()
         return default_catalog
 
@@ -80,8 +60,6 @@ def parse_catalog(blocks: list,
 
     # Create and configure a Catalog instance.
     catalog = default_catalog
-    # catalog._header_comment = '\n'.join(header_msg.user_comments)
     catalog._set_mime_headers(header_dict.items())
-    # Set the catalog header comment using the user_comments from the header message.
     catalog.fuzzy = fuzzy
     return catalog

--- a/babel/messages/catalog_parser.py
+++ b/babel/messages/catalog_parser.py
@@ -1,0 +1,59 @@
+"""
+babel.messages.catalog_parser
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Parsing of gettext PO file header blocks to construct a Babel Catalog instance.
+This module provides a function to parse only the header block (first block)
+of a pre-split PO file and extract metadata to initialize a Catalog.
+
+:copyright: (c) 2013-2024 by the Babel Team.
+:license: BSD, see LICENSE for more details.
+"""
+
+from babel.messages import Catalog
+from babel.messages.msg_parser import process_block, parse_header_msgstr
+from babel.messages.parse_utils import get_char_set, get_int_kwarg, get_str_kwargs, get_boolean_kwarg
+
+def parse_catalog(blocks: list,
+                  default_catalog: Catalog,
+                  ) -> Catalog:
+    """
+    Parse only the first block (header) of the given pre-split PO file blocks and return a Babel Catalog instance.
+
+    The header block is expected to have an empty msgid and a msgstr containing header metadata
+    (each quoted string below msgstr is concatenated). The header msgstr is then split into key-value pairs,
+    and the Catalog is constructed using those values (and default values where necessary).
+
+    :param blocks: A list of tuples (start_line, block_text) representing the pre-split PO file.
+    :param default_catalog: A default Catalog instance to be configured with header metadata.
+    :return: A Catalog instance populated with header metadata.
+    :raises ValueError: If no blocks are found.
+    """
+    if not blocks:
+        raise ValueError("No blocks found in file content.")
+
+    # Use only the first block (the header block).
+    first_block_start, first_block = blocks[0]
+    header_msg = process_block(first_block, first_block_start)
+
+    # The header message's string (msgstr) is parsed into key-value pairs.
+    header_text = header_msg.string
+    header_dict = parse_header_msgstr(header_text)
+
+    # Determine fuzzy flag (if ", fuzzy" appears anywhere in the header block).
+    fuzzy = ", fuzzy" in first_block
+
+    # Extract charset from the Content-Type header if available.
+    content_type = header_dict.get("Content-Type", "")
+    charset = "utf-8"
+    if "charset=" in content_type:
+        charset = content_type.split("charset=")[-1].strip()
+
+    # Create and configure a Catalog instance.
+    catalog = default_catalog
+    header_cm = [f'# {cm}' for cm in header_msg.user_comments]
+    catalog._header_comment = '\n'.join(header_cm)
+    catalog._set_mime_headers(header_dict.items())
+    # Set the catalog header comment using the user_comments from the header message.
+    catalog.fuzzy = fuzzy
+    return catalog

--- a/babel/messages/gvar.py
+++ b/babel/messages/gvar.py
@@ -1,0 +1,80 @@
+# gvar.py
+import re
+import locale
+from babel.messages.catalog import VERSION
+
+class gv:
+    # Define the set of recognized flags for message formatting.
+    RECOGNIZED_FLAGS = {
+        'fuzzy', 'c-format', 'no-c-format', 'objc-format', 'no-objc-format',
+        'java-format', 'no-java-format', 'no-java-printf-format', 'python-format', 'no-python-format',
+        'no-python-brace-format', 'php-format', 'no-php-format', 'gcc-internal-format', 'no-gcc-internal-format',
+        'qt-format', 'qt-plural-format', 'no-qt-format', 'boost-format', 'no-boost-format',
+        'c++-format', 'no-c++-format', 'csharp-format', 'no-csharp-format', 'elisp-format',
+        'no-elisp-format', 'gfc-internal-format', 'no-gfc-internal-format', 'javascript-format', 'no-javascript-format',
+        'lua-format', 'no-lua-format', 'objc-format', 'no-objc-format', 'java-format',
+        'perl-format', 'no-perl-format', 'perl-brace-format', 'no-perl-brace-format', 'ruby-format',
+        'no-ruby-format', 'rust-format', 'no-rust-format', 'scheme-format', 'no-scheme-format',
+        'sh-format', 'no-sh-format', 'smalltalk-format', 'no-smalltalk-format', 'tcl-format',
+        'no-tcl-format', 'ycp-format', 'no-ycp-format', 'awk-format', 'no-awk-format',
+        'lisp-format', 'no-lisp-format', 'librep-format', 'no-librep-format', 'object-pascal-format',
+        'no-object-pascal-format', 'elisp-format', 'no-elisp-format', 'javascript-format', 'no-javascript-format',
+        'lua-format', 'no-lua-format', 'gfc-internal-format', 'no-gfc-internal-format', 'smalltalk-format',
+        'no-smalltalk-format', 'tcl-format', 'no-tcl-format', 'ycp-format', 'no-ycp-format',
+        'awk-format', 'no-awk-format', 'lisp-format', 'no-lisp-format', 'smalltalk-format',
+        'no-smalltalk-format', 'kde-format', 'no-kde-format', 'qt-format', 'no-qt-format'
+    }
+
+    # Parser configuration and state variables.
+    BLOCKS = None  # Pre-split list of blocks from the PO file.
+    IS_DEBUG = False  # Debug flag.
+    IS_HOOK_EXEPT = True  # Hook exception flag.
+    IS_MULTI_PROCESSING = False  # Flag to enable multiprocessing.
+    LOGGER = None  # Global logger instance.
+    CATALOG = None  # Babel Catalog instance.
+    BATCH_DIVISION_REDUCTION = 3  # Reduction factor for batch size.
+    IS_ABORT_ON_INVALID = True  # Flag to abort on invalid entries.
+    all_messages = []  # List to store all parsed messages.
+    all_errors = []  # List to store errors encountered during parsing.
+    ABORT_EVENT = None  # Global event to signal an abort in multiprocessing.
+
+    # Variables used for catalog header processing.
+    IS_CATALOG_HEADER = False
+    VALID_CATALOG_STRING_LIST = None
+
+    # Additional error tracking.
+    ERRORS = []
+    IS_IGNORE_OBSOLETE = True
+
+    # -------------------------------------------------------------------------
+    # Precompiled regex patterns and constants for message fields
+    # -------------------------------------------------------------------------
+    escapped_new_line_pattern = re.compile(r'\\([\\trn"])')
+    COMMENT_PATTERN = re.compile(r'^#(?:[ :,\.\~\|]*?.*)?$')
+    MSGSTR_PLURAL_PATTERN = re.compile(r'msgstr\[(\d+)\]\s+"(.*)"')
+
+    LEN_MSGCTXT = len("msgctxt")
+    LEN_MSGID = len("msgid")
+    LEN_MSGID_PLURAL = len("msgid_plural")
+    LEN_MSGSTR = len("msgstr")
+
+    # Global variables for catalog_parser
+    DEFAULT_CAT_STRINGS = {
+        'Project-Id-Version': 'Foobar 1.0',
+        'Report-Msgid-Bugs-To': 'EMAIL@ADDRESS',
+        'POT-Creation-Date': '1990-04-01 15:30+0000',
+        'PO-Revision-Date': 'YEAR-MO-DA HO:MI+ZONE',
+        'Last-Translator': 'FULL NAME <EMAIL@ADDRESS>',
+        'Language-Team': 'LANGUAGE <LL@li.org>',
+        'Language': 'en',
+        'Plural-Forms': 'nplurals=1; plural=0;',
+        'MIME-Version': '1.0',
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Transfer-Encoding': '8bit',
+        'Generated-By': f'Babel {VERSION}\n',
+        'X-Generator': 'Poedit 3.5\n',
+    }
+    DEFAULT_CAT_STRING_LIST = list(DEFAULT_CAT_STRINGS.keys())
+    HEADER_SEPARATOR = ':'
+
+    machine_language, machine_encoding = locale.getdefaultlocale()

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -6,7 +6,7 @@ This module implements a finite state machine (FSM) to process PO file blocks li
 extracting and unescaping message fields and handling comments, context, and plural forms.
 It also supports multiprocessing to parallelize the parsing process.
 
-:copyright: (c) 2013-2024 by the Babel Team.
+:copyright: (c) 2025 by the Babel Team.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -16,7 +16,7 @@ import multiprocessing
 import logging
 from babel.messages import Message  # Babel’s Message class
 from enum import IntFlag, auto
-import locale
+import inspect
 
 # Define the set of recognized flags for message formatting.
 RECOGNIZED_FLAGS = {
@@ -258,7 +258,11 @@ def DEBUG_LOG(msg):
     :param msg: The message to log.
     """
     if IS_DEBUG:
-        LOGGER.debug(msg)
+        caller_frame = inspect.currentframe().f_back
+        # Extract the caller's function name
+        caller_name = caller_frame.f_code.co_name
+
+        LOGGER.debug(f'{caller_name}() {msg}')
 
 
 def worker_init(abort_event):
@@ -367,7 +371,7 @@ def _handle_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) 
     elif txt_line.startswith("#"):
         _handle_user_comment(txt_line, abs_lineno, msg, dyn_state)
     else:
-        raise ValueError(f"Unrecognized comment format at line {abs_lineno}: {txt_line!r}")
+        raise ValueError(f"Unrecognized comment format at line number {abs_lineno}: {txt_line!r}")
 
 
 def _handle_locations(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -379,7 +383,7 @@ def _handle_locations(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_locations: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     occ_line = txt_line[2:].strip()
     for token in occ_line.split():
         if ':' in token:
@@ -391,7 +395,7 @@ def _handle_locations(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict
             msg['locations'].append((parts[0], lineno_val))
         else:
             msg['locations'].append((token, None))
-    DEBUG_LOG(f"_handle_locations: EXIT at line {abs_lineno} with locations = {msg['locations']}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with locations = {msg['locations']}")
 
 
 def _handle_flags(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -404,13 +408,13 @@ def _handle_flags(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) ->
     :param dyn_state: The dynamic state dictionary.
     :raises ValueError: If an unrecognized flag is encountered.
     """
-    DEBUG_LOG(f"_handle_flags: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     flags = [f.strip() for f in txt_line[2:].strip().split(",") if f.strip()]
     for flag in flags:
         if flag not in RECOGNIZED_FLAGS:
-            raise ValueError(f"Unrecognized flag {flag!r} at line {abs_lineno}")
+            raise ValueError(f"Unrecognized flag {flag!r} at line number {abs_lineno}")
     msg['flags'].extend(flags)
-    DEBUG_LOG(f"_handle_flags: EXIT at line {abs_lineno} with flags = {msg['flags']}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with flags = {msg['flags']}")
 
 
 def _handle_auto_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -422,10 +426,10 @@ def _handle_auto_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: d
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_auto_comment: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     comment_text = txt_line[2:].strip()
     msg['auto_comments'].append(comment_text)
-    DEBUG_LOG(f"_handle_auto_comment: EXIT at line {abs_lineno} with auto_comments = {msg['auto_comments']}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with auto_comments = {msg['auto_comments']}")
 
 
 def _handle_user_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -437,10 +441,10 @@ def _handle_user_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: d
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_user_comment: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     comment_text = txt_line[1:].strip()
     msg['user_comments'].append(comment_text)
-    DEBUG_LOG(f"_handle_user_comment: EXIT at line {abs_lineno} with user_comments = {msg['user_comments']}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with user_comments = {msg['user_comments']}")
 
 
 # -------------------------------------------------------------------------
@@ -455,11 +459,11 @@ def _handle_msgctxt(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) 
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_msgctxt: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     value = extract_quoted_value(txt_line, LEN_MSGCTXT)
     msg['msgctxt'] = value
     dyn_state["current"] = State.MCTX
-    DEBUG_LOG(f"_handle_msgctxt: EXIT at line {abs_lineno} with msg['msgctxt'] = {value}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgctxt'] = {value}")
 
 
 def _handle_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -471,13 +475,13 @@ def _handle_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) ->
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_msgid: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"_handle_msgid: ENTER at line number {abs_lineno}: {txt_line!r}")
     if msg['msgid'] is None:
         msg['lineno'] = abs_lineno
     value = extract_quoted_value(txt_line, LEN_MSGID)
     msg['msgid'] = value
     dyn_state["current"] = State.MSGID
-    DEBUG_LOG(f"_handle_msgid: EXIT at line {abs_lineno} with msg['msgid'] = {value}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgid'] = {value}")
 
 
 def _handle_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -489,11 +493,11 @@ def _handle_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: d
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_msgid_plural: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     value = extract_quoted_value(txt_line, LEN_MSGID_PLURAL)
     msg['msgid_plural'] = value
     dyn_state["current"] = State.MSGID_PLURAL
-    DEBUG_LOG(f"_handle_msgid_plural: EXIT at line {abs_lineno} with msg['msgid_plural'] = {value}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgid_plural'] = {value}")
 
 
 def _handle_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -505,11 +509,11 @@ def _handle_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_msgstr: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     value = extract_quoted_value(txt_line, LEN_MSGSTR)
     msg['msgstr'] = value
     dyn_state["current"] = State.MSGSTR
-    DEBUG_LOG(f"_handle_msgstr: EXIT at line {abs_lineno} with msg['msgstr'] = {value}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgstr'] = {value}")
 
 
 def _handle_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -521,7 +525,7 @@ def _handle_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: 
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_msgstr_plural: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     m = MSGSTR_PLURAL_PATTERN.match(txt_line)
     if m:
         index = int(m.group(1))
@@ -529,9 +533,9 @@ def _handle_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: 
         msg.setdefault('msgstr_plural', {})[index] = value
         dyn_state["current"] = State.MSGSTR_INDEX
         dyn_state["plural_index"] = index
-        DEBUG_LOG(f"_handle_msgstr_plural: EXIT at line {abs_lineno} with msg['msgstr_plural'][{index}] = {value}")
+        DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgstr_plural'][{index}] = {value}")
     else:
-        DEBUG_LOG(f"_handle_msgstr_plural: EXIT at line {abs_lineno} with no match")
+        DEBUG_LOG(f"EXIT at line number {abs_lineno} with no match")
 
 
 # -------------------------------------------------------------------------
@@ -546,7 +550,7 @@ def _handle_obsolete_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state:
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_obsolete_msgid: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()
     if msg.get('msgid') is None:
         msg['lineno'] = abs_lineno
@@ -554,7 +558,7 @@ def _handle_obsolete_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state:
     msg['msgid'] = value
     msg["obsolete"] = True
     dyn_state["current"] = State.OBSOLETE_MSGID
-    DEBUG_LOG(f"_handle_obsolete_msgid: EXIT at line {abs_lineno} with msg['msgid'] = {value}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgid'] = {value}")
 
 
 def _handle_obsolete_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
@@ -566,13 +570,13 @@ def _handle_obsolete_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state
     :param msg: The message dictionary.
     :param dyn_state: The dynamic state dictionary.
     """
-    DEBUG_LOG(f"_handle_obsolete_msgstr: ENTER at line {abs_lineno}: {txt_line}")
+    DEBUG_LOG(f"_handle_obsolete_msgstr: ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()
     value = extract_quoted_value(stripped, LEN_MSGSTR)
     msg['msgstr'] = value
     msg["obsolete"] = True
     dyn_state["current"] = State.OBSOLETE_MSGSTR
-    DEBUG_LOG(f"_handle_obsolete_msgstr: EXIT at line {abs_lineno} with msg['msgstr'] = {value}")
+    DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgstr'] = {value}")
 
 
 # -------------------------------------------------------------------------
@@ -594,10 +598,10 @@ def _handle_continuation(txt_line: str, absolute_line: int, msg: dict, dyn_state
     allowed_states = {State.MCTX, State.MSGID, State.MSGID_PLURAL, State.MSGSTR, State.MSGSTR_INDEX,
                       State.OBSOLETE_MSGID, State.OBSOLETE_MSGSTR}
     if current_state not in allowed_states:
-        raise ValueError(f"Line continuation at line {absolute_line} not allowed in state {current_state}")
+        raise ValueError(f"Line continuation at line number {absolute_line} not allowed in state {current_state}")
     if not (txt_line.startswith('"') and txt_line.endswith('"')):
         raise ValueError(
-            f"Invalid continuation line for state {current_state} at line {absolute_line}: {txt_line!r}. Missing quotes.")
+            f"Invalid continuation line for state {current_state} at line number {absolute_line}: {txt_line!r}. Missing quotes.")
     value = unescape(txt_line[1:-1])
     if current_state == State.MCTX:
         msg['msgctxt'] = (msg.get('msgctxt') or "") + value
@@ -615,8 +619,8 @@ def _handle_continuation(txt_line: str, absolute_line: int, msg: dict, dyn_state
             else:
                 msg.setdefault('msgstr_plural', {})[plural_index] = value
         else:
-            raise ValueError(f"Missing plural index in state {current_state} at line {absolute_line}")
-    DEBUG_LOG(f"_handle_continuation: EXIT at line {absolute_line} with added value = {value}")
+            raise ValueError(f"Missing plural index in state {current_state} at line number {absolute_line}")
+    DEBUG_LOG(f"EXIT at line number {absolute_line} with added value = {value}")
 
 
 # -------------------------------------------------------------------------
@@ -705,19 +709,19 @@ def process_block(block: str, base_line: int) -> Message:
             continue
         token = Token.get(s)
         if token == Token.ERROR:
-            raise ValueError(f"Grammar error at line {abs_lineno}: {s!r}")
+            raise ValueError(f"File structure error at line number {abs_lineno}: {s!r}")
         if token == Token.COMMENT:
             _handle_comment(s, abs_lineno, msg, dyn_state)
             continue
         sub_table = nt_table.get(cur_state)
         if sub_table is None or token not in sub_table:
-            raise ValueError(f"Unexpected token {token.name} at line {abs_lineno} in state {cur_state.name}: {s!r}")
+            raise ValueError(f"Unexpected token {token.name} at line number {abs_lineno} in state {cur_state.name}: {s!r}")
         handler, new_state = sub_table[token]
         handler(s, abs_lineno, msg, dyn_state)
         cur_state = new_state
 
     if cur_state not in (State.MSGSTR, State.MSGSTR_INDEX, State.OBSOLETE_MSGID, State.OBSOLETE_MSGSTR):
-        raise ValueError(f"Incomplete entry starting at line {base_line}: ended in state {cur_state.name}")
+        raise ValueError(f"Incomplete entry starting at line number {base_line}: ended in state {cur_state.name}")
 
     try:
         # If this is a plural message, validate that the plural indexes are sequential.
@@ -726,7 +730,7 @@ def process_block(block: str, base_line: int) -> Message:
             plural_indexes = sorted(msg['msgstr_plural'].keys())
             if plural_indexes != list(range(expected_n)):
                 raise ValueError(
-                    f"Invalid plural indexes at line {msg['lineno']}: expected {list(range(expected_n))}, got {plural_indexes} for {msg['msgstr_plural']}")
+                    f"Invalid plural indexes at line number {msg['lineno']}: expected {list(range(expected_n))}, got {plural_indexes} for {msg['msgstr_plural']}")
             translations = tuple(msg['msgstr_plural'][i] for i in sorted(msg['msgstr_plural']))
             mesg = Message(
                 [msg['msgid'], msg['msgid_plural']],

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -778,10 +778,6 @@ def process_batch(batch, process_block_func, is_debug) -> list:
     global IS_DEBUG
     IS_DEBUG = is_debug
     results = [process_block_func(block, start_line) for start_line, block in batch]
-
-    if IS_MULTI_PROCESSING and ABORT_EVENT.is_set():
-        results = [m for m in results if m is not None]
-
     if IS_DEBUG:
         for handler in LOGGER.handlers:
             handler.flush()
@@ -878,5 +874,6 @@ def parse() -> tuple:
                     raise e
                 else:
                     all_errors.append(e)
+    all_messages = [m for m in all_messages if m is not None]
     all_messages.sort(key=lambda m: m.lineno if m.lineno is not None else 0)
     return all_messages, all_errors

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -431,9 +431,9 @@ def _handle_flags(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) ->
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     flags = [f.strip() for f in txt_line[2:].strip().split(",") if f.strip()]
-    for flag in flags:
-        if flag not in RECOGNIZED_FLAGS:
-            raise ValueError(f"Unrecognized flag {flag!r} at line number {abs_lineno}")
+    # for flag in flags:
+    #     if flag not in RECOGNIZED_FLAGS:
+    #         raise ValueError(f"Unrecognized flag {flag!r} at line number {abs_lineno}")
     msg['flags'].extend(flags)
     DEBUG_LOG(f"EXIT at line number {abs_lineno} with flags = {msg['flags']}")
 
@@ -706,7 +706,11 @@ def _handle_continuation(txt_line: str, absolute_line: int, msg: dict, dyn_state
                       State.OBSOLETE_MSGCTXT, State.OBSOLETE_MSGID_PLURAL, State.OBSOLETE_MSGSTR_PLURAL}
     if current_state not in allowed_states:
         raise ValueError(f"Line continuation at line number {absolute_line} not allowed in state {current_state.name}")
-    if not (txt_line.startswith('"') and txt_line.endswith('"')):
+    
+    is_obsolete = current_state.name.startswith('OBSOLETE')
+    if is_obsolete:
+        txt_line = txt_line[2:].strip()
+    if not (txt_line.startswith('"') and txt_line.endswith('"')):        
         raise ValueError(
             f"Invalid continuation line for state {current_state.name} at line number {absolute_line}: {txt_line!r}. Missing quotes.")
     value = unescape(txt_line[1:-1])
@@ -1026,7 +1030,7 @@ def parse() -> tuple:
         num_batches = (num_batches // BATCH_DIVISION_REDUCTION if num_batches >= 5 else num_batches)
         print(f"Using {num_batches} batch(es) (cpu_count: {num_cores})")
         batches = split_into_batches(blocks, num_batches)
-        print(f'Number of batches: {len(batches)}, batch_size: {len(batches[0])} message records')
+        print(f'number of batches: {len(batches)}, batch_size: {len(batches[0])}')
         pool = multiprocessing.Pool(processes=num_batches,
                                     initializer=worker_init,
                                     initargs=(ABORT_EVENT,))

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -760,6 +760,7 @@ def process_block(block: str, base_line: int) -> Message:
             raise e
         else:
             all_errors.append(e)
+            return None
 
 
 # -------------------------------------------------------------------------

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -1,0 +1,881 @@
+"""
+babel.messages.msg_parser
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Parsing of gettext PO (Portable Object) files to produce Babel Message objects.
+This module implements a finite state machine (FSM) to process PO file blocks line by line,
+extracting and unescaping message fields and handling comments, context, and plural forms.
+It also supports multiprocessing to parallelize the parsing process.
+
+:copyright: (c) 2013-2024 by the Babel Team.
+:license: BSD, see LICENSE for more details.
+"""
+
+import sys
+import re
+import multiprocessing
+import logging
+from babel.messages import Message  # Babel’s Message class
+from enum import IntFlag, auto
+import locale
+
+# Define the set of recognized flags for message formatting.
+RECOGNIZED_FLAGS = {
+    'fuzzy', 'c-format', 'no-c-format', 'objc-format', 'no-objc-format',
+    'java-format', 'no-java-format', 'no-java-printf-format', 'python-format', 'no-python-format',
+    'no-python-brace-format', 'php-format', 'no-php-format', 'gcc-internal-format', 'no-gcc-internal-format',
+    'qt-format', 'qt-plural-format', 'no-qt-format', 'boost-format', 'no-boost-format',
+    'c++-format', 'no-c++-format', 'csharp-format', 'no-csharp-format', 'elisp-format',
+    'no-elisp-format', 'gfc-internal-format', 'no-gfc-internal-format', 'javascript-format', 'no-javascript-format',
+    'lua-format', 'no-lua-format', 'objc-format', 'no-objc-format', 'java-format',
+    'perl-format', 'no-perl-format', 'perl-brace-format', 'no-perl-brace-format', 'ruby-format',
+    'no-ruby-format', 'rust-format', 'no-rust-format', 'scheme-format', 'no-scheme-format',
+    'sh-format', 'no-sh-format', 'smalltalk-format', 'no-smalltalk-format', 'tcl-format',
+    'no-tcl-format', 'ycp-format', 'no-ycp-format', 'awk-format', 'no-awk-format',
+    'lisp-format', 'no-lisp-format', 'librep-format', 'no-librep-format', 'object-pascal-format',
+    'no-object-pascal-format', 'elisp-format', 'no-elisp-format', 'javascript-format', 'no-javascript-format',
+    'lua-format', 'no-lua-format', 'gfc-internal-format', 'no-gfc-internal-format', 'smalltalk-format',
+    'no-smalltalk-format', 'tcl-format', 'no-tcl-format', 'ycp-format', 'no-ycp-format',
+    'awk-format', 'no-awk-format', 'lisp-format', 'no-lisp-format', 'smalltalk-format',
+    'no-smalltalk-format', 'kde-format', 'no-kde-format', 'qt-format', 'no-qt-format'
+}
+
+
+# -------------------------------------------------------------------------
+# Token Enumeration
+# -------------------------------------------------------------------------
+class Token(IntFlag):
+    """
+    Enumeration representing the various token types in a PO file.
+    Tokens indicate message fields, comments, and special markers.
+    """
+    MSGCTXT = auto()
+    MSGID = auto()
+    MSGID_PLURAL = auto()
+    MSGSTR = auto()
+    MSGSTR_INDEX = auto()
+    COMMENT_LOCATION = auto()
+    COMMENT_FLAGS = auto()
+    COMMENT_AUTO_GEN = auto()
+    # Any comment is a combination of the three comment types.
+    COMMENT = COMMENT_LOCATION | COMMENT_FLAGS | COMMENT_AUTO_GEN
+    CONTINUATION = auto()
+    ERROR = auto()  # Token for grammar errors.
+    # Tokens for obsolete messages.
+    OBSOLETE_MSGID = auto()
+    OBSOLETE_MSGSTR = auto()
+
+    @classmethod
+    def get(cls, txt_line: str) -> "Token":
+        """
+        Determine the token type based on the given line.
+
+        Optimized by checking the first character of the line.
+
+        :param txt_line: The text line from the PO file.
+        :return: A Token enum indicating the type of token.
+        """
+        if not txt_line:
+            return cls.ERROR
+        first = txt_line[0]
+        if first == '#':
+            if txt_line.startswith("#~"):
+                # Process obsolete message tokens.
+                stripped = txt_line[2:].lstrip()
+                if stripped.startswith("msgctxt"):
+                    return cls.MSGCTXT
+                elif stripped.startswith("msgid_plural"):
+                    return cls.MSGID_PLURAL
+                elif stripped.startswith("msgid"):
+                    return cls.OBSOLETE_MSGID
+                elif stripped.startswith("msgstr["):
+                    return cls.MSGSTR_INDEX
+                elif stripped.startswith("msgstr"):
+                    return cls.OBSOLETE_MSGSTR
+                elif stripped and stripped[0] == '"':
+                    return cls.CONTINUATION
+                else:
+                    return cls.ERROR
+            else:
+                return cls.COMMENT
+        elif first == 'm':
+            if txt_line.startswith("msgctxt"):
+                return cls.MSGCTXT
+            elif txt_line.startswith("msgid_plural"):
+                return cls.MSGID_PLURAL
+            elif txt_line.startswith("msgid"):
+                return cls.MSGID
+            elif txt_line.startswith("msgstr["):
+                return cls.MSGSTR_INDEX
+            elif txt_line.startswith("msgstr"):
+                return cls.MSGSTR
+        elif first == '"':
+            return cls.CONTINUATION
+        return cls.ERROR
+
+
+# -------------------------------------------------------------------------
+# State Enumeration
+# -------------------------------------------------------------------------
+class State(IntFlag):
+    """
+    Enumeration representing the parser state for processing PO file blocks.
+    Each state corresponds to a particular message component being processed.
+    """
+    INITIAL = auto()
+    HEADER = auto()
+    MCTX = auto()
+    MSGID = auto()
+    MSGID_PLURAL = auto()
+    MSGSTR = auto()
+    MSGSTR_INDEX = auto()
+    # States for obsolete messages.
+    OBSOLETE_MSGID = auto()
+    OBSOLETE_MSGSTR = auto()
+
+    @classmethod
+    def get(cls, txt_line: str) -> "State":
+        """
+        Determine the initial parser state based on the beginning of a line.
+
+        :param txt_line: A line from the PO file.
+        :return: A State enum corresponding to the line's content.
+        """
+        if txt_line.startswith("msgctxt"):
+            return cls.MCTX
+        elif txt_line.startswith("msgid_plural"):
+            return cls.MSGID_PLURAL
+        elif txt_line.startswith("msgid"):
+            return cls.MSGID
+        elif txt_line.startswith("msgstr["):
+            return cls.MSGSTR_INDEX
+        elif txt_line.startswith("msgstr"):
+            return cls.MSGSTR
+        elif txt_line.startswith("#"):
+            return cls.HEADER
+        else:
+            return cls.INITIAL
+
+
+# -------------------------------------------------------------------------
+# Global Parser Configuration Variables
+# -------------------------------------------------------------------------
+BLOCKS = None  # Pre-split list of blocks from the PO file.
+IS_DEBUG = False  # Debug flag.
+IS_HOOK_EXEPT = True  # Hook exception flag.
+IS_MULTI_PROCESSING = False  # Flag to enable multiprocessing.
+LOGGER = None  # Global logger instance.
+CATALOG = None  # Global Babel Catalog instance.
+BATCH_DIVISION_REDUCTION = 3  # Reduction factor for batch size.
+
+IS_ABORT_ON_INVALID = True  # Flag to abort on invalid entries.
+
+all_messages = []  # List to store all parsed messages.
+all_errors = []  # List to store errors encountered during parsing.
+
+# Global event to signal an abort in multiprocessing.
+ABORT_EVENT = None
+
+# Precompiled regex patterns.
+escapped_new_line_pattern = re.compile(r'\\([\\trn"])')
+COMMENT_PATTERN = re.compile(r'^#(?:[ :,\.\~\|]*?.*)?$')
+MSGSTR_PLURAL_PATTERN = re.compile(r'msgstr\[(\d+)\]\s+"(.*)"')
+
+# Constants for prefix lengths in message fields.
+LEN_MSGCTXT = len("msgctxt")
+LEN_MSGID = len("msgid")
+LEN_MSGID_PLURAL = len("msgid_plural")
+LEN_MSGSTR = len("msgstr")
+
+
+# -------------------------------------------------------------------------
+# Helper Functions
+# -------------------------------------------------------------------------
+def extract_quoted_value(txt_line: str, prefix_len: int) -> str:
+    """
+    Extract and unescape a quoted value from a line by removing the prefix and quotes.
+
+    :param txt_line: The input text line containing a quoted value.
+    :param prefix_len: Length of the prefix to strip from the line.
+    :return: The unescaped string inside the quotes.
+    """
+    value = txt_line[prefix_len:].strip()
+    if value and value[0] == '"' and value[-1] == '"':
+        return unescape(value[1:-1])
+    return ''
+
+
+def _replace_escapes(match):
+    """
+    Helper function to replace escape sequences with their actual characters.
+
+    :param match: A regex match object.
+    :return: The replaced character based on the escape sequence.
+    """
+    m = match.group(1)
+    return {'n': '\n', 't': '\t', 'r': '\r'}.get(m, m)
+
+
+def setup_logger(name="POFileParser", level=None):
+    """
+    Set up the global LOGGER with the specified name and logging level.
+
+    :param name: The name for the logger.
+    :param level: The logging level (DEBUG, INFO, etc.). Defaults based on IS_DEBUG.
+    :return: The configured logger instance.
+    """
+    global LOGGER, IS_DEBUG
+    if level is None:
+        level = logging.DEBUG if IS_DEBUG else logging.INFO
+    LOGGER = logging.getLogger(name)
+    LOGGER.setLevel(level)
+    for handler in LOGGER.handlers[:]:
+        LOGGER.removeHandler(handler)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s [%(processName)s] %(levelname)s: %(message)s")
+    handler.setFormatter(formatter)
+    LOGGER.addHandler(handler)
+
+    if not IS_DEBUG:
+        LOGGER.disabled = True
+    return LOGGER
+
+
+def custom_excepthook(exc_type, exc_value, exc_traceback):
+    """
+    Custom exception hook to print errors.
+
+    :param exc_type: Exception type.
+    :param exc_value: Exception value.
+    :param exc_traceback: Exception traceback.
+    """
+    print(f"Error: {exc_value}")
+
+
+def DEBUG_LOG(msg):
+    """
+    Log a debug message if debugging is enabled.
+
+    :param msg: The message to log.
+    """
+    if IS_DEBUG:
+        LOGGER.debug(msg)
+
+
+def worker_init(abort_event):
+    """
+    Initializer function for worker processes in multiprocessing.
+
+    Sets up the logger and abort event.
+
+    :param abort_event: The multiprocessing event to signal abort.
+    """
+    global LOGGER, ABORT_EVENT
+    ABORT_EVENT = abort_event
+    LOGGER = setup_logger(name="POFileParser", level=logging.DEBUG)
+
+
+def init_parser(blocks,
+                catalog=None,
+                is_debug=False,
+                batch_size_division=2,
+                is_multi_processing=True,
+                is_hook_except=True,
+                ignore_obsolete=True,
+                abort_on_invalid=True):
+    """
+    Initialize the global parser configuration.
+
+    This function sets global variables used during parsing.
+
+    :param blocks: The pre-split list of PO file blocks.
+    :param catalog: An optional Babel Catalog instance.
+    :param is_debug: Enable debug mode if True.
+    :param batch_size_division: Factor to reduce batch size in multiprocessing.
+    :param is_multi_processing: Enable multiprocessing if True.
+    :param is_hook_except: Enable custom exception hook if True.
+    :param ignore_obsolete: Whether to ignore obsolete messages.
+    :param abort_on_invalid: Whether to abort on invalid entries.
+    """
+    global BLOCKS, IS_DEBUG, IS_MULTI_PROCESSING, IS_HOOK_EXEPT, BATCH_DIVISION_REDUCTION
+    global CATALOG, IS_IGNORE_OBSOLETE, IS_ABORT_ON_INVALID, ERRORS
+
+    BATCH_DIVISION_REDUCTION = batch_size_division
+    BLOCKS = blocks
+    IS_DEBUG = is_debug
+    IS_MULTI_PROCESSING = is_multi_processing
+    IS_HOOK_EXEPT = is_hook_except
+    CATALOG = catalog
+    IS_IGNORE_OBSOLETE = ignore_obsolete
+    IS_ABORT_ON_INVALID = abort_on_invalid
+    ERRORS = []
+    setup_logger(level=logging.DEBUG if IS_DEBUG else logging.INFO)
+
+    if IS_HOOK_EXEPT:
+        sys.excepthook = custom_excepthook
+
+
+def unescape(string: str) -> str:
+    r"""
+    Reverse escape the given string by replacing escape sequences with their actual characters.
+
+    :param string: The string with escape sequences.
+    :return: The unescaped string.
+    """
+    if '\\' not in string:
+        return string
+    return escapped_new_line_pattern.sub(_replace_escapes, string)
+
+
+def parse_header_msgstr(header: str) -> dict:
+    """
+    Parse a header msgstr (multi-line) into a dictionary of key-value pairs.
+
+    Each line in the header is expected to have a "Key: Value" format.
+
+    :param header: The header string from the PO file.
+    :return: A dictionary with header metadata.
+    """
+    result = {}
+    for txt_line in header.split("\n"):
+        txt_line = txt_line.strip()
+        if txt_line and ":" in txt_line:
+            key, value = txt_line.split(":", 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+# -------------------------------------------------------------------------
+# Comment Handlers
+# -------------------------------------------------------------------------
+def _handle_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Process a comment line and update the message dictionary accordingly.
+
+    Delegates to specific comment handlers based on the comment type.
+
+    :param txt_line: The comment line.
+    :param abs_lineno: Absolute line number in the PO file.
+    :param msg: The current message dictionary being built.
+    :param dyn_state: Dynamic state dictionary tracking current processing state.
+    """
+    if txt_line.startswith("#:"):
+        _handle_locations(txt_line, abs_lineno, msg, dyn_state)
+    elif txt_line.startswith("#,"):
+        _handle_flags(txt_line, abs_lineno, msg, dyn_state)
+    elif txt_line.startswith("#."):
+        _handle_auto_comment(txt_line, abs_lineno, msg, dyn_state)
+    elif txt_line.startswith("#"):
+        _handle_user_comment(txt_line, abs_lineno, msg, dyn_state)
+    else:
+        raise ValueError(f"Unrecognized comment format at line {abs_lineno}: {txt_line!r}")
+
+
+def _handle_locations(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle location comments (starting with "#:") and update message locations.
+
+    :param txt_line: The location comment line.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_locations: ENTER at line {abs_lineno}: {txt_line}")
+    occ_line = txt_line[2:].strip()
+    for token in occ_line.split():
+        if ':' in token:
+            parts = token.rsplit(":", 1)
+            try:
+                lineno_val = int(parts[1])
+            except ValueError:
+                lineno_val = None
+            msg['locations'].append((parts[0], lineno_val))
+        else:
+            msg['locations'].append((token, None))
+    DEBUG_LOG(f"_handle_locations: EXIT at line {abs_lineno} with locations = {msg['locations']}")
+
+
+def _handle_flags(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Process flag comments (starting with "#,") and validate them against recognized flags.
+
+    :param txt_line: The flag comment line.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    :raises ValueError: If an unrecognized flag is encountered.
+    """
+    DEBUG_LOG(f"_handle_flags: ENTER at line {abs_lineno}: {txt_line}")
+    flags = [f.strip() for f in txt_line[2:].strip().split(",") if f.strip()]
+    for flag in flags:
+        if flag not in RECOGNIZED_FLAGS:
+            raise ValueError(f"Unrecognized flag {flag!r} at line {abs_lineno}")
+    msg['flags'].extend(flags)
+    DEBUG_LOG(f"_handle_flags: EXIT at line {abs_lineno} with flags = {msg['flags']}")
+
+
+def _handle_auto_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle automatic comments (starting with "#.") and update the message.
+
+    :param txt_line: The auto-comment line.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_auto_comment: ENTER at line {abs_lineno}: {txt_line}")
+    comment_text = txt_line[2:].strip()
+    msg['auto_comments'].append(comment_text)
+    DEBUG_LOG(f"_handle_auto_comment: EXIT at line {abs_lineno} with auto_comments = {msg['auto_comments']}")
+
+
+def _handle_user_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle user comments (starting with "#") and update the message.
+
+    :param txt_line: The user comment line.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_user_comment: ENTER at line {abs_lineno}: {txt_line}")
+    comment_text = txt_line[1:].strip()
+    msg['user_comments'].append(comment_text)
+    DEBUG_LOG(f"_handle_user_comment: EXIT at line {abs_lineno} with user_comments = {msg['user_comments']}")
+
+
+# -------------------------------------------------------------------------
+# Field Handlers for Normal Messages
+# -------------------------------------------------------------------------
+def _handle_msgctxt(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle the msgctxt field in a message block.
+
+    :param txt_line: The line containing the msgctxt.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_msgctxt: ENTER at line {abs_lineno}: {txt_line}")
+    value = extract_quoted_value(txt_line, LEN_MSGCTXT)
+    msg['msgctxt'] = value
+    dyn_state["current"] = State.MCTX
+    DEBUG_LOG(f"_handle_msgctxt: EXIT at line {abs_lineno} with msg['msgctxt'] = {value}")
+
+
+def _handle_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle the msgid field in a message block.
+
+    :param txt_line: The line containing the msgid.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_msgid: ENTER at line {abs_lineno}: {txt_line}")
+    if msg['msgid'] is None:
+        msg['lineno'] = abs_lineno
+    value = extract_quoted_value(txt_line, LEN_MSGID)
+    msg['msgid'] = value
+    dyn_state["current"] = State.MSGID
+    DEBUG_LOG(f"_handle_msgid: EXIT at line {abs_lineno} with msg['msgid'] = {value}")
+
+
+def _handle_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle the msgid_plural field in a message block.
+
+    :param txt_line: The line containing the msgid_plural.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_msgid_plural: ENTER at line {abs_lineno}: {txt_line}")
+    value = extract_quoted_value(txt_line, LEN_MSGID_PLURAL)
+    msg['msgid_plural'] = value
+    dyn_state["current"] = State.MSGID_PLURAL
+    DEBUG_LOG(f"_handle_msgid_plural: EXIT at line {abs_lineno} with msg['msgid_plural'] = {value}")
+
+
+def _handle_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle the msgstr field in a message block.
+
+    :param txt_line: The line containing the msgstr.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_msgstr: ENTER at line {abs_lineno}: {txt_line}")
+    value = extract_quoted_value(txt_line, LEN_MSGSTR)
+    msg['msgstr'] = value
+    dyn_state["current"] = State.MSGSTR
+    DEBUG_LOG(f"_handle_msgstr: EXIT at line {abs_lineno} with msg['msgstr'] = {value}")
+
+
+def _handle_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle plural msgstr fields in a message block.
+
+    :param txt_line: The line containing a plural msgstr (e.g. msgstr[0]).
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_msgstr_plural: ENTER at line {abs_lineno}: {txt_line}")
+    m = MSGSTR_PLURAL_PATTERN.match(txt_line)
+    if m:
+        index = int(m.group(1))
+        value = unescape(m.group(2))
+        msg.setdefault('msgstr_plural', {})[index] = value
+        dyn_state["current"] = State.MSGSTR_INDEX
+        dyn_state["plural_index"] = index
+        DEBUG_LOG(f"_handle_msgstr_plural: EXIT at line {abs_lineno} with msg['msgstr_plural'][{index}] = {value}")
+    else:
+        DEBUG_LOG(f"_handle_msgstr_plural: EXIT at line {abs_lineno} with no match")
+
+
+# -------------------------------------------------------------------------
+# Handlers for Obsolete Messages
+# -------------------------------------------------------------------------
+def _handle_obsolete_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle an obsolete msgid field.
+
+    :param txt_line: The obsolete msgid line.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_obsolete_msgid: ENTER at line {abs_lineno}: {txt_line}")
+    stripped = txt_line[2:].lstrip()
+    if msg.get('msgid') is None:
+        msg['lineno'] = abs_lineno
+    value = extract_quoted_value(stripped, LEN_MSGID)
+    msg['msgid'] = value
+    msg["obsolete"] = True
+    dyn_state["current"] = State.OBSOLETE_MSGID
+    DEBUG_LOG(f"_handle_obsolete_msgid: EXIT at line {abs_lineno} with msg['msgid'] = {value}")
+
+
+def _handle_obsolete_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle an obsolete msgstr field.
+
+    :param txt_line: The obsolete msgstr line.
+    :param abs_lineno: Absolute line number.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary.
+    """
+    DEBUG_LOG(f"_handle_obsolete_msgstr: ENTER at line {abs_lineno}: {txt_line}")
+    stripped = txt_line[2:].lstrip()
+    value = extract_quoted_value(stripped, LEN_MSGSTR)
+    msg['msgstr'] = value
+    msg["obsolete"] = True
+    dyn_state["current"] = State.OBSOLETE_MSGSTR
+    DEBUG_LOG(f"_handle_obsolete_msgstr: EXIT at line {abs_lineno} with msg['msgstr'] = {value}")
+
+
+# -------------------------------------------------------------------------
+# Continuation Handler (supports obsolete states)
+# -------------------------------------------------------------------------
+def _handle_continuation(txt_line: str, absolute_line: int, msg: dict, dyn_state: dict) -> None:
+    """
+    Handle a line continuation for multi-line message fields.
+
+    Continuation lines must start and end with quotes.
+
+    :param txt_line: The continuation line.
+    :param absolute_line: The absolute line number in the PO file.
+    :param msg: The message dictionary.
+    :param dyn_state: The dynamic state dictionary containing the current state and plural index.
+    :raises ValueError: If continuation is not allowed in the current state.
+    """
+    current_state = dyn_state.get("current")
+    allowed_states = {State.MCTX, State.MSGID, State.MSGID_PLURAL, State.MSGSTR, State.MSGSTR_INDEX,
+                      State.OBSOLETE_MSGID, State.OBSOLETE_MSGSTR}
+    if current_state not in allowed_states:
+        raise ValueError(f"Line continuation at line {absolute_line} not allowed in state {current_state}")
+    if not (txt_line.startswith('"') and txt_line.endswith('"')):
+        raise ValueError(
+            f"Invalid continuation line for state {current_state} at line {absolute_line}: {txt_line!r}. Missing quotes.")
+    value = unescape(txt_line[1:-1])
+    if current_state == State.MCTX:
+        msg['msgctxt'] = (msg.get('msgctxt') or "") + value
+    elif current_state in {State.MSGID, State.OBSOLETE_MSGID}:
+        msg['msgid'] = (msg.get('msgid') or "") + value
+    elif current_state == State.MSGID_PLURAL:
+        msg['msgid_plural'] = (msg.get('msgid_plural') or "") + value
+    elif current_state in {State.MSGSTR, State.OBSOLETE_MSGSTR}:
+        msg['msgstr'] = (msg.get('msgstr') or "") + value
+    elif current_state == State.MSGSTR_INDEX:
+        plural_index = dyn_state.get("plural_index")
+        if plural_index is not None:
+            if plural_index in msg.get('msgstr_plural', {}):
+                msg['msgstr_plural'][plural_index] += value
+            else:
+                msg.setdefault('msgstr_plural', {})[plural_index] = value
+        else:
+            raise ValueError(f"Missing plural index in state {current_state} at line {absolute_line}")
+    DEBUG_LOG(f"_handle_continuation: EXIT at line {absolute_line} with added value = {value}")
+
+
+# -------------------------------------------------------------------------
+# Nested Transition Table Using Enums
+# -------------------------------------------------------------------------
+NESTED_TRANSITION_TABLE = {
+    State.INITIAL: {
+        Token.MSGCTXT: (_handle_msgctxt, State.MCTX),
+        Token.MSGID: (_handle_msgid, State.MSGID),
+        Token.OBSOLETE_MSGID: (_handle_obsolete_msgid, State.OBSOLETE_MSGID),
+    },
+    State.MCTX: {
+        Token.MSGID: (_handle_msgid, State.MSGID),
+    },
+    State.MSGID: {
+        Token.CONTINUATION: (_handle_continuation, State.MSGID),
+        Token.MSGID_PLURAL: (_handle_msgid_plural, State.MSGID_PLURAL),
+        Token.MSGSTR: (_handle_msgstr, State.MSGSTR),
+        Token.MSGSTR_INDEX: (_handle_msgstr_plural, State.MSGSTR_INDEX),
+    },
+    State.MSGID_PLURAL: {
+        Token.CONTINUATION: (_handle_continuation, State.MSGID_PLURAL),
+        Token.MSGSTR_INDEX: (_handle_msgstr_plural, State.MSGSTR_INDEX),
+    },
+    State.MSGSTR: {
+        Token.CONTINUATION: (_handle_continuation, State.MSGSTR),
+    },
+    State.MSGSTR_INDEX: {
+        Token.CONTINUATION: (_handle_continuation, State.MSGSTR_INDEX),
+        Token.MSGSTR_INDEX: (_handle_msgstr_plural, State.MSGSTR_INDEX),
+    },
+    State.OBSOLETE_MSGID: {
+        Token.CONTINUATION: (_handle_continuation, State.OBSOLETE_MSGID),
+        Token.OBSOLETE_MSGSTR: (_handle_obsolete_msgstr, State.OBSOLETE_MSGSTR),
+    },
+    State.OBSOLETE_MSGSTR: {
+        Token.CONTINUATION: (_handle_continuation, State.OBSOLETE_MSGSTR),
+    },
+}
+
+
+# -------------------------------------------------------------------------
+# State Machine for Processing a Block (Line-by-Line)
+# -------------------------------------------------------------------------
+def process_block(block: str, base_line: int) -> Message:
+    """
+    Process a single block (entry) using a shift-reduce finite state machine (FSM).
+
+    Each block represents an individual entry in the PO file. The function iterates
+    over the lines in the block, determines the token type, and uses the nested transition
+    table to invoke the appropriate handler for each line.
+
+    :param block: A block of text representing a PO file entry.
+    :param base_line: The starting line number of the block in the original file.
+    :return: A Message instance populated with the parsed data.
+    :raises ValueError: If a grammar error is encountered or the block is incomplete.
+    """
+    global all_errors, ABORT_EVENT
+
+    if IS_MULTI_PROCESSING and ABORT_EVENT and ABORT_EVENT.is_set():
+        return None  # Skip processing if abort event is set
+
+    cur_state = State.INITIAL
+    msg = {
+        'msgctxt': None,
+        'msgid': None,
+        'msgid_plural': None,
+        'msgstr': '',
+        'msgstr_plural': {},
+        'locations': [],
+        'flags': [],
+        'auto_comments': [],
+        'user_comments': [],
+        'previous_msgid': tuple(),
+        'lineno': None,
+        'obsolete': False,
+    }
+    dyn_state = {"current": None, "plural_index": None}
+    lines = block.splitlines()
+    nt_table = NESTED_TRANSITION_TABLE  # Local alias for faster lookup.
+
+    for i, txt_line in enumerate(lines):
+        abs_lineno = base_line + i
+        s = txt_line.strip()
+        if not s:
+            continue
+        token = Token.get(s)
+        if token == Token.ERROR:
+            raise ValueError(f"Grammar error at line {abs_lineno}: {s!r}")
+        if token == Token.COMMENT:
+            _handle_comment(s, abs_lineno, msg, dyn_state)
+            continue
+        sub_table = nt_table.get(cur_state)
+        if sub_table is None or token not in sub_table:
+            raise ValueError(f"Unexpected token {token.name} at line {abs_lineno} in state {cur_state.name}: {s!r}")
+        handler, new_state = sub_table[token]
+        handler(s, abs_lineno, msg, dyn_state)
+        cur_state = new_state
+
+    if cur_state not in (State.MSGSTR, State.MSGSTR_INDEX, State.OBSOLETE_MSGID, State.OBSOLETE_MSGSTR):
+        raise ValueError(f"Incomplete entry starting at line {base_line}: ended in state {cur_state.name}")
+
+    try:
+        # If this is a plural message, validate that the plural indexes are sequential.
+        if msg.get('msgid_plural'):
+            expected_n = CATALOG.num_plurals  # Get number of plurals from catalog header.
+            plural_indexes = sorted(msg['msgstr_plural'].keys())
+            if plural_indexes != list(range(expected_n)):
+                raise ValueError(
+                    f"Invalid plural indexes at line {msg['lineno']}: expected {list(range(expected_n))}, got {plural_indexes} for {msg['msgstr_plural']}")
+            translations = tuple(msg['msgstr_plural'][i] for i in sorted(msg['msgstr_plural']))
+            mesg = Message(
+                [msg['msgid'], msg['msgid_plural']],
+                string=translations,
+                locations=msg['locations'],
+                flags=msg['flags'],
+                auto_comments=msg['auto_comments'],
+                user_comments=msg['user_comments'],
+                previous_id=msg['previous_msgid'],
+                lineno=msg['lineno'],
+                context=msg['msgctxt']
+            )
+        else:
+            mesg = Message(
+                msg['msgid'],
+                string=msg['msgstr'],
+                locations=msg['locations'],
+                flags=set(msg['flags']),
+                auto_comments=msg['auto_comments'],
+                user_comments=msg['user_comments'],
+                previous_id=msg['previous_msgid'],
+                lineno=msg['lineno'],
+                context=msg['msgctxt']
+            )
+        if msg.get("obsolete"):
+            mesg.obsolete = True
+        return mesg
+    except Exception as e:
+        if IS_ABORT_ON_INVALID:
+            ABORT_EVENT.set()  # Signal other processes to stop.
+            raise e
+        else:
+            all_errors.append(e)
+
+
+# -------------------------------------------------------------------------
+# Multiprocessing Helper and Main Parse Function
+# -------------------------------------------------------------------------
+def process_batch(batch, process_block_func, is_debug) -> list:
+    """
+    Process a batch of blocks and return a list of parsed Message instances.
+
+    :param batch: A list of tuples (start_line, block) representing a batch of blocks.
+    :param process_block_func: The function used to process each block.
+    :param is_debug: Debug flag to control logging.
+    :return: A list of Message instances parsed from the batch.
+    """
+    global IS_DEBUG
+    IS_DEBUG = is_debug
+    results = [process_block_func(block, start_line) for start_line, block in batch]
+
+    if IS_MULTI_PROCESSING and ABORT_EVENT.is_set():
+        results = [m for m in results if m is not None]
+
+    if IS_DEBUG:
+        for handler in LOGGER.handlers:
+            handler.flush()
+    return results
+
+
+def process_batch_wrapper(batch):
+    """
+    Wrapper function for processing a batch of blocks.
+
+    This function is used to interface with the multiprocessing Pool.
+
+    :param batch: A batch of blocks.
+    :return: A list of parsed Message instances.
+    """
+    return process_batch(batch, process_block, IS_DEBUG)
+
+
+def split_into_batches(lst, num_batches):
+    """
+    Split the list 'lst' into 'num_batches' contiguous batches,
+    distributing any remainder evenly among the first batches.
+
+    :param lst: The list of items to split.
+    :param num_batches: The number of batches to split into.
+    :return: A list of batches (sublists).
+    """
+    n = len(lst)
+    batch_size = n // num_batches
+    remainder = n % num_batches
+    batches = []
+    start = 0
+    for i in range(num_batches):
+        extra = 1 if i < remainder else 0
+        end = start + batch_size + extra
+        batches.append(lst[start:end])
+        start = end
+    return batches
+
+
+def parse() -> tuple:
+    """
+    Parse the pre-split PO file blocks into Message instances and collect any errors.
+
+    This function orchestrates the parsing process, using multiprocessing if enabled,
+    or processing blocks sequentially. The parsed messages are sorted by line number.
+
+    :return: A tuple (all_messages, all_errors) where:
+             - all_messages: List of parsed Message instances.
+             - all_errors: List of errors encountered during parsing.
+    """
+    global all_errors, all_messages, ABORT_EVENT
+
+    blocks = BLOCKS
+    DEBUG_LOG(f"Total blocks found: {len(blocks)}")
+
+    if IS_MULTI_PROCESSING:
+        ABORT_EVENT = multiprocessing.Event()
+        ABORT_EVENT.clear()
+
+        num_cores = multiprocessing.cpu_count()
+        num_batches = max(1, num_cores - 2)
+        num_batches = (num_batches // BATCH_DIVISION_REDUCTION if num_batches >= 5 else num_batches)
+        DEBUG_LOG(f"Using {num_batches} batch(es) (cpu_count: {num_cores})")
+        batches = split_into_batches(blocks, num_batches)
+        DEBUG_LOG(f'number of batches: {len(batches)}, batch_size: {len(batches[0])}')
+        pool = multiprocessing.Pool(processes=num_batches,
+                                    initializer=worker_init,
+                                    initargs=(ABORT_EVENT,))
+        try:
+            results = pool.map(process_batch_wrapper, batches)
+        except Exception as e:
+            ERRORS.append(e)
+            if IS_ABORT_ON_INVALID:
+                ABORT_EVENT.set()
+                pool.terminate()
+                pool.join()
+                raise e
+            else:
+                all_errors.append(e)
+
+        pool.close()
+        pool.join()
+        for batch_results in results:
+            all_messages.extend(batch_results)
+    else:
+        ABORT_EVENT = multiprocessing.Event()
+        DEBUG_LOG("Processing blocks sequentially.")
+        for start_line, block in blocks:
+            try:
+                all_messages.append(process_block(block, start_line))
+            except Exception as e:
+                if IS_ABORT_ON_INVALID:
+                    raise e
+                else:
+                    all_errors.append(e)
+    all_messages.sort(key=lambda m: m.lineno if m.lineno is not None else 0)
+    return all_messages, all_errors

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -837,6 +837,7 @@ def parse() -> tuple:
 
     blocks = BLOCKS
     DEBUG_LOG(f"Total blocks found: {len(blocks)}")
+    results = []
 
     if IS_MULTI_PROCESSING:
         ABORT_EVENT = multiprocessing.Event()

--- a/babel/messages/msg_parser.py
+++ b/babel/messages/msg_parser.py
@@ -14,31 +14,10 @@ import sys
 import re
 import multiprocessing
 import logging
+import locale
 from babel.messages import Message  # Babel’s Message class
 from enum import IntFlag, auto
-import locale
-
-# Define the set of recognized flags for message formatting.
-RECOGNIZED_FLAGS = {
-    'fuzzy', 'c-format', 'no-c-format', 'objc-format', 'no-objc-format',
-    'java-format', 'no-java-format', 'no-java-printf-format', 'python-format', 'no-python-format',
-    'no-python-brace-format', 'php-format', 'no-php-format', 'gcc-internal-format', 'no-gcc-internal-format',
-    'qt-format', 'qt-plural-format', 'no-qt-format', 'boost-format', 'no-boost-format',
-    'c++-format', 'no-c++-format', 'csharp-format', 'no-csharp-format', 'elisp-format',
-    'no-elisp-format', 'gfc-internal-format', 'no-gfc-internal-format', 'javascript-format', 'no-javascript-format',
-    'lua-format', 'no-lua-format', 'objc-format', 'no-objc-format', 'java-format',
-    'perl-format', 'no-perl-format', 'perl-brace-format', 'no-perl-brace-format', 'ruby-format',
-    'no-ruby-format', 'rust-format', 'no-rust-format', 'scheme-format', 'no-scheme-format',
-    'sh-format', 'no-sh-format', 'smalltalk-format', 'no-smalltalk-format', 'tcl-format',
-    'no-tcl-format', 'ycp-format', 'no-ycp-format', 'awk-format', 'no-awk-format',
-    'lisp-format', 'no-lisp-format', 'librep-format', 'no-librep-format', 'object-pascal-format',
-    'no-object-pascal-format', 'elisp-format', 'no-elisp-format', 'javascript-format', 'no-javascript-format',
-    'lua-format', 'no-lua-format', 'gfc-internal-format', 'no-gfc-internal-format', 'smalltalk-format',
-    'no-smalltalk-format', 'tcl-format', 'no-tcl-format', 'ycp-format', 'no-ycp-format',
-    'awk-format', 'no-awk-format', 'lisp-format', 'no-lisp-format', 'smalltalk-format',
-    'no-smalltalk-format', 'kde-format', 'no-kde-format', 'qt-format', 'no-qt-format'
-}
-
+from babel.messages.gvar import gv  # Import the global variable class
 
 # -------------------------------------------------------------------------
 # Token Enumeration
@@ -72,11 +51,7 @@ class Token(IntFlag):
     def get(cls, txt_line: str) -> "Token":
         """
         Determine the token type based on the given line.
-
         Optimized by checking the first character of the line.
-
-        :param txt_line: The text line from the PO file.
-        :return: A Token enum indicating the type of token.
         """
         if not txt_line:
             return cls.ERROR
@@ -145,9 +120,6 @@ class State(IntFlag):
     def get(cls, txt_line: str) -> "State":
         """
         Determine the initial parser state based on the beginning of a line.
-
-        :param txt_line: A line from the PO file.
-        :return: A State enum corresponding to the line's content.
         """
         if txt_line.startswith("msgctxt"):
             return cls.MCTX
@@ -166,43 +138,10 @@ class State(IntFlag):
 
 
 # -------------------------------------------------------------------------
-# Global Parser Configuration Variables
+# Global Parser Configuration Variables are now in gv.py
 # -------------------------------------------------------------------------
-BLOCKS = None  # Pre-split list of blocks from the PO file.
-IS_DEBUG = False  # Debug flag.
-IS_HOOK_EXEPT = True  # Hook exception flag.
-IS_MULTI_PROCESSING = False  # Flag to enable multiprocessing.
-LOGGER = None  # Global logger instance.
-CATALOG = None  # Global Babel Catalog instance.
-BATCH_DIVISION_REDUCTION = 3  # Reduction factor for batch size.
-
-IS_ABORT_ON_INVALID = True  # Flag to abort on invalid entries.
-
-all_messages = []  # List to store all parsed messages.
-all_errors = []  # List to store errors encountered during parsing.
-
-# Global event to signal an abort in multiprocessing.
-ABORT_EVENT = None
-
-# Precompiled regex patterns.
-escapped_new_line_pattern = re.compile(r'\\([\\trn"])')
-COMMENT_PATTERN = re.compile(r'^#(?:[ :,\.\~\|]*?.*)?$')
-MSGSTR_PLURAL_PATTERN = re.compile(r'msgstr\[(\d+)\]\s+"(.*)"')
-
-# Constants for prefix lengths in message fields.
-LEN_MSGCTXT = len("msgctxt")
-LEN_MSGID = len("msgid")
-LEN_MSGID_PLURAL = len("msgid_plural")
-LEN_MSGSTR = len("msgstr")
-IS_CATALOG_HEADER = False
-VALID_CATALOG_STRING_LIST = None
-HEADER_SEPARATOR = None
-
-expecting_set = (State.MSGSTR, State.MSGSTR_INDEX, State.OBSOLETE_MSGID, State.OBSOLETE_MSGSTR)
-expecting_name_set = [s.name for s in expecting_set]
-
-expecting_catalog_set = (State.MSGID, State.MSGSTR,)
-expecting_catalog_name_set = [s.name for s in expecting_catalog_set]
+# (All global variables are now accessed via gv.<varname>)
+# Note: Precompiled regex patterns and prefix constants are now in gv.
 
 # -------------------------------------------------------------------------
 # Helper Functions
@@ -210,10 +149,6 @@ expecting_catalog_name_set = [s.name for s in expecting_catalog_set]
 def extract_quoted_value(txt_line: str, prefix_len: int) -> str:
     """
     Extract and unescape a quoted value from a line by removing the prefix and quotes.
-
-    :param txt_line: The input text line containing a quoted value.
-    :param prefix_len: Length of the prefix to strip from the line.
-    :return: The unescaped string inside the quotes.
     """
     value = txt_line[prefix_len:].strip()
     if value and value[0] == '"' and value[-1] == '"':
@@ -224,9 +159,6 @@ def extract_quoted_value(txt_line: str, prefix_len: int) -> str:
 def _replace_escapes(match):
     """
     Helper function to replace escape sequences with their actual characters.
-
-    :param match: A regex match object.
-    :return: The replaced character based on the escape sequence.
     """
     m = match.group(1)
     return {'n': '\n', 't': '\t', 'r': '\r'}.get(m, m)
@@ -235,35 +167,26 @@ def _replace_escapes(match):
 def setup_logger(name="POFileParser", level=None):
     """
     Set up the global LOGGER with the specified name and logging level.
-
-    :param name: The name for the logger.
-    :param level: The logging level (DEBUG, INFO, etc.). Defaults based on IS_DEBUG.
-    :return: The configured logger instance.
     """
-    global LOGGER, IS_DEBUG
     if level is None:
-        level = logging.DEBUG if IS_DEBUG else logging.INFO
-    LOGGER = logging.getLogger(name)
-    LOGGER.setLevel(level)
-    for handler in LOGGER.handlers[:]:
-        LOGGER.removeHandler(handler)
+        level = logging.DEBUG if gv.IS_DEBUG else logging.INFO
+    gv.LOGGER = logging.getLogger(name)
+    gv.LOGGER.setLevel(level)
+    for handler in gv.LOGGER.handlers[:]:
+        gv.LOGGER.removeHandler(handler)
     handler = logging.StreamHandler()
     formatter = logging.Formatter("%(asctime)s [%(processName)s] %(levelname)s: %(message)s")
     handler.setFormatter(formatter)
-    LOGGER.addHandler(handler)
+    gv.LOGGER.addHandler(handler)
 
-    if not IS_DEBUG:
-        LOGGER.disabled = True
-    return LOGGER
+    if not gv.IS_DEBUG:
+        gv.LOGGER.disabled = True
+    return gv.LOGGER
 
 
 def custom_excepthook(exc_type, exc_value, exc_traceback):
     """
     Custom exception hook to print errors.
-
-    :param exc_type: Exception type.
-    :param exc_value: Exception value.
-    :param exc_traceback: Exception traceback.
     """
     print(f"Error: {exc_value}")
 
@@ -272,28 +195,19 @@ def DEBUG_LOG(msg):
     import inspect
     """
     Log a debug message if debugging is enabled.
-
-    :param msg: The message to log.
     """
-    if IS_DEBUG:
+    if gv.IS_DEBUG:
         caller_frame = inspect.currentframe().f_back
-        # Extract the caller's function name
         caller_name = caller_frame.f_code.co_name
-
-        LOGGER.debug(f'{caller_name}() {msg}')
+        gv.LOGGER.debug(f'{caller_name}() {msg}')
 
 
 def worker_init(abort_event):
     """
     Initializer function for worker processes in multiprocessing.
-
-    Sets up the logger and abort event.
-
-    :param abort_event: The multiprocessing event to signal abort.
     """
-    global LOGGER, ABORT_EVENT
-    ABORT_EVENT = abort_event
-    LOGGER = setup_logger(name="POFileParser", level=logging.DEBUG)
+    gv.ABORT_EVENT = abort_event
+    setup_logger(name="POFileParser", level=logging.DEBUG)
 
 
 def init_parser(blocks,
@@ -306,56 +220,34 @@ def init_parser(blocks,
                 abort_on_invalid=True):
     """
     Initialize the global parser configuration.
-
-    This function sets global variables used during parsing.
-
-    :param blocks: The pre-split list of PO file blocks.
-    :param catalog: An optional Babel Catalog instance.
-    :param is_debug: Enable debug mode if True.
-    :param batch_size_division: Factor to reduce batch size in multiprocessing.
-    :param is_multi_processing: Enable multiprocessing if True.
-    :param is_hook_except: Enable custom exception hook if True.
-    :param ignore_obsolete: Whether to ignore obsolete messages.
-    :param abort_on_invalid: Whether to abort on invalid entries.
     """
-    global BLOCKS, IS_DEBUG, IS_MULTI_PROCESSING, IS_HOOK_EXEPT, BATCH_DIVISION_REDUCTION
-    global CATALOG, IS_IGNORE_OBSOLETE, IS_ABORT_ON_INVALID, ERRORS
+    gv.BATCH_DIVISION_REDUCTION = batch_size_division
+    gv.BLOCKS = blocks
+    gv.IS_DEBUG = is_debug
+    gv.IS_MULTI_PROCESSING = is_multi_processing
+    gv.IS_HOOK_EXEPT = is_hook_except
+    gv.CATALOG = catalog
+    gv.IS_IGNORE_OBSOLETE = ignore_obsolete
+    gv.IS_ABORT_ON_INVALID = abort_on_invalid
+    gv.ERRORS = []
+    setup_logger(level=logging.DEBUG if gv.IS_DEBUG else logging.INFO)
 
-    BATCH_DIVISION_REDUCTION = batch_size_division
-    BLOCKS = blocks
-    IS_DEBUG = is_debug
-    IS_MULTI_PROCESSING = is_multi_processing
-    IS_HOOK_EXEPT = is_hook_except
-    CATALOG = catalog
-    IS_IGNORE_OBSOLETE = ignore_obsolete
-    IS_ABORT_ON_INVALID = abort_on_invalid
-    ERRORS = []
-    setup_logger(level=logging.DEBUG if IS_DEBUG else logging.INFO)
-
-    if IS_HOOK_EXEPT:
+    if gv.IS_HOOK_EXEPT:
         sys.excepthook = custom_excepthook
 
 
 def unescape(string: str) -> str:
     r"""
     Reverse escape the given string by replacing escape sequences with their actual characters.
-
-    :param string: The string with escape sequences.
-    :return: The unescaped string.
     """
     if '\\' not in string:
         return string
-    return escapped_new_line_pattern.sub(_replace_escapes, string)
+    return gv.escapped_new_line_pattern.sub(_replace_escapes, string)
 
 
 def parse_header_msgstr(header: str) -> dict:
     """
     Parse a header msgstr (multi-line) into a dictionary of key-value pairs.
-
-    Each line in the header is expected to have a "Key: Value" format.
-
-    :param header: The header string from the PO file.
-    :return: A dictionary with header metadata.
     """
     result = {}
     for txt_line in header.split("\n"):
@@ -373,13 +265,6 @@ def parse_header_msgstr(header: str) -> dict:
 def _handle_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Process a comment line and update the message dictionary accordingly.
-
-    Delegates to specific comment handlers based on the comment type.
-
-    :param txt_line: The comment line.
-    :param abs_lineno: Absolute line number in the PO file.
-    :param msg: The current message dictionary being built.
-    :param dyn_state: Dynamic state dictionary tracking current processing state.
     """
     if txt_line.startswith("#:"):
         _handle_locations(txt_line, abs_lineno, msg, dyn_state)
@@ -398,11 +283,6 @@ def _handle_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) 
 def _handle_locations(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle location comments (starting with "#:") and update message locations.
-
-    :param txt_line: The location comment line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     occ_line = txt_line[2:].strip()
@@ -422,15 +302,10 @@ def _handle_locations(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict
 def _handle_flags(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Process flag comments (starting with "#,") and validate them against recognized flags.
-
-    :param txt_line: The flag comment line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
-    :raises ValueError: If an unrecognized flag is encountered.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     flags = [f.strip() for f in txt_line[2:].strip().split(",") if f.strip()]
+    # Uncomment the following lines to enforce recognized flags:
     # for flag in flags:
     #     if flag not in RECOGNIZED_FLAGS:
     #         raise ValueError(f"Unrecognized flag {flag!r} at line number {abs_lineno}")
@@ -441,11 +316,6 @@ def _handle_flags(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) ->
 def _handle_auto_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle automatic comments (starting with "#.") and update the message.
-
-    :param txt_line: The auto-comment line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     comment_text = txt_line[2:].strip()
@@ -455,14 +325,7 @@ def _handle_auto_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: d
 
 def _handle_prev_field(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
-    Handle previous-field lines (starting with "#|") for all fields (msgid, msgid_plural,
-    msgctxt, msgstr, msgstr_plural). Retains the original marker and stores the tuple
-    (field, text) into the 'previous_id' list.
-
-    :param txt_line: The previous-field comment line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
+    Handle previous-field lines (starting with "#|") for all fields.
     """
     DEBUG_LOG(f"ENTER previous field at line number {abs_lineno}: {txt_line!r}")
     prev_text = txt_line[2:].strip()
@@ -478,11 +341,6 @@ def _handle_prev_field(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dic
 def _handle_user_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle user comments (starting with "#") and update the message.
-
-    :param txt_line: The user comment line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     comment_text = txt_line[1:].strip()
@@ -496,14 +354,9 @@ def _handle_user_comment(txt_line: str, abs_lineno: int, msg: dict, dyn_state: d
 def _handle_msgctxt(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle the msgctxt field in a message block.
-
-    :param txt_line: The line containing the msgctxt.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
-    value = extract_quoted_value(txt_line, LEN_MSGCTXT)
+    value = extract_quoted_value(txt_line, gv.LEN_MSGCTXT)
     msg['msgctxt'] = value
     dyn_state["current"] = State.MCTX
     DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgctxt'] = {value}")
@@ -512,16 +365,11 @@ def _handle_msgctxt(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) 
 def _handle_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle the msgid field in a message block.
-
-    :param txt_line: The line containing the msgid.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"_handle_msgid: ENTER at line number {abs_lineno}: {txt_line!r}")
     if msg['msgid'] is None:
         msg['lineno'] = abs_lineno
-    value = extract_quoted_value(txt_line, LEN_MSGID)
+    value = extract_quoted_value(txt_line, gv.LEN_MSGID)
     msg['msgid'] = value
     dyn_state["current"] = State.MSGID
     DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgid'] = {value}")
@@ -530,14 +378,9 @@ def _handle_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) ->
 def _handle_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle the msgid_plural field in a message block.
-
-    :param txt_line: The line containing the msgid_plural.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
-    value = extract_quoted_value(txt_line, LEN_MSGID_PLURAL)
+    value = extract_quoted_value(txt_line, gv.LEN_MSGID_PLURAL)
     msg['msgid_plural'] = value
     dyn_state["current"] = State.MSGID_PLURAL
     DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgid_plural'] = {value}")
@@ -546,14 +389,9 @@ def _handle_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: d
 def _handle_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle the msgstr field in a message block.
-
-    :param txt_line: The line containing the msgstr.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
-    value = extract_quoted_value(txt_line, LEN_MSGSTR)
+    value = extract_quoted_value(txt_line, gv.LEN_MSGSTR)
     msg['msgstr'] = value
     dyn_state["current"] = State.MSGSTR
     DEBUG_LOG(f"EXIT at line number {abs_lineno} with msg['msgstr'] = {value}")
@@ -562,14 +400,9 @@ def _handle_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -
 def _handle_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle plural msgstr fields in a message block.
-
-    :param txt_line: The line containing a plural msgstr (e.g. msgstr[0]).
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
-    m = MSGSTR_PLURAL_PATTERN.match(txt_line)
+    m = gv.MSGSTR_PLURAL_PATTERN.match(txt_line)
     if m:
         index = int(m.group(1))
         value = unescape(m.group(2))
@@ -587,17 +420,12 @@ def _handle_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: 
 def _handle_obsolete_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle an obsolete msgid field.
-
-    :param txt_line: The obsolete msgid line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()
     if msg.get('msgid') is None:
         msg['lineno'] = abs_lineno
-    value = extract_quoted_value(stripped, LEN_MSGID)
+    value = extract_quoted_value(stripped, gv.LEN_MSGID)
     msg['msgid'] = value
     msg["obsolete"] = True
     dyn_state["current"] = State.OBSOLETE_MSGID
@@ -607,15 +435,10 @@ def _handle_obsolete_msgid(txt_line: str, abs_lineno: int, msg: dict, dyn_state:
 def _handle_obsolete_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle an obsolete msgstr field.
-
-    :param txt_line: The obsolete msgstr line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"_handle_obsolete_msgstr: ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()
-    value = extract_quoted_value(stripped, LEN_MSGSTR)
+    value = extract_quoted_value(stripped, gv.LEN_MSGSTR)
     msg['msgstr'] = value
     msg["obsolete"] = True
     dyn_state["current"] = State.OBSOLETE_MSGSTR
@@ -625,15 +448,10 @@ def _handle_obsolete_msgstr(txt_line: str, abs_lineno: int, msg: dict, dyn_state
 def _handle_obsolete_msgctxt(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle an obsolete msgctxt field.
-
-    :param txt_line: The obsolete msgctxt line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()  # remove "#~"
-    value = extract_quoted_value(stripped, LEN_MSGCTXT)
+    value = extract_quoted_value(stripped, gv.LEN_MSGCTXT)
     msg['msgctxt'] = value
     msg["obsolete"] = True
     dyn_state["current"] = State.OBSOLETE_MSGCTXT
@@ -643,15 +461,10 @@ def _handle_obsolete_msgctxt(txt_line: str, abs_lineno: int, msg: dict, dyn_stat
 def _handle_obsolete_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle an obsolete msgid_plural field.
-
-    :param txt_line: The obsolete msgid_plural line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()  # remove "#~"
-    value = extract_quoted_value(stripped, LEN_MSGID_PLURAL)
+    value = extract_quoted_value(stripped, gv.LEN_MSGID_PLURAL)
     msg['msgid_plural'] = value
     msg["obsolete"] = True
     dyn_state["current"] = State.OBSOLETE_MSGID_PLURAL
@@ -661,11 +474,6 @@ def _handle_obsolete_msgid_plural(txt_line: str, abs_lineno: int, msg: dict, dyn
 def _handle_obsolete_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle an obsolete msgstr_plural field.
-
-    :param txt_line: The obsolete msgstr_plural line.
-    :param abs_lineno: Absolute line number.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary.
     """
     DEBUG_LOG(f"ENTER at line number {abs_lineno}: {txt_line!r}")
     stripped = txt_line[2:].lstrip()  # remove "#~"
@@ -689,28 +497,18 @@ def _handle_obsolete_msgstr_plural(txt_line: str, abs_lineno: int, msg: dict, dy
 def _handle_continuation(txt_line: str, absolute_line: int, msg: dict, dyn_state: dict) -> None:
     """
     Handle a line continuation for multi-line message fields.
-
-    Continuation lines must start and end with quotes.
-
-    :param txt_line: The continuation line.
-    :param absolute_line: The absolute line number in the PO file.
-    :param msg: The message dictionary.
-    :param dyn_state: The dynamic state dictionary containing the current state and plural index.
-    :raises ValueError: If continuation is not allowed in the current state.
     """
-    global VALID_CATALOG_STRING_LIST, IS_CATALOG_HEADER, HEADER_SEPARATOR
-
     current_state = dyn_state.get("current")
     allowed_states = {State.MCTX, State.MSGID, State.MSGID_PLURAL, State.MSGSTR, State.MSGSTR_INDEX,
                       State.OBSOLETE_MSGID, State.OBSOLETE_MSGSTR,
                       State.OBSOLETE_MSGCTXT, State.OBSOLETE_MSGID_PLURAL, State.OBSOLETE_MSGSTR_PLURAL}
     if current_state not in allowed_states:
         raise ValueError(f"Line continuation at line number {absolute_line} not allowed in state {current_state.name}")
-    
+
     is_obsolete = current_state.name.startswith('OBSOLETE')
     if is_obsolete:
         txt_line = txt_line[2:].strip()
-    if not (txt_line.startswith('"') and txt_line.endswith('"')):        
+    if not (txt_line.startswith('"') and txt_line.endswith('"')):
         raise ValueError(
             f"Invalid continuation line for state {current_state.name} at line number {absolute_line}: {txt_line!r}. Missing quotes.")
     value = unescape(txt_line[1:-1])
@@ -721,16 +519,16 @@ def _handle_continuation(txt_line: str, absolute_line: int, msg: dict, dyn_state
     elif current_state == State.MSGID_PLURAL:
         msg['msgid_plural'] = (msg.get('msgid_plural') or "") + value
     elif current_state in {State.MSGSTR, State.OBSOLETE_MSGSTR}:
-        if IS_CATALOG_HEADER:
-            is_valid = (HEADER_SEPARATOR in value)
+        if gv.IS_CATALOG_HEADER:
+            is_valid = (gv.HEADER_SEPARATOR in value)
             if is_valid:
-                front_part = value.split(HEADER_SEPARATOR)[0]
-                is_valid = front_part in VALID_CATALOG_STRING_LIST
+                front_part = value.split(gv.HEADER_SEPARATOR)[0]
+                is_valid = front_part in gv.VALID_CATALOG_STRING_LIST
                 if not is_valid:
                     raise ValueError(
                         f"Processing Catalog Header, {value!r} is not a valid header prefix, in state {current_state.name} at line number {absolute_line}")
             else:
-                raise ValueError(f"Processing Catalog Header, missing {HEADER_SEPARATOR!r} in text line {value!r}, at state {current_state.name} at line number {absolute_line}")
+                raise ValueError(f"Processing Catalog Header, missing {gv.HEADER_SEPARATOR!r} in text line {value!r}, at state {current_state.name} at line number {absolute_line}")
         msg['msgstr'] = (msg.get('msgstr') or "") + value
     elif current_state == State.MSGSTR_INDEX:
         plural_index = dyn_state.get("plural_index")
@@ -811,14 +609,22 @@ NESTED_TRANSITION_TABLE = {
 
 def printErrors():
     """
-    Check to see if all_errors has registered any instance of errors.
-    If it does then printing out errors to standard error, each on a separate line.
+    Print any errors encountered during parsing.
     """
-    if all_errors:
+    if gv.all_errors:
         print("Errors encountered:", file=sys.stderr)
-        for err in all_errors:
+        for err in gv.all_errors:
             print(err, file=sys.stderr)
 
+
+msg_valid_state = { State.MSGID,
+                         State.MSGSTR,
+                         State.OBSOLETE_MSGSTR,
+                         State.OBSOLETE_MSGID,
+                         State.OBSOLETE_MSGCTXT,
+                         State.OBSOLETE_MSGID_PLURAL,
+                         State.OBSOLETE_MSGSTR_PLURAL}
+header_valid_state = {State.MSGID, State.MSGSTR}
 
 # -------------------------------------------------------------------------
 # State Machine for Processing a Block (Line-by-Line)
@@ -829,25 +635,14 @@ def process_block(block: str, base_line: int,
                   valid_catalog_string_list=None,
                   header_separator=None) -> Message:
     """
-    Process a single block (entry) using a shift-reduce finite state machine (FSM).
-
-    Each block represents an individual entry in the PO file. The function iterates
-    over the lines in the block, determines the token type, and uses the nested transition
-    table to invoke the appropriate handler for each line.
-
-    :param block: A block of text representing a PO file entry.
-    :param base_line: The starting line number of the block in the original file.
-    :return: A Message instance populated with the parsed data.
-    :raises ValueError: If a grammar error is encountered or the block is incomplete.
+    Process a single block (entry) using a finite state machine (FSM).
     """
-    global all_errors, ABORT_EVENT, IS_CATALOG_HEADER, VALID_CATALOG_STRING_LIST, HEADER_SEPARATOR
-
-    if IS_MULTI_PROCESSING and ABORT_EVENT and ABORT_EVENT.is_set():
+    if gv.IS_MULTI_PROCESSING and gv.ABORT_EVENT and gv.ABORT_EVENT.is_set():
         return None  # Skip processing if abort event is set
 
-    IS_CATALOG_HEADER = is_catalog_header
-    VALID_CATALOG_STRING_LIST = valid_catalog_string_list
-    HEADER_SEPARATOR = header_separator
+    gv.IS_CATALOG_HEADER = is_catalog_header
+    gv.VALID_CATALOG_STRING_LIST = valid_catalog_string_list
+    gv.HEADER_SEPARATOR = header_separator
 
     cur_state = State.INITIAL
     msg = {
@@ -876,8 +671,6 @@ def process_block(block: str, base_line: int,
         s = txt_line.strip()
         if not s:
             raise ValueError(f"Unexpected empty line at line number: {abs_lineno}: {txt_line!r}")
-            continue
-
         err_line = abs_lineno
         err_line_txt = txt_line
         token = Token.get(s)
@@ -894,13 +687,13 @@ def process_block(block: str, base_line: int,
         handler(s, abs_lineno, msg, dyn_state)
         cur_state = new_state
 
+
     # --- NEW CHECK FOR ABRUPT BLOCK ENDING ---
-    expected_final_states = expecting_catalog_set if IS_CATALOG_HEADER else expecting_set
-    is_valid = (cur_state in expected_final_states)
-    if not is_valid:
+    expected_final_states = msg_valid_state if not gv.IS_CATALOG_HEADER else header_valid_state
+    if cur_state not in expected_final_states:
         if msg['msgid'] is not None and cur_state in {State.MSGID, State.MSGID_PLURAL}:
-            raise ValueError(f"Abrupt ending of block at line {err_line}: MSGID exists but no MSGSTR was found. Last line: {err_line_txt!r}")
-        report_expecting_set = (expecting_catalog_name_set if IS_CATALOG_HEADER else expecting_name_set)
+            raise ValueError(f"Abrupt ending of block at line number {err_line}: MSGID exists but no MSGSTR was found. Last text line: {err_line_txt!r}")
+        report_expecting_set = [s.name for s in expected_final_states]
         is_multiple = len(report_expecting_set) > 1
         state_multiple_stmt = "one of these states" if is_multiple else "this state"
         raise ValueError(f"Incomplete entry at line number {err_line}, ended in state {err_token.name}, {err_line_txt!r},\n"
@@ -909,7 +702,7 @@ def process_block(block: str, base_line: int,
 
     try:
         if msg.get('msgid_plural'):
-            expected_n = CATALOG.num_plurals  # Get number of plurals from catalog header.
+            expected_n = gv.CATALOG.num_plurals  # Get number of plurals from catalog header.
             plural_indexes = sorted(msg['msgstr_plural'].keys())
             if plural_indexes != list(range(expected_n)):
                 raise ValueError(
@@ -942,11 +735,11 @@ def process_block(block: str, base_line: int,
             mesg.obsolete = True
         return mesg
     except Exception as e:
-        if IS_ABORT_ON_INVALID:
-            ABORT_EVENT.set()  # Signal other processes to stop.
+        if gv.IS_ABORT_ON_INVALID:
+            gv.ABORT_EVENT.set()  # Signal other processes to stop.
             raise e
         else:
-            all_errors.append(e)
+            gv.all_errors.append(e)
             return None
 
 
@@ -956,17 +749,11 @@ def process_block(block: str, base_line: int,
 def process_batch(batch, process_block_func, is_debug) -> list:
     """
     Process a batch of blocks and return a list of parsed Message instances.
-
-    :param batch: A list of tuples (start_line, block) representing a batch of blocks.
-    :param process_block_func: The function used to process each block.
-    :param is_debug: Debug flag to control logging.
-    :return: A list of Message instances parsed from the batch.
     """
-    global IS_DEBUG
-    IS_DEBUG = is_debug
+    gv.IS_DEBUG = is_debug
     results = [process_block_func(block, start_line) for start_line, block in batch]
-    if IS_DEBUG:
-        for handler in LOGGER.handlers:
+    if gv.IS_DEBUG:
+        for handler in gv.LOGGER.handlers:
             handler.flush()
     return results
 
@@ -974,23 +761,13 @@ def process_batch(batch, process_block_func, is_debug) -> list:
 def process_batch_wrapper(batch):
     """
     Wrapper function for processing a batch of blocks.
-
-    This function is used to interface with the multiprocessing Pool.
-
-    :param batch: A batch of blocks.
-    :return: A list of parsed Message instances.
     """
-    return process_batch(batch, process_block, IS_DEBUG)
+    return process_batch(batch, process_block, gv.IS_DEBUG)
 
 
 def split_into_batches(lst, num_batches):
     """
-    Split the list 'lst' into 'num_batches' contiguous batches,
-    distributing any remainder evenly among the first batches.
-
-    :param lst: The list of items to split.
-    :param num_batches: The number of batches to split into.
-    :return: A list of batches (sublists).
+    Split the list 'lst' into 'num_batches' contiguous batches.
     """
     n = len(lst)
     batch_size = n // num_batches
@@ -1008,60 +785,51 @@ def split_into_batches(lst, num_batches):
 def parse() -> tuple:
     """
     Parse the pre-split PO file blocks into Message instances and collect any errors.
-
-    This function orchestrates the parsing process, using multiprocessing if enabled,
-    or processing blocks sequentially. The parsed messages are sorted by line number.
-
-    :return: A tuple (all_messages, all_errors) where:
-             - all_messages: List of parsed Message instances.
-             - all_errors: List of errors encountered during parsing.
     """
-    global all_errors, all_messages, ABORT_EVENT
-
-    blocks = BLOCKS
+    blocks = gv.BLOCKS
     DEBUG_LOG(f"Total blocks found: {len(blocks)}")
 
-    if IS_MULTI_PROCESSING:
-        ABORT_EVENT = multiprocessing.Event()
-        ABORT_EVENT.clear()
+    if gv.IS_MULTI_PROCESSING:
+        gv.ABORT_EVENT = multiprocessing.Event()
+        gv.ABORT_EVENT.clear()
 
         num_cores = multiprocessing.cpu_count()
         num_batches = max(1, num_cores - 2)
-        num_batches = (num_batches // BATCH_DIVISION_REDUCTION if num_batches >= 5 else num_batches)
+        num_batches = (num_batches // gv.BATCH_DIVISION_REDUCTION if num_batches >= 5 else num_batches)
         print(f"Using {num_batches} batch(es) (cpu_count: {num_cores})")
         batches = split_into_batches(blocks, num_batches)
         print(f'number of batches: {len(batches)}, batch_size: {len(batches[0])}')
         pool = multiprocessing.Pool(processes=num_batches,
                                     initializer=worker_init,
-                                    initargs=(ABORT_EVENT,))
+                                    initargs=(gv.ABORT_EVENT,))
         results = []
         try:
             results = pool.map(process_batch_wrapper, batches)
         except Exception as e:
-            ERRORS.append(e)
-            if IS_ABORT_ON_INVALID:
-                ABORT_EVENT.set()
+            gv.ERRORS.append(e)
+            if gv.IS_ABORT_ON_INVALID:
+                gv.ABORT_EVENT.set()
                 pool.terminate()
                 pool.join()
                 raise e
             else:
-                all_errors.append(e)
+                gv.all_errors.append(e)
 
         pool.close()
         pool.join()
         for batch_results in results:
-            all_messages.extend(batch_results)
+            gv.all_messages.extend(batch_results)
     else:
-        ABORT_EVENT = multiprocessing.Event()
+        gv.ABORT_EVENT = multiprocessing.Event()
         DEBUG_LOG("Processing blocks sequentially.")
         for start_line, block in blocks:
             try:
-                all_messages.append(process_block(block, start_line))
+                gv.all_messages.append(process_block(block, start_line))
             except Exception as e:
-                if IS_ABORT_ON_INVALID:
+                if gv.IS_ABORT_ON_INVALID:
                     raise e
                 else:
-                    all_errors.append(e)
-    all_messages = [m for m in all_messages if m is not None]
-    all_messages.sort(key=lambda m: m.lineno if m.lineno is not None else 0)
-    return all_messages, all_errors
+                    gv.all_errors.append(e)
+    gv.all_messages = [m for m in gv.all_messages if m is not None]
+    gv.all_messages.sort(key=lambda m: m.lineno if m.lineno is not None else 0)
+    return gv.all_messages, gv.all_errors

--- a/babel/messages/parse_utils.py
+++ b/babel/messages/parse_utils.py
@@ -1,0 +1,155 @@
+"""
+babel.messages.parse_utils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Utility functions for parsing PO file data, including charset detection and conversion
+of keyword arguments to various types.
+
+:copyright: (c) 2025 by the Babel Team.
+:license: BSD, see LICENSE for more details.
+"""
+
+import re
+
+# Compile a regular expression pattern to match a "Content-Type" header with a charset specification.
+# The pattern looks for lines like:
+#   Content-Type: text/html; charset=UTF-8
+# and captures the charset value.
+CONTENT_TYPE_CHARSET_PATTERN = re.compile(b"Content-Type: [^;]+; charset=([^\r\n]+)")
+true_set = {"true", "1", "yes", "y", "t", "on"}
+# false_set = {"false", "0", "no", "n", "f", "off"}
+
+def get_char_set(filename: str) -> str:
+    """
+    Open a file in binary mode, search its content for a Content-Type header that specifies the charset,
+    and return the corresponding encoding. If no charset is found, it defaults to 'utf-8'.
+
+    Parameters:
+        filename (str): The path to the file to be read.
+
+    Returns:
+        str: The charset found in the file or 'utf-8' if not present.
+
+    Workflow:
+      1. Open the file in binary mode to correctly handle non-UTF8 encoded files.
+      2. Read the entire file content.
+      3. Search for the Content-Type header using the precompiled regex pattern.
+      4. If found, decode the captured charset value from ASCII (replacing errors) and strip
+         any extraneous newline characters or quotes.
+      5. If not found, return 'utf-8' as the default encoding.
+    """
+    with open(filename, "rb") as f:
+        content = f.read()
+    m = re.search(CONTENT_TYPE_CHARSET_PATTERN, content)
+    if m:
+        # Decode the captured charset value using ASCII decoding.
+        match_part = m.group(1).decode("ascii", errors="replace")
+        # Strip potential newline and quote characters from the decoded string.
+        char_code = match_part.strip('\\n"').strip()
+        return char_code
+    return "utf-8"
+
+
+def get_int_kwarg(kwargs, keys, default=0):
+    """
+    Extract an integer value from a dictionary of keyword arguments using a list of possible keys.
+
+    Parameters:
+        kwargs (dict): A dictionary containing keyword arguments.
+        keys (iterable): An iterable of keys to look for in the dictionary.
+        default (int, optional): The value to return if none of the keys are found. Defaults to 0.
+
+    Returns:
+        int: The integer value corresponding to the first key found in the kwargs.
+
+    Raises:
+        ValueError: If the value found cannot be converted to an integer.
+
+    Workflow:
+      1. Iterate over the provided keys.
+      2. For the first key present in kwargs, attempt to convert its value to an integer.
+      3. If conversion fails, raise a ValueError with an informative message.
+      4. If no key is found, return the default value.
+    """
+    for key in keys:
+        val = kwargs.get(key)
+        if val is not None:
+            try:
+                return int(val)
+            except ValueError as e:
+                raise ValueError(f"Invalid integer value for {key}: {val}") from e
+    return default
+
+
+def get_boolean_kwarg(kwargs, keys: list, default=False):
+    """
+    Extract a boolean value from a kwargs dictionary using a list of keys.
+
+    This function iterates over the specified keys and retrieves the corresponding
+    value from the kwargs dictionary. It then converts the value to lowercase and checks
+    if it belongs to a predefined set of truthy strings (e.g., {"true", "1", "yes", "y", "t", "on"}).
+    If any key's value is found in this truth set, the function returns True.
+    Otherwise, if no key is found or if an error occurs during processing, the function
+    returns the specified default value.
+
+    Parameters:
+        kwargs (dict): The dictionary containing keyword arguments.
+        keys (list): A list of keys to search for in the dictionary.
+        default (bool, optional): The value to return if none of the keys are found or
+                                  if an error occurs. Defaults to False.
+
+    Returns:
+        bool: True if any key's value (after conversion to lowercase) is in the truth set;
+              otherwise, returns the default value.
+
+    Conversion Logic:
+      - For each key in the provided list, attempt to retrieve its value from kwargs.
+      - If the value exists and is a string, strip leading/trailing whitespace and convert
+        it to lowercase.
+      - Check whether the resulting string is in a predefined set of truthy strings.
+      - If any such value is found, return True.
+      - If none match or an error occurs (for example, if the value does not support the
+        lower() method), return the default value.
+
+    Example:
+        >>> kwargs = {'is_debug': 'false', 'verbose': 'yes'}
+        >>> get_boolean_kwarg(kwargs, ['is_debug', 'debug'])
+        False
+        >>> get_boolean_kwarg(kwargs, ['verbose', 'log'])
+        True
+        >>> get_boolean_kwarg(kwargs, ['not_found'], default=True)
+        True
+    """
+    try:
+        val_list = [kwargs.get(k) for k in keys]
+        # Check if any non-empty value, after being lowercased, is in the truth set.
+        val = any([True for v in val_list if (v and v.lower() in true_set)])
+        return val
+    except Exception:
+        return default
+
+
+def get_str_kwargs(kwargs, keys, default=None):
+    """
+    Extract a string value from a kwargs dictionary using a list of possible keys.
+
+    Parameters:
+        kwargs (dict): A dictionary containing keyword arguments.
+        keys (iterable): An iterable of keys to search for in the dictionary.
+        default: The default value to return if none of the keys are found or if the value is None.
+
+    Returns:
+        str: The string representation of the value corresponding to the first found key,
+             or the default if no key is found.
+
+    Note:
+        The function converts the value to a string using the built-in str() function.
+
+    Example:
+        >>> kwargs = {'name': 'Alice', 'username': None}
+        >>> get_str_kwargs(kwargs, ['username', 'name'], default='Unknown')
+        'Alice'
+    """
+    for key in keys:
+        if key in kwargs and kwargs[key] is not None:
+            return str(kwargs[key])
+    return default

--- a/babel/messages/parse_utils.py
+++ b/babel/messages/parse_utils.py
@@ -120,11 +120,13 @@ def get_boolean_kwarg(kwargs, keys: list, default=False):
         True
     """
     try:
-        val_list = [kwargs.get(k) for k in keys]
+        value_list = [kwargs.get(k) for k in keys]
         # Check if any non-empty value, after being lowercased, is in the truth set.
-        val = any([True for v in val_list if (v and v.lower() in true_set)])
+        bool_val_list = [(v.lower() in true_set) if isinstance(v, str) else v
+         for v in value_list]
+        val = any(bool_val_list)
         return val
-    except Exception:
+    except Exception as e:
         return default
 
 

--- a/babel/messages/poparse.py
+++ b/babel/messages/poparse.py
@@ -84,7 +84,7 @@ def load_po(filename, **kwargs):
     # Extract string-based configuration options.
     generator_version = get_str_kwargs(kwargs, ['-v', 'version'], default=VERSION)
     cat_locale = get_str_kwargs(kwargs, ['-l', 'locale'], default=machine_language)
-    cat_charset = get_str_kwargs(kwargs, ['-chs', '-enc', 'charset', 'encoding'], default=machine_encoding)
+    cat_charset = get_str_kwargs(kwargs, ['-chs', 'charset'], default=machine_encoding)
     cat_domain = get_str_kwargs(kwargs, ['-dom', 'domain'], default='messages')
 
     # Create a default catalog using the provided or default parameters.

--- a/babel/messages/poparse.py
+++ b/babel/messages/poparse.py
@@ -1,0 +1,145 @@
+"""
+babel.messages.poparse
+~~~~~~~~~~~~~~~~~~~~~
+
+Reading and writing of files in the ``gettext`` PO (portable object)
+format.
+
+:copyright: (c) 2013-2024 by the Babel Team.
+:license: BSD, see LICENSE for more details.
+"""
+
+import argparse
+import os
+import re
+import sys
+from local_logging import benchmark
+from sphinx_intl import catalog as c
+from babel import __version__ as VERSION
+import locale
+from babel.messages import Catalog
+from babel.messages.catalog_parser import parse_catalog
+from babel.messages.block_utils import split_into_blocks
+import babel.messages.msg_parser as ps
+from babel.messages.parse_utils import get_str_kwargs, get_boolean_kwarg, get_int_kwarg, get_char_set
+
+def load_po(filename, **kwargs):
+    """
+    Load and parse a PO (Portable Object) file into a Babel Catalog object.
+
+    This function performs the following steps:
+      1. Retrieves the machine's default locale and encoding.
+      2. Extracts various configuration options from the provided kwargs:
+         - Debug mode flag.
+         - Multiprocessing flag.
+         - Hook exception flag.
+         - Batch size division for processing.
+         - Flags for ignoring obsolete messages and aborting on invalid entries.
+         - Generator version, locale, charset, and domain for the catalog.
+      3. Creates a default catalog using these parameters.
+      4. Determines the charset of the PO file via the get_char_set function.
+      5. Reads and decodes the file content based on the detected charset.
+      6. Splits the file content into blocks for parsing.
+      7. Initializes the message parser with the pre-split blocks and configuration options.
+      8. Parses the catalog header from the blocks.
+      9. Sets the catalog version if not provided.
+     10. Assigns the catalog to the parser's global state.
+     11. Parses the individual messages, classifying obsolete messages separately.
+     12. Prints any encountered parsing errors to stderr.
+     13. Returns the populated Catalog object.
+
+    Parameters:
+        filename (str): Path to the PO file to be loaded.
+        **kwargs: Additional keyword arguments for configuration.
+            Recognized keys include:
+              - '-d' or 'debug': Enable debug mode (bool).
+              - '-m' or 'multiprocessing': Enable multiprocessing (bool).
+              - '-hk' or 'hookexcept': Enable hook exception handling (bool).
+              - '-bd' or 'batch_size_division': Set the batch size division (int).
+              - '-igob' or 'ignore_obsolete': Ignore obsolete messages (bool).
+              - '-abrt' or 'abort_invalid': Abort on invalid entries (bool).
+              - '-v' or 'version': Specify the generator version (str).
+              - '-l' or 'locale': Specify the catalog locale (str).
+              - '-chs' or 'charset': Specify the catalog charset (str).
+              - '-dom' or 'domain': Specify the catalog domain (str).
+
+    Returns:
+        Catalog: A Babel Catalog object containing the parsed messages and metadata.
+
+    Raises:
+        Exceptions from underlying parsing functions if the PO file content is invalid
+        or if keyword argument conversions fail.
+    """
+    # Retrieve the machine's default language and encoding.
+    machine_language, machine_encoding = locale.getdefaultlocale()
+
+    # Extract boolean and integer configuration options from kwargs.
+    is_debug = get_boolean_kwarg(kwargs, ['-d', 'debug'], default=False)
+    is_multi_processing = get_boolean_kwarg(kwargs, ['-m', 'multiprocessing'], default=False)
+    is_hook_except = get_boolean_kwarg(kwargs, ['-hk', 'hookexcept'], default=False)
+    batch_size_division = get_int_kwarg(kwargs, ['-bd', 'batch_size_division'], default=2)
+    is_ignore_obsolete = get_boolean_kwarg(kwargs, ['-igob', 'ignore_obsolete'], default=True)
+    is_abort_on_invalid = get_boolean_kwarg(kwargs, ['-abrt', 'abort_invalid'], default=True)
+
+    # Extract string-based configuration options.
+    generator_version = get_str_kwargs(kwargs, ['-v', 'version'], default=VERSION)
+    cat_locale = get_str_kwargs(kwargs, ['-l', 'locale'], default=machine_language)
+    cat_charset = get_str_kwargs(kwargs, ['-chs', 'charset'], default=machine_encoding)
+    cat_domain = get_str_kwargs(kwargs, ['-dom', 'domain'], default='messages')
+
+    # Create a default catalog using the provided or default parameters.
+    default_catalog = Catalog(locale=cat_locale, domain=cat_domain, charset=cat_charset, version=generator_version)
+
+    # Determine the charset of the PO file content.
+    charset = get_char_set(filename)
+
+    # Open the file in binary mode and decode its content using the detected charset.
+    with open(filename, "rb") as f:
+        file_content = f.read().decode(charset, errors="replace")
+
+    # Split the file content into blocks, which are used as units for parsing.
+    blocks = split_into_blocks(file_content)
+
+    # Initialize the parser with the pre-split blocks and configuration options.
+    ps.init_parser(
+        blocks,
+        is_debug=is_debug,
+        is_multi_processing=is_multi_processing,
+        batch_size_division=batch_size_division,
+        is_hook_except=is_hook_except,
+        abort_on_invalid=is_abort_on_invalid,
+        ignore_obsolete=is_ignore_obsolete,
+    )
+
+    # Parse the catalog header from the blocks using the default catalog.
+    catalog = parse_catalog(blocks, default_catalog)
+
+    # If the catalog version is not set or is empty, use the generator version.
+    is_using_custom_generated_catalog_version = (catalog.version is None) or (len(catalog.version) == 0)
+    if is_using_custom_generated_catalog_version:
+        catalog.version = generator_version
+
+    # Set the global catalog for the message parser.
+    ps.CATALOG = catalog
+
+    # Parse the individual messages from the blocks and collect any errors.
+    messages, errors = ps.parse()
+
+    # Store parsed messages in the catalog. Obsolete messages are kept separately.
+    for msg in messages[1:]:
+        is_obsolete = getattr(msg, 'obsolete', False)
+        if is_obsolete:
+            catalog.obsolete[msg.id] = msg
+        else:
+            catalog[msg.id] = msg
+
+    # If there are errors, remove duplicates and print them to stderr.
+    if errors:
+        errors = list(set(errors))
+        print("Errors encountered:", file=sys.stderr)
+        for err in errors:
+            print(err, file=sys.stderr)
+
+    # Return the populated catalog.
+    return catalog
+

--- a/babel/messages/poparse.py
+++ b/babel/messages/poparse.py
@@ -8,24 +8,13 @@ format.
 :copyright: (c) 2025 by the Babel Team.
 :license: BSD, see LICENSE for more details.
 """
-
-import argparse
-import os
-import re
-import sys
-from local_logging import benchmark
-from sphinx_intl import catalog as c
 from babel import __version__ as VERSION
-import locale
 from babel.messages import Catalog
 from babel.messages.catalog_parser import parse_catalog, printErrors
 from babel.messages.block_utils import split_into_blocks
 from babel.messages.parse_utils import get_char_set
-
+from babel.messages.gvar import gv
 import babel.messages.msg_parser as ps
-
-
-machine_language, machine_encoding = locale.getdefaultlocale()
 
 def load_po(filename: str,
             debug: bool = False,
@@ -35,8 +24,8 @@ def load_po(filename: str,
             ignore_obsolete: bool = False,
             abort_invalid: bool = True,
             version=VERSION,
-            locale=machine_language,
-            charset=machine_encoding,
+            locale=gv.machine_language,
+            charset=gv.machine_encoding,
             domain: str = 'message',
             ):
     """

--- a/babel/messages/poparse.py
+++ b/babel/messages/poparse.py
@@ -18,77 +18,65 @@ from sphinx_intl import catalog as c
 from babel import __version__ as VERSION
 import locale
 from babel.messages import Catalog
-from babel.messages.catalog_parser import parse_catalog
+from babel.messages.catalog_parser import parse_catalog, printErrors
 from babel.messages.block_utils import split_into_blocks
-import babel.messages.msg_parser as ps
-from babel.messages.parse_utils import get_str_kwargs, get_boolean_kwarg, get_int_kwarg, get_char_set
+from babel.messages.parse_utils import get_char_set
 
-def load_po(filename, **kwargs):
+import babel.messages.msg_parser as ps
+
+
+machine_language, machine_encoding = locale.getdefaultlocale()
+
+def load_po(filename: str,
+            debug: bool = False,
+            multiprocessing: bool = False,
+            hookexcept: bool = False,
+            batch_size_division: int = 2,
+            ignore_obsolete: bool = False,
+            abort_invalid: bool = True,
+            version=VERSION,
+            locale=machine_language,
+            charset=machine_encoding,
+            domain: str = 'message',
+            ):
     """
     Load and parse a PO (Portable Object) file into a Babel Catalog object.
 
-    This function performs the following steps:
-      1. Retrieves the machine's default locale and encoding.
-      2. Extracts various configuration options from the provided kwargs:
-         - Debug mode flag.
-         - Multiprocessing flag.
-         - Hook exception flag.
-         - Batch size division for processing.
-         - Flags for ignoring obsolete messages and aborting on invalid entries.
-         - Generator version, locale, charset, and domain for the catalog.
-      3. Creates a default catalog using these parameters.
-      4. Determines the charset of the PO file via the get_char_set function.
-      5. Reads and decodes the file content based on the detected charset.
-      6. Splits the file content into blocks for parsing.
-      7. Initializes the message parser with the pre-split blocks and configuration options.
-      8. Parses the catalog header from the blocks.
-      9. Sets the catalog version if not provided.
-     10. Assigns the catalog to the parser's global state.
-     11. Parses the individual messages, classifying obsolete messages separately.
-     12. Prints any encountered parsing errors to stderr.
-     13. Returns the populated Catalog object.
+    The function performs the following steps:
+      1. Creates a default catalog using the provided locale, domain, charset, and version.
+      2. Determines the charset of the PO file via the get_char_set function.
+      3. Opens and decodes the file content using the detected charset.
+      4. Splits the file content into blocks for parsing.
+      5. Initializes the message parser with the pre-split blocks and the specified configuration options.
+      6. Parses the catalog header from the blocks.
+      7. Sets the catalog version to the provided generator version if it is not already set.
+      8. Assigns the catalog to the parser’s global state.
+      9. Parses the individual messages and classifies obsolete messages separately.
+     10. Prints any encountered parsing errors to stderr.
+     11. Returns the populated Catalog object.
 
     Parameters:
         filename (str): Path to the PO file to be loaded.
-        **kwargs: Additional keyword arguments for configuration.
-            Recognized keys include:
-              - '-d' or 'debug': Enable debug mode (bool).
-              - '-m' or 'multiprocessing': Enable multiprocessing (bool).
-              - '-hk' or 'hookexcept': Enable hook exception handling (bool).
-              - '-bd' or 'batch_size_division': Set the batch size division (int).
-              - '-igob' or 'ignore_obsolete': Ignore obsolete messages (bool).
-              - '-abrt' or 'abort_invalid': Abort on invalid entries (bool).
-              - '-v' or 'version': Specify the generator version (str).
-              - '-l' or 'locale': Specify the catalog locale (str).
-              - '-chs' or 'charset': Specify the catalog charset (str).
-              - '-dom' or 'domain': Specify the catalog domain (str).
+        debug (bool, optional): Enable debug mode. Defaults to False.
+        multiprocessing (bool, optional): Enable multiprocessing support. Dividing message blocks into batches and run each batch in CPU cores concurrently. Defaults to False.
+        hookexcept (bool, optional): Enable hook exception handling to print out frame stacks or not. Defaults to False.
+        batch_size_division (int, optional): Division factor for batch processing. Reduce the amount of batches to reduce the process switching. Defaults to 2.
+        ignore_obsolete (bool, optional): Whether to ignore obsolete messages. Defaults to False.
+        abort_invalid (bool, optional): Abort parsing on encountering invalid entries. Defaults to True.
+        version (str, optional): Generator version to be used if the catalog version is not set. Defaults to VERSION.
+        locale (str, optional): Locale to be used for the catalog. Defaults to machine_language, ie. LANG=en_GB.UTF-8 in environment variables.
+        charset (str, optional): Charset for the catalog (used in Catalog creation). Defaults to machine_encoding, ie. using UTF-8 above.
+        domain (str, optional): Domain for the catalog. Defaults to 'message'.
 
     Returns:
         Catalog: A Babel Catalog object containing the parsed messages and metadata.
 
     Raises:
-        Exceptions from underlying parsing functions if the PO file content is invalid
-        or if keyword argument conversions fail.
+        Exception: Any exception raised by the underlying parsing functions if the PO file content is invalid
+                   or if parameter conversion fails.
     """
-    # Retrieve the machine's default language and encoding.
-    machine_language, machine_encoding = locale.getdefaultlocale()
-
-    # Extract boolean and integer configuration options from kwargs.
-    is_debug = get_boolean_kwarg(kwargs, ['-d', 'debug'], default=False)
-    is_multi_processing = get_boolean_kwarg(kwargs, ['-m', 'multiprocessing'], default=False)
-    is_hook_except = get_boolean_kwarg(kwargs, ['-hk', 'hookexcept'], default=False)
-    batch_size_division = get_int_kwarg(kwargs, ['-bd', 'batch_size_division'], default=2)
-    is_ignore_obsolete = get_boolean_kwarg(kwargs, ['-igob', 'ignore_obsolete'], default=True)
-    is_abort_on_invalid = get_boolean_kwarg(kwargs, ['-abrt', 'abort_invalid'], default=True)
-
-    # Extract string-based configuration options.
-    generator_version = get_str_kwargs(kwargs, ['-v', 'version'], default=VERSION)
-    cat_locale = get_str_kwargs(kwargs, ['-l', 'locale'], default=machine_language)
-    cat_charset = get_str_kwargs(kwargs, ['-chs', 'charset'], default=machine_encoding)
-    cat_domain = get_str_kwargs(kwargs, ['-dom', 'domain'], default='messages')
-
-    # Create a default catalog using the provided or default parameters.
-    default_catalog = Catalog(locale=cat_locale, domain=cat_domain, charset=cat_charset, version=generator_version)
+    # Create a default catalog using the provided parameters.
+    default_catalog = Catalog(locale=locale, domain=domain, charset=charset, version=version)
 
     # Determine the charset of the PO file content.
     charset = get_char_set(filename)
@@ -97,49 +85,44 @@ def load_po(filename, **kwargs):
     with open(filename, "rb") as f:
         file_content = f.read().decode(charset, errors="replace")
 
-    # Split the file content into blocks, which are used as units for parsing.
+    # Split the file content into blocks for parsing.
     blocks = split_into_blocks(file_content)
 
-    # Initialize the parser with the pre-split blocks and configuration options.
+    # Initialize the parser with the blocks and configuration options.
     ps.init_parser(
         blocks,
-        is_debug=is_debug,
-        is_multi_processing=is_multi_processing,
+        is_debug=debug,
+        is_multi_processing=multiprocessing,
         batch_size_division=batch_size_division,
-        is_hook_except=is_hook_except,
-        abort_on_invalid=is_abort_on_invalid,
-        ignore_obsolete=is_ignore_obsolete,
+        is_hook_except=hookexcept,
+        abort_on_invalid=abort_invalid,
+        ignore_obsolete=ignore_obsolete,
     )
 
-    # Parse the catalog header from the blocks using the default catalog.
+    # Parse the catalog header from the blocks.
     catalog = parse_catalog(blocks, default_catalog)
 
-    # If the catalog version is not set or is empty, use the generator version.
-    is_using_custom_generated_catalog_version = (catalog.version is None) or (len(catalog.version) == 0)
-    if is_using_custom_generated_catalog_version:
-        catalog.version = generator_version
+    # Set the catalog version to the generator version if it is not already set.
+    if (catalog.version is None) or (len(catalog.version) == 0):
+        catalog.version = version
 
     # Set the global catalog for the message parser.
     ps.CATALOG = catalog
 
-    # Parse the individual messages from the blocks and collect any errors.
+    # Parse the individual messages and collect errors.
     messages, errors = ps.parse()
 
-    # Store parsed messages in the catalog. Obsolete messages are kept separately.
-    for msg in messages[1:]:
+    # Store parsed messages in the catalog; classify obsolete messages separately.
+    for msg in messages:
         is_obsolete = getattr(msg, 'obsolete', False)
         if is_obsolete:
             catalog.obsolete[msg.id] = msg
         else:
             catalog[msg.id] = msg
 
-    # If there are errors, remove duplicates and print them to stderr.
-    if errors:
-        errors = list(set(errors))
-        print("Errors encountered:", file=sys.stderr)
-        for err in errors:
-            print(err, file=sys.stderr)
+    # If any errors were encountered, print them to stderr.
+    printErrors()
 
-    # Return the populated catalog.
     return catalog
+
 

--- a/babel/messages/poparse.py
+++ b/babel/messages/poparse.py
@@ -5,7 +5,7 @@ babel.messages.poparse
 Reading and writing of files in the ``gettext`` PO (portable object)
 format.
 
-:copyright: (c) 2013-2024 by the Babel Team.
+:copyright: (c) 2025 by the Babel Team.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/babel/messages/poparse.py
+++ b/babel/messages/poparse.py
@@ -84,7 +84,7 @@ def load_po(filename, **kwargs):
     # Extract string-based configuration options.
     generator_version = get_str_kwargs(kwargs, ['-v', 'version'], default=VERSION)
     cat_locale = get_str_kwargs(kwargs, ['-l', 'locale'], default=machine_language)
-    cat_charset = get_str_kwargs(kwargs, ['-chs', 'charset'], default=machine_encoding)
+    cat_charset = get_str_kwargs(kwargs, ['-chs', '-enc', 'charset', 'encoding'], default=machine_encoding)
     cat_domain = get_str_kwargs(kwargs, ['-dom', 'domain'], default='messages')
 
     # Create a default catalog using the provided or default parameters.


### PR DESCRIPTION
maintenance and also speed up the parsing using multiprocessing option, including debugging, abort if invalid in multiprocessing as well as in linear processing mode, plus custom hook to system's exception handling to not show the frame stacks tracing. Note the number of batches is based on the number of batches = (CPU cores  - 2) / batch division reduction. The speed for 10.8MB PO file loading just takes about 1.7seconds in multi-processing mode
Using 11 batch(es) (cpu_count: 24)
number of batches: 11, batch_size: 3222
1.623452367
Execution of run took 0:00:01.62.