### PR TITLE
Use CLDR 47

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1162,7 +1162,7 @@ def get_period_id(
     'midnight'
 
     >>> get_period_id(time(0), type="selection", locale="en_US")
-    'night1'
+    'morning1'
 
     :param time: The time to inspect.
     :param tzinfo: The timezone for the time. See ``format_time``.

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -9,10 +9,10 @@ import sys
 import zipfile
 from urllib.request import urlretrieve
 
-URL = 'https://unicode.org/Public/cldr/46/cldr-common-46.0.zip'
-FILENAME = 'cldr-common-46.0.zip'
+URL = 'https://unicode.org/Public/cldr/47/cldr-common-47.zip'
+FILENAME = 'cldr-common-47.0.zip'
 # Via https://unicode.org/Public/cldr/45/hashes/SHASUM512.txt
-FILESUM = '316d644b79a4976d4da57d59ca57c689b339908fe61bb49110bfe1a9269c94144cb27322a0ea080398e6dc4c54a16752fd1ca837e14c054b3a6806b1ef9d3ec3'
+FILESUM = '3b1eb2a046dae23cf16f611f452833e2a95affb1aa2ae3fa599753d229d152577114c2ff44ca98a7f369fa41dc6f45b0d7a6647653ca79694aacfd3f3be59801'
 BLKSIZE = 131072
 
 

--- a/tests/test_day_periods.py
+++ b/tests/test_day_periods.py
@@ -11,7 +11,7 @@ import babel.dates as dates
     ("fi", time(0), "midnight"),  # (at)
     ("en_US", time(12), "noon"),  # (at)
     ("en_US", time(21), "night1"),  # (from, before) across 0:00
-    ("en_US", time(5), "night1"),  # (from, before) across 0:00
+    ("en_US", time(5), "morning1"),  # (from, before) across 0:00
     ("en_US", time(6), "morning1"),  # (from, before)
     ("agq", time(10), "am"),  # no periods defined
     ("agq", time(22), "pm"),  # no periods defined


### PR DESCRIPTION
[CLDR 47](https://cldr.unicode.org/downloads/cldr-47) has been released.

Looking at the changes (which also include [46.1](https://cldr.unicode.org/downloads/cldr-46#461-changes)) there doesn't seem to be anything that requires changes on our side (but another pair of eyes would be helpful!)

More interesting are the upcoming changes in [v48](https://cldr.unicode.org/downloads/cldr-47#v48-advance-warnings) which might necessitate changes on our side, especially the part about `supplementalData.xml` and `supplementalMetadata.xml`:

> This will make it easier for implementations to filter out data that they don’t need, and make internal maintenance easier. This will not affect the data: just which file it is located in. Please plan to update XML and JSON parsers accordingly.