### PR TITLE
Extract parametrized gettext from javascript files

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -917,10 +917,12 @@ def parse_template_string(
         if level:
             expression_contents += character
         if not inside_str:
-            if character == '{' and prev_character == '$':
+            # start of `${...}` interpolation, or a nested `{` already inside one
+            if character == '{' and (level or prev_character == '$'):
                 level += 1
             elif level and character == '}':
                 level -= 1
+                # end of template string
                 if level == 0 and expression_contents:
                     expression_contents = expression_contents[0:-1]
                     fake_file_obj = io.BytesIO(expression_contents.encode())

--- a/tests/messages/test_js_extract.py
+++ b/tests/messages/test_js_extract.py
@@ -191,3 +191,21 @@ def test_inside_nested_template_string():
     )
 
     assert messages == [(1, 'Greetings!', [], None), (1, 'This is a lovely evening.', [], None), (1, 'The day is really nice!', [], None)]
+
+
+def test_template_string_with_parameters() -> None:
+    buf = BytesIO(
+        b'`${gettext("text %(param)s", { param: myVar })}`;',
+    )
+    messages = list(extract.extract("javascript", buf, {"gettext": None}, [], {"parse_template_string": True}))
+    assert messages == [
+        (1, "text %(param)s", [], None),
+    ]
+
+
+def test_template_string_with_literal_braces() -> None:
+    buf = BytesIO(
+        b'hello(`there is {nothing} to worry about`);',
+    )
+    messages = list(extract.extract("javascript", buf, {"gettext": None}, [], {"parse_template_string": True}))
+    assert messages == []


### PR DESCRIPTION
Hello,
I prepared PR which allows extraction of translations from JS files that use gettext function with parameters.

Usually code that uses parametrized translations looks like this:
```js
gettext("Hello %(user)s", {user: userName})
```
which works (gets extracted) but problem is with template-strings:
```js
`${gettext("Hello %(user)s", {user: userName})}`
```
It probably got confused with the curly braces for object initialization and thinks that end of object initialization is end of whole template-string (which is not true - there are 3 more chars). Later this incomplete template string get parsed as JS code again and ends up as incomplete/invalid and the translation is not extracted at all.

My fix is simply marking all `{` as start of "nesting" which allows extraction of non-nested template-strings.

I tried to support also nested template-strings but didn't get it to work at all... it needs a bit more complicated parser than just regex and I guess nobody use that atm as I don't see any issue about it.

Hope you find it usefull.
Thanks for review and possibly merge 😉 