### PR TITLE
Skip byte strings in extract_python instead of crashing

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -710,6 +710,8 @@ def _parse_python_string(value: str, encoding: str, future_flags: int) -> str | 
     if isinstance(code, ast.Expression):
         body = code.body
         if isinstance(body, ast.Constant):
+            if isinstance(body.value, bytes):
+                return None  # byte strings are not translatable
             return body.value
         if isinstance(body, ast.JoinedStr):  # f-string
             if all(isinstance(node, ast.Constant) for node in body.values):

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -180,3 +180,17 @@ foof = _(
         'NOTE: This should still be considered, even if',
         'the text is far away',
     ]
+
+
+def test_extract_byte_string_does_not_crash():
+    """Byte strings like _(b'foo') should be skipped without crashing."""
+    buf = BytesIO(b"""\
+_(b'foo')
+_('hello')
+_(b"bar")
+_('world')
+""")
+    messages = list(extract.extract('python', buf, {'_': None}, [], {}))
+    assert len(messages) == 2
+    assert messages[0][1] == 'hello'
+    assert messages[1][1] == 'world'


### PR DESCRIPTION
When `pybabel extract` encounters a byte string like `_(b'foo')`, `_parse_python_string` returns a `bytes` object which then causes `''.join(buf)` to crash with `TypeError: sequence item 0: expected str instance, bytes found`.

Since byte strings are not valid translation strings (gettext uses normal strings internally), this just skips them by returning `None` from `_parse_python_string` when it encounters bytes.

Added a test that confirms byte strings are silently skipped while normal strings in the same file are still extracted correctly.

Fixes #1190
