### PR TITLE
Repair Python 3.9 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,11 @@ envlist =
 [testenv]
 extras =
     dev
-deps = {env:BABEL_TOX_EXTRA_DEPS:}
+deps =
+    # On Python 3.9, we need a version of Setuptools that still has pkg_resources
+    # to be able to run the Jinja extractor tests.
+    py39: setuptools<82
+    {env:BABEL_TOX_EXTRA_DEPS:}
 allowlist_externals = make
 commands = make clean-cldr test
 setenv =


### PR DESCRIPTION
[Setuptools 82 removes pkg_resources](https://github.com/pypa/setuptools/issues/5174), which we need on Pythons older than 3.10 (see https://github.com/python-babel/babel/pull/1102) to load extractor entrypoints.

This pins Setuptools on Python 3.9 to < 82.

End users on Python 3.9 (which is EOL as of 31 Oct 2025 anyway) will need to deal with this in their downstream package pins if they need extractor support.