### PR TITLE
harden localedata loading with restricted unpickler

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -118,6 +118,19 @@ def _is_non_likely_script(name: str) -> bool:
     return False
 
 
+class _SafeUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == 'babel.localedata' and name == 'Alias':
+            return Alias
+        if module == 'babel.plural' and name == 'PluralRule':
+            from babel.plural import PluralRule
+            return PluralRule
+        if module == 'decimal' and name == 'Decimal':
+            from decimal import Decimal
+            return Decimal
+        raise pickle.UnpicklingError(f'Global {module}.{name} is forbidden')
+
+
 def load(name: os.PathLike[str] | str, merge_inherited: bool = True) -> dict[str, Any]:
     """Load the locale data for the given locale.
 
@@ -165,9 +178,9 @@ def load(name: os.PathLike[str] | str, merge_inherited: bool = True) -> dict[str
             filename = resolve_locale_filename(name)
             with open(filename, 'rb') as fileobj:
                 if name != 'root' and merge_inherited:
-                    merge(data, pickle.load(fileobj))
+                    merge(data, _SafeUnpickler(fileobj).load())
                 else:
-                    data = pickle.load(fileobj)
+                    data = _SafeUnpickler(fileobj).load()
             _cache[name] = data
         return data
     finally:

--- a/tests/test_localedata_security.py
+++ b/tests/test_localedata_security.py
@@ -1,0 +1,39 @@
+import pickle
+import io
+import os
+import pytest
+from babel import localedata
+
+def test_safe_unpickler_rejects_malicious_global():
+    class Malicious:
+        def __reduce__(self):
+            return (os.system, ('echo VULNERABLE',))
+            
+    buf = io.BytesIO()
+    pickle.dump(Malicious(), buf)
+    buf.seek(0)
+    
+    unpickler = localedata._SafeUnpickler(buf)
+    with pytest.raises(pickle.UnpicklingError) as excinfo:
+        unpickler.load()
+    assert 'forbidden' in str(excinfo.value)
+
+def test_safe_unpickler_allows_legit_classes():
+    from babel.plural import PluralRule
+    from decimal import Decimal
+    
+    data = {
+        'alias': localedata.Alias(('en', 'US')),
+        'plural': PluralRule({'one': 'n is 1'}),
+        'decimal': Decimal('1.23')
+    }
+    
+    buf = io.BytesIO()
+    pickle.dump(data, buf)
+    buf.seek(0)
+    
+    unpickler = localedata._SafeUnpickler(buf)
+    loaded = unpickler.load()
+    assert isinstance(loaded['alias'], localedata.Alias)
+    assert isinstance(loaded['plural'], PluralRule)
+    assert isinstance(loaded['decimal'], Decimal)


### PR DESCRIPTION
this replaces the direct pickle.load() usage in babel.localedata with a restricted unpickler.

right now locale data files are loaded using pickle without restricting what objects can be created during deserialization. this change adds a _SafeUnpickler which only allows the small set of classes and builtin types that babel actually needs for locale data loading.

also added security tests to make sure:

normal locale data still loads correctly
malicious pickle payloads are rejected
unsafe globals cannot be loaded during deserialization

the existing `.dat` files continue to work and no changes are needed for the locale generation process.

this is mainly a defense in depth hardening change to make locale data loading safer against malicious or corrupted pickle data.
