### PR TITLE
Use standard library `timezone` instead of `FixedOffsetTimezone`

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -23,7 +23,7 @@ from babel import __version__ as VERSION
 from babel.core import Locale, UnknownLocaleError
 from babel.dates import format_datetime
 from babel.messages.plurals import get_plural
-from babel.util import LOCALTZ, FixedOffsetTimezone, _cmp, distinct
+from babel.util import LOCALTZ, _cmp, distinct
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -118,7 +118,10 @@ def _parse_datetime_header(value: str) -> datetime.datetime:
         net_mins_offset *= plus_minus
 
         # Create an offset object
-        tzoffset = FixedOffsetTimezone(net_mins_offset)
+        tzoffset = datetime.timezone(
+            offset=datetime.timedelta(minutes=net_mins_offset),
+            name=f'Etc/GMT{net_mins_offset:+d}',
+        )
 
         # Store the offset in a datetime object
         dt = dt.replace(tzinfo=tzoffset)

--- a/babel/util.py
+++ b/babel/util.py
@@ -255,10 +255,20 @@ odict = dict
 
 
 class FixedOffsetTimezone(datetime.tzinfo):
-    """Fixed offset in minutes east from UTC."""
+    """
+    Fixed offset in minutes east from UTC.
+
+    DEPRECATED: Use the standard library `datetime.timezone` instead.
+    """
+    # TODO (Babel 3.x): Remove this class
 
     def __init__(self, offset: float, name: str | None = None) -> None:
-
+        warnings.warn(
+            "`FixedOffsetTimezone` is deprecated and will be removed in a future version of Babel. "
+            "Use the standard library `datetime.timezone` class.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._offset = datetime.timedelta(minutes=offset)
         if name is None:
             name = 'Etc/GMT%+d' % offset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,7 @@ markers = [
 ]
 filterwarnings = [
     # The doctest for format_number would raise this, but we don't really want to see it.
-    "ignore:babel.numbers.format_decimal:DeprecationWarning"
+    "ignore:babel.numbers.format_decimal:DeprecationWarning",
+    # FixedOffsetTimezone is still being tested, but we don't want to see the deprecation warning.
+    "ignore:.*FixedOffsetTimezone:DeprecationWarning",
 ]


### PR DESCRIPTION
Noticed `FixedOffsetTimezone`s didn't unpickle, and then realized we shouldn't use them at all.