### PR TITLE
Handle blank PO-Revision-Date and POT-Creation-Date headers

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -582,10 +582,11 @@ class Catalog:
                 self._num_plurals = int(params.get('nplurals', 2))
                 self._plural_expr = params.get('plural', '(n != 1)')
             elif name == 'pot-creation-date':
-                self.creation_date = _parse_datetime_header(value)
+                if value.strip():
+                    self.creation_date = _parse_datetime_header(value)
             elif name == 'po-revision-date':
                 # Keep the value if it's not the default one
-                if 'YEAR' not in value:
+                if 'YEAR' not in value and value.strip():
                     self.revision_date = _parse_datetime_header(value)
 
     mime_headers = property(


### PR DESCRIPTION
When a PO file has a blank `PO-Revision-Date` header (e.g. generated by Poedit), `_parse_datetime_header` crashes with a `ValueError` because it tries to parse an empty string with `strptime`.

```
ValueError: time data '' does not match format '%Y-%m-%d %H:%M'
```

This adds a `value.strip()` check before calling `_parse_datetime_header` for both `PO-Revision-Date` and `POT-Creation-Date` headers. When the value is blank, the catalog keeps its existing defaults instead of crashing.

Fixes #1219
