### PR TITLE
Extract: Merge in per-format keywords and auto_comments

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -316,13 +316,31 @@ def check_and_call_extract_file(
             if pathmatch(opattern, filename):
                 options = odict
                 break
+
+        # Merge keywords and comment_tags from per-format options if present.
+        file_keywords = keywords
+        file_comment_tags = comment_tags
+        if keywords_opt := options.get("keywords"):
+            if not isinstance(keywords_opt, dict):  # pragma: no cover
+                raise TypeError(
+                    f"The `keywords` option must be a dict of parsed keywords, not {keywords_opt!r}",
+                )
+            file_keywords = {**keywords, **keywords_opt}
+
+        if comments_opt := options.get("add_comments"):
+            if not isinstance(comments_opt, (list, tuple, set)):  # pragma: no cover
+                raise TypeError(
+                    f"The `add_comments` option must be a collection of comment tags, not {comments_opt!r}.",
+                )
+            file_comment_tags = tuple(set(comment_tags) | set(comments_opt))
+
         if callback:
             callback(filename, method, options)
         for message_tuple in extract_from_file(
             method,
             filepath,
-            keywords=keywords,
-            comment_tags=comment_tags,
+            keywords=file_keywords,
+            comment_tags=file_comment_tags,
             options=options,
             strip_comment_tags=strip_comment_tags,
         ):

--- a/tests/messages/data/mapping_with_keywords.cfg
+++ b/tests/messages/data/mapping_with_keywords.cfg
@@ -1,0 +1,5 @@
+# Test mapping file with keywords option (issue #1224)
+
+[python: **.py]
+encoding = utf-8
+keywords = _ _l _n:1,2 _nl:1,2 _p:1c,2 _pl:1c,2 _np:1c,2,3 _npl:1c,2,3

--- a/tests/messages/data/mapping_with_keywords_and_comments.toml
+++ b/tests/messages/data/mapping_with_keywords_and_comments.toml
@@ -1,0 +1,8 @@
+# Test mapping file with keywords and add_comments options (issue #1224)
+
+[[mappings]]
+method = "python"
+pattern = "**.py"
+encoding = "utf-8"
+keywords = ["_", "_l", "_n:1,2"]
+add_comments = ["SPECIAL:"]

--- a/tests/messages/data/project/issue_1224_test.py
+++ b/tests/messages/data/project/issue_1224_test.py
@@ -1,0 +1,12 @@
+from myproject.i18n import lazy_gettext as _l, lazy_ngettext as _n
+
+
+class Choices:
+    # SPECIAL: This comment should be extracted
+    CHOICE_X = 1, _l("Choice X")
+    # SPECIAL: Another special comment
+    CHOICE_Y = 2, _l("Choice Y")
+    # No comment...
+    OPTION_C = 3, _l("Option C")
+    # Test for _n too! (but no comment... shush...)
+    OPTION_A = 4, (_n("Option A", "Options of the A kind", 1))

--- a/tests/messages/test_toml_config.py
+++ b/tests/messages/test_toml_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from io import BytesIO
 
@@ -9,19 +11,64 @@ toml_test_cases_path = pathlib.Path(__file__).parent / "toml-test-cases"
 assert toml_test_cases_path.is_dir(), "toml-test-cases directory not found"
 
 
+def parse_toml(cfg: bytes | str):
+    if isinstance(cfg, str):
+        cfg = cfg.encode("utf-8")
+    return frontend._parse_mapping_toml(BytesIO(cfg))
+
+
 def test_toml_mapping_multiple_patterns():
     """
     Test that patterns may be specified as a list in TOML,
     and are expanded to multiple entries in the method map.
     """
-    method_map, options_map = frontend._parse_mapping_toml(BytesIO(b"""
+    method_map, options_map = parse_toml("""
 [[mappings]]
 method = "python"
 pattern = ["xyz/**.py", "foo/**.py"]
-"""))
-    assert len(method_map) == 2
-    assert method_map[0] == ('xyz/**.py', 'python')
-    assert method_map[1] == ('foo/**.py', 'python')
+""")
+    assert method_map == [
+        ('xyz/**.py', 'python'),
+        ('foo/**.py', 'python'),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("keywords_val", "expected"),
+    [
+        pytest.param('"foo bar quz"', {'bar': None, 'foo': None, 'quz': None}, id='string'),
+        pytest.param('["foo", "bar", "quz"]', {'bar': None, 'foo': None, 'quz': None}, id='list'),
+        pytest.param('"foo:1,2 bar quz"', {'bar': None, 'foo': (1, 2), 'quz': None}, id='s-args'),
+        pytest.param('["bar", "foo:1,2", "quz"]', {'bar': None, 'foo': (1, 2), 'quz': None}, id='l-args'),
+        pytest.param('[]', None, id='empty'),
+    ],
+)
+def test_toml_mapping_keywords_parsing(keywords_val, expected):
+    method_map, options_map = parse_toml(f"""
+[[mappings]]
+method = "python"
+pattern = ["**.py"]
+keywords = {keywords_val}
+""")
+    assert options_map['**.py'].get('keywords') == expected
+
+
+@pytest.mark.parametrize(
+    ("add_comments_val", "expected"),
+    [
+        ('"SPECIAL SAUCE"', ['SPECIAL SAUCE']),  # TOML will allow this as a single string
+        ('["SPECIAL", "SAUCE"]', ['SPECIAL', 'SAUCE']),
+        ('[]', None),
+    ],
+)
+def test_toml_mapping_add_comments_parsing(add_comments_val, expected):
+    method_map, options_map = parse_toml(f"""
+[[mappings]]
+method = "python"
+pattern = ["**.py"]
+add_comments = {add_comments_val}
+""")
+    assert options_map['**.py'].get('add_comments') == expected
 
 
 @pytest.mark.parametrize("test_case", toml_test_cases_path.glob("bad.*.toml"), ids=lambda p: p.name)


### PR DESCRIPTION
This PR adds support for adding additional per-extractor keywords in addition to the default set.

Fixes #1224
Fixes #71 (yes, you read that right, a double-digit issue that had still been open)