### PR TITLE
fix(mofile): decode msgctxt to str in read_mo

### DIFF
--- a/babel/messages/mofile.py
+++ b/babel/messages/mofile.py
@@ -84,6 +84,7 @@ def read_mo(fileobj: SupportsRead[bytes]) -> Catalog:
 
         if b'\x04' in msg:  # context
             ctxt, msg = msg.split(b'\x04')
+            ctxt = ctxt.decode(catalog.charset)
         else:
             ctxt = None
 

--- a/tests/messages/test_mofile.py
+++ b/tests/messages/test_mofile.py
@@ -20,8 +20,7 @@ data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
 
 def test_basics():
-    mo_path = os.path.join(data_dir, 'project', 'i18n', 'de',
-                           'LC_MESSAGES', 'messages.mo')
+    mo_path = os.path.join(data_dir, 'project', 'i18n', 'de', 'LC_MESSAGES', 'messages.mo')
     with open(mo_path, 'rb') as mo_file:
         catalog = mofile.read_mo(mo_file)
         assert len(catalog) == 2
@@ -31,15 +30,17 @@ def test_basics():
         assert catalog['foobar'].string == ['Fuhstange', 'Fuhstangen']
 
 
-
 def test_sorting():
     # Ensure the header is sorted to the first entry so that its charset
     # can be applied to all subsequent messages by GNUTranslations
     # (ensuring all messages are safely converted to unicode)
     catalog = Catalog(locale='en_US')
-    catalog.add('', '''\
+    catalog.add(
+        '',
+        '''\
 "Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n''')
+"Content-Transfer-Encoding: 8bit\n''',
+    )
     catalog.add('foo', 'Voh')
     catalog.add(('There is', 'There are'), ('Es gibt', 'Es gibt'))
     catalog.add('Fizz', '')
@@ -64,17 +65,23 @@ def test_more_plural_forms():
 
 def test_empty_translation_with_fallback():
     catalog1 = Catalog(locale='fr_FR')
-    catalog1.add('', '''\
+    catalog1.add(
+        '',
+        '''\
 "Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n''')
+"Content-Transfer-Encoding: 8bit\n''',
+    )
     catalog1.add('Fuzz', '')
     buf1 = BytesIO()
     mofile.write_mo(buf1, catalog1)
     buf1.seek(0)
     catalog2 = Catalog(locale='fr')
-    catalog2.add('', '''\
+    catalog2.add(
+        '',
+        '''\
 "Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n''')
+"Content-Transfer-Encoding: 8bit\n''',
+    )
     catalog2.add('Fuzz', 'Flou')
     buf2 = BytesIO()
     mofile.write_mo(buf2, catalog2)
@@ -84,3 +91,57 @@ def test_empty_translation_with_fallback():
     translations.add_fallback(Translations(fp=buf2))
 
     assert translations.ugettext('Fuzz') == 'Flou'
+
+
+def test_read_mo_decodes_context():
+    """read_mo should decode msgctxt to str, not leave it as bytes.
+
+    Regression test for https://github.com/python-babel/babel/issues/1147
+    """
+    catalog = Catalog(locale='en_US')
+    catalog.add('foo', 'Voh', context='Menu')
+    catalog.add('foo', 'Fuh', context='Button')
+    catalog.add('foo', 'Foo')  # no context
+
+    buf = BytesIO()
+    mofile.write_mo(buf, catalog)
+    buf.seek(0)
+
+    loaded = mofile.read_mo(buf)
+
+    # Context should be str, not bytes
+    menu_msg = loaded.get('foo', context='Menu')
+    assert menu_msg is not None
+    assert menu_msg.string == 'Voh'
+    assert menu_msg.context == 'Menu'
+    assert isinstance(menu_msg.context, str)
+
+    button_msg = loaded.get('foo', context='Button')
+    assert button_msg is not None
+    assert button_msg.string == 'Fuh'
+
+    # Message without context should still work
+    plain_msg = loaded.get('foo')
+    assert plain_msg is not None
+    assert plain_msg.string == 'Foo'
+    assert plain_msg.context is None
+
+
+def test_read_mo_decodes_non_ascii_context():
+    """read_mo should correctly decode non-ASCII msgctxt.
+
+    Regression test for https://github.com/python-babel/babel/issues/1147
+    """
+    catalog = Catalog(locale='de_DE', charset='utf-8')
+    catalog.add('greeting', 'Grüße', context='Begrüßung')
+
+    buf = BytesIO()
+    mofile.write_mo(buf, catalog)
+    buf.seek(0)
+
+    loaded = mofile.read_mo(buf)
+    msg = loaded.get('greeting', context='Begrüßung')
+    assert msg is not None
+    assert msg.string == 'Grüße'
+    assert msg.context == 'Begrüßung'
+    assert isinstance(msg.context, str)


### PR DESCRIPTION
## Summary

- `read_mo` keeps `msgctxt` as bytes while `msgid`/`msgstr` are decoded to strings, causing `Catalog.get(id, context='...')` to fail for messages with context
- Added `ctxt.decode(catalog.charset)` after splitting on the `\x04` separator, consistent with how `msgid`/`msgstr` are decoded and how `write_mo` expects `context` to be `str`
- Added two regression tests: context round-trip through write_mo → read_mo, and non-ASCII context handling

Closes #1147

## Test plan

- [x] `test_read_mo_decodes_context` — verifies context is str, messages retrievable by string context, and no-context messages unaffected
- [x] `test_read_mo_decodes_non_ascii_context` — verifies non-ASCII context (German umlauts) round-trips correctly
- [x] Full test suite passes (7305 passed, pre-existing timezone failures excluded)
- [x] `ruff check` and `ruff format --check` clean

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)