### PR TITLE
messages: skip untranslated plural messages when writing MO files

### DIFF
--- a/babel/messages/mofile.py
+++ b/babel/messages/mofile.py
@@ -19,6 +19,8 @@ from babel.messages.catalog import Catalog, Message
 if TYPE_CHECKING:
     from _typeshed import SupportsRead, SupportsWrite
 
+    from babel.messages.catalog import _MessageID
+
 LE_MAGIC: int = 0x950412DE
 BE_MAGIC: int = 0xDE120495
 
@@ -105,6 +107,22 @@ def read_mo(fileobj: SupportsRead[bytes]) -> Catalog:
     return catalog
 
 
+def _has_translation(string: _MessageID | None) -> bool:
+    """Return whether ``string`` holds an actual translation.
+
+    For pluralizable messages ``string`` is a sequence of plural forms, and the
+    message counts as translated only if at least one form is non-empty. A
+    fully empty sequence (e.g. ``('', '')``) is therefore treated the same as
+    an empty string, so that untranslated plural messages are omitted from the
+    MO file just like untranslated singular ones. This lets ``gettext`` fall
+    back to the message id or to a fallback catalog instead of returning the
+    untranslated id as though it were a translation.
+    """
+    if isinstance(string, (list, tuple)):
+        return any(string)
+    return bool(string)
+
+
 def write_mo(fileobj: SupportsWrite[bytes], catalog: Catalog, use_fuzzy: bool = False) -> None:
     """Write a catalog to the specified file-like object using the GNU MO file
     format.
@@ -154,7 +172,7 @@ def write_mo(fileobj: SupportsWrite[bytes], catalog: Catalog, use_fuzzy: bool = 
                       in the output
     """
     messages = list(catalog)
-    messages[1:] = [m for m in messages[1:] if m.string and (use_fuzzy or not m.fuzzy)]
+    messages[1:] = [m for m in messages[1:] if _has_translation(m.string) and (use_fuzzy or not m.fuzzy)]
     messages.sort()
 
     ids = strs = b''

--- a/tests/messages/test_mofile.py
+++ b/tests/messages/test_mofile.py
@@ -84,3 +84,31 @@ def test_empty_translation_with_fallback():
     translations.add_fallback(Translations(fp=buf2))
 
     assert translations.ugettext('Fuzz') == 'Flou'
+
+
+def test_empty_plural_translation_with_fallback():
+    # An untranslated pluralizable message must be omitted from the MO file,
+    # just like an untranslated singular one, so that gettext falls back to the
+    # fallback catalog instead of returning the untranslated message id.
+    catalog1 = Catalog(locale='fr_FR')
+    catalog1.add('', '''\
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n''')
+    catalog1.add(('Fuzz', 'Fuzzes'), ('', ''))
+    buf1 = BytesIO()
+    mofile.write_mo(buf1, catalog1)
+    buf1.seek(0)
+    catalog2 = Catalog(locale='fr')
+    catalog2.add('', '''\
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n''')
+    catalog2.add(('Fuzz', 'Fuzzes'), ('Flou', 'Flous'))
+    buf2 = BytesIO()
+    mofile.write_mo(buf2, catalog2)
+    buf2.seek(0)
+
+    translations = Translations(fp=buf1)
+    translations.add_fallback(Translations(fp=buf2))
+
+    assert translations.ungettext('Fuzz', 'Fuzzes', 1) == 'Flou'
+    assert translations.ungettext('Fuzz', 'Fuzzes', 2) == 'Flous'


### PR DESCRIPTION
Fixes #697

## Problem

`write_mo()` drops untranslated *singular* messages so that, at runtime, gettext can fall back to the message id (or to a fallback catalog) instead of returning the untranslated id as though it were a real translation. This was added in #564.

Pluralizable messages were never given the same treatment. A plural message stores its translation as a sequence of plural forms, e.g. `('', '')`, which is *truthy* even when every form is empty. The filter that removes untranslated messages therefore never matched them:

```python
messages[1:] = [m for m in messages[1:] if m.string and (use_fuzzy or not m.fuzzy)]
```

As a result, an untranslated plural entry was still written to the MO file, with the message ids substituted in as the "translations" (the `if not string: msgstrs.append(message.id[...])` branch). At runtime `ngettext` then found that entry and returned the untranslated id, so the fallback chain was never consulted — exactly the behaviour #697 reports.

## Fix

Introduce a small `_has_translation()` helper that treats a plural message as untranslated when *all* of its forms are empty (mirroring the existing behaviour for singular messages), and use it in the filter. Fully untranslated plural messages are now omitted from the MO file, so `ngettext` falls back correctly.

This intentionally only changes the *fully untranslated* case; partially translated plurals are unaffected.

## Testing

- Added `test_empty_plural_translation_with_fallback`, the plural analogue of the existing `test_empty_translation_with_fallback`, which asserts that an untranslated plural message resolves to its fallback catalogs translations via `ngettext`.
- The existing `write_mo` doctest and `test_sorting` (which exercise empty plural messages) still pass, since gettext returns the message id whether the entry is absent or present-with-id.
- `pytest tests/messages/` — 353 passed.
- `ruff check` — clean.