### PR TITLE
Cache validity of a locale name

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -60,6 +60,7 @@ def resolve_locale_filename(name: os.PathLike[str] | str) -> str:
     return os.path.join(_dirname, f"{name}.dat")
 
 
+@lru_cache(maxsize=None)
 def exists(name: str) -> bool:
     """Check whether locale data is available for the given locale.
 
@@ -72,7 +73,7 @@ def exists(name: str) -> bool:
     if name in _cache:
         return True
     file_found = os.path.exists(resolve_locale_filename(name))
-    return True if file_found else bool(normalize_locale(name))
+    return file_found or bool(normalize_locale(name))
 
 
 @lru_cache(maxsize=None)

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -109,10 +109,10 @@ def test_locale_argument_acceptance():
     assert normalized_locale is None
     assert not localedata.exists(None)
 
-    # Testing list input.
+    # Testing tuple input.
     normalized_locale = localedata.normalize_locale(['en_us', None])
     assert normalized_locale is None
-    assert not localedata.exists(['en_us', None])
+    assert not localedata.exists(('en_us', None))
 
 
 def test_locale_identifiers_cache(monkeypatch):


### PR DESCRIPTION
Currently `_cache` is only populated on `load`, this is an issue with code which do a lot of locale parsing / instantiation but for one reason or an other rarely end up needing to actually load the locale data (e.g. date formatting with non-locale-dependent patterns) because every cache miss is an `os.path.exists`.

This change takes advantage of semantics differences between `exists` and `load`: `exists` just needs the entry to exist in the cache, while `load` needs the entry to be truthy. Thus `exists` can cache its lookup by setting an empty dict (or even `None` but that seems a bit too dodgy).

Alternatively we could remove the `os.path.exists` "slow path" and call `normalize_locale` every time, as `locale_identifiers` gets cached on first call, the initial call would be a lot more expensive but then no further `exists` would need to touch the filesystem.

For a third alternative, `exists` could be decorated with `functools.cache`, in order to have its own cache completely independent of `load`. `load` could also be migrated to `functools.cache` as, as far as I can tell, the `localedata._cache` is never invalidated anyway, with the drawback that a locale's data might be resolved multiple times if concurrent calls are tight enough (`functools.cache` synchronises the cache but not the resolution of the value).