### PR TITLE
Remove double newline at EOF of po files

### DIFF
--- a/tests/messages/frontend/test_cli.py
+++ b/tests/messages/frontend/test_cli.py
@@ -164,7 +164,6 @@ msgid "FooBar"
 msgid_plural "FooBars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 
@@ -213,7 +212,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 
@@ -260,7 +258,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 
@@ -308,7 +305,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     with open(po_file) as f:
         actual_content = f.read()
@@ -357,7 +353,6 @@ msgstr ""
 msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
-
 """
     with open(po_file) as f:
         actual_content = f.read()
@@ -409,7 +404,6 @@ msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
 """
     with open(po_file) as f:
         actual_content = f.read()

--- a/tests/messages/frontend/test_extract.py
+++ b/tests/messages/frontend/test_extract.py
@@ -148,7 +148,6 @@ msgid "FooBar"
 msgid_plural "FooBars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 
@@ -196,7 +195,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 
@@ -250,7 +248,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 
@@ -278,7 +275,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     assert expected_content == pot_file.read_text()
 

--- a/tests/messages/frontend/test_init.py
+++ b/tests/messages/frontend/test_init.py
@@ -101,7 +101,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     with open(get_po_file_path('en_US')) as f:
         actual_content = f.read()
@@ -150,7 +149,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     with open(get_po_file_path('en_US')) as f:
         actual_content = f.read()
@@ -201,7 +199,6 @@ msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
 """
     with open(get_po_file_path('lv_LV')) as f:
         actual_content = f.read()
@@ -249,7 +246,6 @@ msgstr ""
 msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
-
 """
     with open(get_po_file_path('ja_JP')) as f:
         actual_content = f.read()
@@ -307,7 +303,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     with open(get_po_file_path('en_US')) as f:
         actual_content = f.read()
@@ -364,7 +359,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """
     with open(get_po_file_path('en_US')) as f:
         actual_content = f.read()

--- a/tests/messages/test_checkers.py
+++ b/tests/messages/test_checkers.py
@@ -68,7 +68,6 @@ msgstr ""
 msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
-
 """).encode('utf-8')
 
         # This test will fail for revisions <= 406 because so far
@@ -130,7 +129,6 @@ msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
 """.encode('utf-8')
         # we should be adding the missing msgstr[0]
 
@@ -177,7 +175,6 @@ msgid "foobar"
 msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
-
 """.encode('utf-8')
 
         # This test will fail for revisions <= 406 because so far
@@ -225,7 +222,6 @@ msgid_plural "foobars"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
 """.encode('utf-8')
 
         # This test will fail for revisions <= 406 because so far
@@ -274,7 +270,6 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
-
 """.encode('utf-8')
 
         # This test will fail for revisions <= 406 because so far
@@ -324,7 +319,6 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
-
 """.encode('utf-8')
 
         # This test will fail for revisions <= 406 because so far

--- a/tests/messages/test_pofile_read.py
+++ b/tests/messages/test_pofile_read.py
@@ -363,7 +363,6 @@ msgstr "Bahr"
 #~ msgctxt "orange"
 #~ msgid "foo"
 #~ msgstr "Bar"
-
 ''')
     generated_po_file = ''.join(pofile.generate_po(pofile.read_po(buf), omit_header=True))
     assert buf.getvalue() == generated_po_file

--- a/tests/messages/test_pofile_write.py
+++ b/tests/messages/test_pofile_write.py
@@ -136,7 +136,6 @@ def test_no_wrap_and_width_behaviour_on_comments():
 #: fake.py:29
 msgid "pretty dam long message id, which must really be big to test this wrap behaviour, if not it won't work."
 msgstr ""
-
 """
     buf = BytesIO()
     pofile.write_po(buf, catalog, width=100, omit_header=True)
@@ -149,7 +148,6 @@ msgid ""
 "pretty dam long message id, which must really be big to test this wrap behaviour, if not it won't"
 " work."
 msgstr ""
-
 """
 
 


### PR DESCRIPTION
Hello !

This is my first PR, so I'm not fully sure about everything. I used the unit tests to check for regressions, but are there other untested edge-cases we should worry about ?

Fixes #799 