### PR TITLE
Update keywords for extraction of dpgettext and dnpgettext

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -88,9 +88,11 @@ DEFAULT_KEYWORDS: dict[str, _Keyword] = {
     'ungettext': (1, 2),
     'dgettext': (2,),
     'dngettext': (2, 3),
+    'dpgettext': ((2, 'c'), 3),
     'N_': None,
     'pgettext': ((1, 'c'), 2),
     'npgettext': ((1, 'c'), 2, 3),
+    'dnpgettext': ((2, 'c'), 3, 4),
 }
 
 DEFAULT_MAPPING: list[tuple[str, str]] = [('**.py', 'python')]

--- a/tests/messages/frontend/test_frontend.py
+++ b/tests/messages/frontend/test_frontend.py
@@ -218,6 +218,7 @@ def test_extract_keyword_args_384(split, arg_name):
     )
     assert isinstance(cmdinst, ExtractMessages)
     assert set(cmdinst.keywords.keys()) == {'_', 'dgettext', 'dngettext',
+                                            'dnpgettext', 'dpgettext',
                                             'gettext', 'gettext_lazy',
                                             'gettext_noop', 'N_', 'ngettext',
                                             'ngettext_lazy', 'npgettext',

--- a/tests/messages/test_extract_python.py
+++ b/tests/messages/test_extract_python.py
@@ -145,6 +145,27 @@ msg2 = ngettext('elvis',
     ]
 
 
+def test_dpgettext():
+    buf = BytesIO(b"""\
+msg1 = dpgettext('dev', 'Strings',
+             'pylon')
+msg2 = dpgettext('dev', 'Strings', 'elvis')
+""")
+    messages = list(extract.extract_python(buf, ('dpgettext',), [], {}))
+    assert messages == [
+        (1, 'dpgettext', ('dev', 'Strings', 'pylon'), []),
+        (3, 'dpgettext', ('dev', 'Strings', 'elvis'), []),
+    ]
+    buf = BytesIO(b"""\
+msg = dpgettext('dev', 'Strings', 'pylon',  # TRANSLATORS: shouldn't be
+            )                # TRANSLATORS: seeing this
+""")
+    messages = list(extract.extract_python(buf, ('dpgettext',),['TRANSLATORS:'], {}))
+    assert messages == [
+        (1, 'dpgettext', ('dev', 'Strings', 'pylon', None), []),
+    ]
+
+
 def test_npgettext():
     buf = BytesIO(b"""\
 msg1 = npgettext('Strings','pylon',
@@ -167,6 +188,30 @@ msg = npgettext('Strings', 'pylon',  # TRANSLATORS: shouldn't be
                                            ['TRANSLATORS:'], {}))
     assert messages == [
         (1, 'npgettext', ('Strings', 'pylon', 'pylons', None), []),
+    ]
+
+
+def test_dnpgettext():
+    buf = BytesIO(b"""\
+msg1 = dnpgettext('dev', 'Strings','pylon',
+            'pylons', count)
+msg2 = dnpgettext('dev', 'Strings','elvis',
+            'elvises',
+             count)
+""")
+    messages = list(extract.extract_python(buf, ('dnpgettext',), [], {}))
+    assert messages == [
+        (1, 'dnpgettext', ('dev', 'Strings', 'pylon', 'pylons', None), []),
+        (3, 'dnpgettext', ('dev', 'Strings', 'elvis', 'elvises', None), []),
+    ]
+    buf = BytesIO(b"""\
+msg = dnpgettext('dev', 'Strings', 'pylon',  # TRANSLATORS: shouldn't be
+             'pylons', # TRANSLATORS: seeing this
+             count)
+""")
+    messages = list(extract.extract_python(buf, ('dnpgettext',),['TRANSLATORS:'], {}))
+    assert messages == [
+        (1, 'dnpgettext', ('dev', 'Strings', 'pylon', 'pylons', None), []),
     ]
 
 


### PR DESCRIPTION
At the moment, the localization methods dpgettext and dnpgettext are not properly handled by extract command.

It raises KeyError exception.

except if you pass explicitly `--keyword dpgettext:2c,3 --keyword dnpgettext:2c,3,4`

This MR fixed the issue by declaring the default position parameter of those methods.


Traceback raised:

```bash
$ uv run pybabel extract -F tests/functionals/i18n/babel.ini --input-dirs tests/functionals/ -o tests/functionals/i18n/mydomain.pot
extracting messages from tests/functionals/i18n/test_l10n.py (encoding="utf-8")
Traceback (most recent call last):
  File "/home/guillaume/workspace/git/xcomponent/.venv/bin/pybabel", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/frontend.py", line 998, in main
    return CommandLineInterface().run(sys.argv)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/frontend.py", line 924, in run
    return cmdinst.run()
           ~~~~~~~~~~~^^
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/frontend.py", line 522, in run
    for filename, lineno, message, comments, context in extracted:
                                                        ^^^^^^^^^
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/extract.py", line 217, in extract_from_dir
    yield from check_and_call_extract_file(
    ...<8 lines>...
    )
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/extract.py", line 282, in check_and_call_extract_file
    for message_tuple in extract_from_file(
                         ~~~~~~~~~~~~~~~~~^
        method, filepath,
        ^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        strip_comment_tags=strip_comment_tags,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/extract.py", line 324, in extract_from_file
    return list(extract(method, fileobj, keywords, comment_tags,
                        options, strip_comment_tags))
  File "/home/guillaume/workspace/git/xcomponent/.venv/lib/python3.13/site-packages/babel/messages/extract.py", line 457, in extract
    specs = keywords[funcname] or None if funcname else None
            ~~~~~~~~^^^^^^^^^^
KeyError: 'dpgettext'
```
