### PR TITLE
Ignore blank PO revision dates

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -585,7 +585,7 @@ class Catalog:
                 self.creation_date = _parse_datetime_header(value)
             elif name == 'po-revision-date':
                 # Keep the value if it's not the default one
-                if 'YEAR' not in value:
+                if value.strip() and 'YEAR' not in value:
                     self.revision_date = _parse_datetime_header(value)
 
     mime_headers = property(

--- a/tests/messages/test_pofile_read.py
+++ b/tests/messages/test_pofile_read.py
@@ -164,6 +164,16 @@ msgstr ""
     assert list(catalog)[0].fuzzy
 
 
+def test_header_entry_blank_revision_date():
+    buf = StringIO(r'''
+msgid ""
+msgstr ""
+"PO-Revision-Date: \n"
+''')
+    catalog = pofile.read_po(buf)
+    assert catalog.revision_date == 'YEAR-MO-DA HO:MI+ZONE'
+
+
 def test_obsolete_message():
     buf = StringIO(r'''# This is an obsolete message
 #~ msgid "foo"


### PR DESCRIPTION
## Summary
- ignore blank `PO-Revision-Date` header values when loading catalog MIME headers
- preserve the existing placeholder revision date instead of trying to parse an empty string
- add a focused regression test for reading a `.po` header with a blank revision date

Closes #1219.

## Validation
- E1 baseline repro exists: yes
  - On `master`, `pofile.read_po()` raises `ValueError: time data '' does not match format '%Y-%m-%d %H:%M'` when the header contains `PO-Revision-Date:` with an empty value.
- E2 new regression test fails on baseline: yes
  - In a detached `origin/master` worktree with only the new test applied:
  - `python3 -m pytest tests/messages/test_pofile_read.py -k 'blank_revision_date' -q`
  - Result: `1 failed, 31 deselected`
- E3 regression test passes after fix: yes
  - `python3 -m pytest tests/messages/test_pofile_read.py -k 'blank_revision_date' -q`
  - Result: `1 passed, 31 deselected`
- E4 nearby targeted behavior passes: yes
  - Direct issue repro now returns a catalog with `revision_date == 'YEAR-MO-DA HO:MI+ZONE'`
  - `python3 -m pytest tests/messages/test_catalog.py -k 'datetime_parsing' -q`
  - Result: `1 passed, 43 deselected`
- E5 diff stays localized: yes
  - Changes are limited to `babel/messages/catalog.py` and `tests/messages/test_pofile_read.py`.

Note: I did not use the full `tests/messages/test_pofile_read.py` file as a validation gate because this raw source checkout does not have Babel's locale data bundle built, and many unrelated tests in that file fail before reaching this issue's code path.
