### PR TITLE
Fix Locale subclass __str__ issue

### DIFF
--- a/babel/core.py
+++ b/babel/core.py
@@ -211,7 +211,9 @@ class Locale:
         self.modifier = modifier
         self.__data: localedata.LocaleDataDict | None = None
 
-        identifier = str(self)
+        identifier = get_locale_identifier(
+            (self.language, self.territory, self.script, self.variant, self.modifier),
+        )
         identifier_without_modifier = identifier.partition('@')[0]
         if localedata.exists(identifier):
             self.__data_identifier = identifier

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -83,6 +83,14 @@ class TestLocaleClass:
         locale = Locale('en', 'US')
         assert locale.language == 'en'
         assert locale.territory == 'US'
+    
+    def test_locale_subclass_custom_str(self):
+        class MyLocale(Locale):
+            def __str__(self):
+                return f"[{self.language}]"
+        locale = MyLocale("en")
+        assert locale.language == "en"
+        assert str(locale) == "[en]"
 
     def test_default(self, monkeypatch):
         for name in ['LANGUAGE', 'LC_ALL', 'LC_CTYPE', 'LC_MESSAGES']:


### PR DESCRIPTION
Fixes #1252 

I noticed that Locale.__init__ was using str(self) to build the identifier. This breaks when a subclass overrides __str__ with a custom format.

This PR replaces it with get_locale_identifier() and adds a small test to make sure subclassed Locale objects work correctly.