### PR TITLE
Implement long/narrow -> short fallback in babel.units

### DIFF
--- a/babel/units.py
+++ b/babel/units.py
@@ -156,9 +156,7 @@ def format_unit(
     # so these aliases specified in `root.xml` are hard-coded here:
     # <unitLength type="long"><alias source="locale" path="../unitLength[@type='short']"/></unitLength>
     # <unitLength type="narrow"><alias source="locale" path="../unitLength[@type='short']"/></unitLength>
-    lengths_to_check = [length]
-    if length in ("long", "narrow"):
-        lengths_to_check.append("short")
+    lengths_to_check = [length, "short"] if length in ("long", "narrow") else [length]
 
     for real_length in lengths_to_check:
         length_patterns = unit_patterns.get(real_length, {})

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -17,3 +17,15 @@ from babel.units import format_unit
 ])
 def test_new_cldr46_units(unit, count, expected):
     assert format_unit(count, unit, locale='cs_CZ') == expected
+
+
+@pytest.mark.parametrize('count, unit, locale, length, expected', [
+    (1, 'duration-month', 'et', 'long', '1 kuu'),
+    (1, 'duration-minute', 'et', 'narrow', '1 min'),
+    (2, 'duration-minute', 'et', 'narrow', '2 min'),
+    (2, 'digital-byte', 'et', 'long', '2 baiti'),
+    (1, 'duration-day', 'it', 'long', '1 giorno'),
+    (1, 'duration-day', 'it', 'short', '1 giorno'),
+])
+def test_issue_1217(count, unit, locale, length, expected):
+    assert format_unit(count, unit, length, locale=locale) == expected


### PR DESCRIPTION
Also implemented fallback from the correct pluralization to "other", which was also missing.

Fixes #1217.