### PR TITLE
fix(localedata): don't memoize resolved aliases into shared parent data

### DIFF
--- a/babel/localedata.py
+++ b/babel/localedata.py
@@ -263,15 +263,19 @@ class LocaleDataDict(abc.MutableMapping):
 
     def __getitem__(self, key: str | int | None) -> Any:
         orig = val = self._data[key]
+        resolved = False
         if isinstance(val, Alias):  # resolve an alias
             val = val.resolve(self.base)
+            resolved = True
         if isinstance(val, tuple):  # Merge a partial dict with an alias
             alias, others = val
             val = alias.resolve(self.base).copy()
             merge(val, others)
+            resolved = True
         if isinstance(val, dict):  # Return a nested alias-resolving dict
             val = LocaleDataDict(val, base=self.base)
-        if val is not orig:
+        # Don't memoize resolved aliases: the backing dict may be shared with a parent locale (issue #1234).
+        if val is not orig and not resolved:
             self._data[key] = val
         return val
 

--- a/tests/test_localedata.py
+++ b/tests/test_localedata.py
@@ -10,6 +10,7 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at https://github.com/python-babel/babel/commits/master/.
 
+import datetime
 import os
 import pickle
 import random
@@ -60,6 +61,19 @@ def test_merge_with_alias_and_resolve():
 def test_load():
     assert localedata.load('en_US')['languages']['sv'] == 'Swedish'
     assert localedata.load('en_US') is localedata.load('en_US')
+
+
+def test_resolving_alias_does_not_corrupt_shared_data():
+    # Resolving an alias in one locale must not leak into a sibling locale (issue #1234).
+    from babel.dates import format_date
+
+    localedata._cache.clear()
+    date = datetime.date(2024, 10, 15)
+    # 'he' aliases its stand-alone wide months to the Hebrew format ones.
+    hebrew = format_date(date, 'LLLL', 'he')
+    german = format_date(date, 'LLLL', 'de')
+    assert german != hebrew
+    assert german == 'Oktober'
 
 
 def test_load_inheritance(monkeypatch):


### PR DESCRIPTION
Fixes #1234.

A locale that inherits an entire nested sub-dict from its parent shares the same dict object (merge only copies keys present in the child's own data). When `LocaleDataDict.__getitem__` resolved an `Alias` and wrote the resolved value back into `self._data` as a memoization, it mutated that shared dict, corrupting the parent locale (and every sibling that inherits it).

For example `he` aliases its stand-alone wide months to the Hebrew format months. After `format_date(d, 'LLLL', 'he')`, a later `format_date(d, 'LLLL', 'de')` returned Hebrew text because root's shared `months/stand-alone/wide` Alias had been overwritten.

Fix: skip the write-back memoization when the value came from resolving an alias, since the backing dict may be shared with a parent locale. Plain nested dicts are still wrapped and memoized as before.

Added a regression test.