### PR TITLE
Declare the major CLDR version used

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -30,6 +30,8 @@ _dirname = os.path.join(os.path.dirname(__file__), 'locale-data')
 _windows_reserved_name_re = re.compile("^(con|prn|aux|nul|com[0-9]|lpt[0-9])$", re.I)
 
 
+CLDR_MAJOR_VERSION=47
+
 def normalize_locale(name: str) -> str | None:
     """Normalize a locale ID by stripping spaces and apply proper casing.
 

--- a/scripts/download_import_cldr.py
+++ b/scripts/download_import_cldr.py
@@ -9,8 +9,10 @@ import sys
 import zipfile
 from urllib.request import urlretrieve
 
-URL = 'https://unicode.org/Public/cldr/47/cldr-common-47.zip'
-FILENAME = 'cldr-common-47.0.zip'
+from babel.localedata import CLDR_MAJOR_VERSION
+
+URL = f'https://unicode.org/Public/cldr/{CLDR_MAJOR_VERSION}/cldr-common-{CLDR_MAJOR_VERSION}.zip'
+FILENAME = f'cldr-common-{CLDR_MAJOR_VERSION}.0.zip'
 # Via https://unicode.org/Public/cldr/45/hashes/SHASUM512.txt
 FILESUM = '3b1eb2a046dae23cf16f611f452833e2a95affb1aa2ae3fa599753d229d152577114c2ff44ca98a7f369fa41dc6f45b0d7a6647653ca79694aacfd3f3be59801'
 BLKSIZE = 131072


### PR DESCRIPTION
This fixes (is a first stab at) https://github.com/python-babel/babel/issues/1237