### PR TITLE
Fix parsing of xgettext plural forms headers

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -557,7 +557,10 @@ class Catalog:
                     self.charset = params['charset'].lower()
             elif name == 'plural-forms':
                 params = parse_separated_header(f" ;{value}")
-                self._num_plurals = int(params.get('nplurals', 2))
+                try:
+                    self._num_plurals = int(params.get('nplurals', 2))
+                except ValueError:
+                    self._num_plurals = 2
                 self._plural_expr = params.get('plural', '(n != 1)')
             elif name == 'pot-creation-date':
                 self.creation_date = _parse_datetime_header(value)

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -98,6 +98,17 @@ msgstr ""''')
             "mightbutshouldnt throw us into an infinite loop\n"
         )
 
+    def test_xgettext_plural_forms_header(self):
+        """Test that xgettext-style plural forms headers with placeholders work."""
+        buf = StringIO(r'''msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "foo"
+msgstr "bar"''')
+        catalog = pofile.read_po(buf)
+        assert len(catalog) == 1
+        assert catalog.num_plurals == 2  # Should fall back to default
     def test_fuzzy_header(self):
         buf = StringIO(r'''
 # Translations template for AReallyReallyLongNameForAProject.


### PR DESCRIPTION
Fixes #1154 <!-- Needed for GitHub to link the issue to the PR -->

## Fix parsing of xgettext plural forms headers
This change fixes parsing of POT files with plural forms headers generated by `xgettext`, which uses all-caps placeholders (`INTEGER`, `EXPRESSION`). The parser now gracefully handles invalid `nplurals` values by falling back to a default of 2. 

- Added error handling for `ValueError` when parsing `nplurals`
- Included a test case for xgettext-style plural forms headers
- Maintains backward compatibility with properly formatted files

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci9jNjVjOTkzMTk4YjkwN2Q0ZTY0N2IzYzM2ZTNiOTI2YS9yYXcvc3dlYmVuY2hfcHl0aG9uLWJhYmVsX19iYWJlbC0xMTU0Lmpzb24&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL3B5dGhvbi1iYWJlbC9iYWJlbC9wdWxsLzEyMTU) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/python-babel/babel/pull/1215&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/python-babel/babel&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/python-babel/babel/pull/1215&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/python-babel/babel/pull/1215) 📬.