### PR TITLE
Fix standalone month alias cache leakage

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -269,7 +269,7 @@ class LocaleDataDict(abc.MutableMapping):
             val = alias.resolve(self.base).copy()
             merge(val, others)
         if isinstance(val, dict):  # Return a nested alias-resolving dict
-            val = LocaleDataDict(val, base=self.base)
+            return LocaleDataDict(val, base=self.base)
         if val is not orig:
             self._data[key] = val
         return val

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -16,7 +16,7 @@ from datetime import date, datetime, time, timedelta
 import freezegun
 import pytest
 
-from babel import Locale, dates
+from babel import Locale, dates, localedata
 from babel.dates import NO_INHERITANCE_MARKER, UTC, _localize, parse_pattern
 from babel.util import FixedOffsetTimezone
 
@@ -559,6 +559,23 @@ def test_format_date():
             'Sonntag, 1. April 2007')
     assert (dates.format_date(d, "EEE, MMM d, ''yy", locale='en') ==
             "Sun, Apr 1, '07")
+
+
+@pytest.mark.parametrize(
+    ('locale', 'expected'),
+    [
+        ('de', 'Oktober'),
+        ('he', 'אוקטובר'),
+        ('no', 'oktober'),
+        ('fr', 'octobre'),
+    ],
+)
+def test_format_date_standalone_month_name_isolation(locale, expected):
+    localedata._cache.clear()
+    d = date(2025, 10, 1)
+
+    assert dates.format_date(d, 'LLLL', locale='he') == 'אוקטובר'
+    assert dates.format_date(d, 'LLLL', locale=locale) == expected
 
 
 def test_format_datetime(timezone_getter):


### PR DESCRIPTION
## Problem background
Using `babel.dates.format_date(..., 'LLLL', locale='he')` could corrupt later standalone month-name lookups for other locales in the same process. After Hebrew resolved `months['stand-alone']['wide']`, subsequent `LLLL` formatting for locales such as `no`, `fr`, and `de` could incorrectly return Hebrew month names.

The underlying issue was in `LocaleDataDict.__getitem__()`: when an alias resolved to a nested dict, the resolved `LocaleDataDict` wrapper was memoized back into the underlying cached locale data. That leaked alias resolution state across locales through the shared locale-data cache.

## Changes summary
- Stop memoizing dict-backed alias resolutions back into the underlying locale cache in `LocaleDataDict.__getitem__()`.
- Add a regression test covering `LLLL` formatting after Hebrew for `de`, `no`, and `fr`, while preserving the expected Hebrew result itself.

## Test results
- Reproduced the bug on `v2.16.0` with:
  - `de -> Oktober`
  - `he -> אוקטובר`
  - `no -> אוקטובר` (wrong before fix)
  - `fr -> אוקטובר` (wrong before fix)
- Verified the fix locally on current `master`:
  - `de -> Oktober`
  - `he -> אוקטובר`
  - `no -> oktober`
  - `fr -> octobre`
- Test suite run:
  - `pytest tests/test_dates.py -k 'standalone_month_name_isolation or test_format_date' -q`
  - `pytest tests/test_localedata.py tests/test_core.py tests/test_dates.py -q`
  - Result: `3441 passed, 1 skipped, 2 xfailed`

## Risk assessment
Low risk. The change is narrowly scoped to avoid caching `LocaleDataDict` wrappers for nested dict values. Non-dict scalar alias resolutions are still memoized as before, and the added regression test specifically covers the cross-locale contamination case.
