### PR TITLE
Add `babel.core.get_cldr_version()`

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -22,6 +22,7 @@ __all__ = [
     'Locale',
     'UnknownLocaleError',
     'default_locale',
+    'get_cldr_version',
     'get_global',
     'get_locale_identifier',
     'negotiate_locale',
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
 
     _GLOBAL_KEY: TypeAlias = Literal[
         "all_currencies",
+        "cldr",
         "currency_fractions",
         "language_aliases",
         "likely_subtags",
@@ -80,6 +82,7 @@ def get_global(key: _GLOBAL_KEY) -> Mapping[str, Any]:
     The keys available are:
 
     - ``all_currencies``
+    - ``cldr`` (metadata)
     - ``currency_fractions``
     - ``language_aliases``
     - ``likely_subtags``
@@ -1363,3 +1366,19 @@ def get_locale_identifier(
     lang, territory, script, variant, modifier = tup + (None,) * (5 - len(tup))
     ret = sep.join(filter(None, (lang, script, territory, variant)))
     return f'{ret}@{modifier}' if modifier else ret
+
+
+def get_cldr_version() -> str:
+    """Return the Unicode CLDR version used by this Babel installation.
+
+    Generally, you should be able to assume that the return value of this
+    function is a string representing a version number, e.g. '47'.
+
+    >>> get_cldr_version()
+    '47'
+
+    .. versionadded:: 2.18
+
+    :rtype: str
+    """
+    return str(get_global("cldr")["version"])

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -36,3 +36,5 @@ Utility Functions
 .. autofunction:: parse_locale
 
 .. autofunction:: get_locale_identifier
+
+.. autofunction:: get_cldr_version

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -206,6 +206,19 @@ def process_data(srcdir, destdir, force=False, dump_json=False):
 
 def parse_global(srcdir, sup):
     global_data = {}
+
+    with open(os.path.join(srcdir, 'dtd', 'ldml.dtd')) as dtd_file:
+        cldr_version_match = re.search(
+            r'<!ATTLIST version cldrVersion CDATA #FIXED "(.+?)"',
+            dtd_file.read(),
+        )
+        if not cldr_version_match:
+            raise ValueError("Could not find CLDR version in DTD file")
+        cldr_version = cldr_version_match.group(1)
+        global_data.setdefault('cldr', {})['version'] = cldr_version
+
+    log.info('Processing CLDR version %s from %s', cldr_version, srcdir)
+
     sup_dir = os.path.join(srcdir, 'supplemental')
     territory_zones = global_data.setdefault('territory_zones', {})
     zone_aliases = global_data.setdefault('zone_aliases', {})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -402,3 +402,7 @@ def test_locale_parse_empty():
         Locale.parse(None)
     with pytest.raises(TypeError, match="Empty"):
         Locale.parse(False)  # weird...!
+
+
+def test_get_cldr_version():
+    assert core.get_cldr_version() == "47"


### PR DESCRIPTION
Fixes #1237

Closes #1238 (supersedes it)