### PR TITLE
fix: preserve original skeleton in KeyError when fuzzy format_skeleton finds no match

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -870,7 +870,7 @@ def format_skeleton(
     >>> format_skeleton('GH', t, fuzzy=True, locale='fi_FI')  # GH is not in the Finnish locale and there is no close match, an error is thrown
     Traceback (most recent call last):
         ...
-    KeyError: None
+    KeyError: 'GH'
 
     After the skeleton is resolved to a pattern `format_datetime` is called so
     all timezone processing etc is the same as for that.
@@ -881,12 +881,12 @@ def format_skeleton(
     :param tzinfo: the time-zone to apply to the time for display
     :param fuzzy: If the skeleton is not found, allow choosing a skeleton that's
                   close enough to it. If there is no close match, a `KeyError`
-                  is thrown.
+                  with the requested skeleton is thrown.
     :param locale: a `Locale` object or a locale identifier. Defaults to the system time locale.
     """
     locale = Locale.parse(locale or LC_TIME)
     if fuzzy and skeleton not in locale.datetime_skeletons:
-        skeleton = match_skeleton(skeleton, locale.datetime_skeletons)
+        skeleton = match_skeleton(skeleton, locale.datetime_skeletons) or skeleton
     format = locale.datetime_skeletons[skeleton]
     return format_datetime(datetime, format, tzinfo, locale)
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -618,6 +618,10 @@ def test_format_skeleton(timezone_getter):
     assert (dates.format_skeleton('EHm', dt, locale='en') == 'Sun 15:30')
     assert (dates.format_skeleton('EHm', dt, tzinfo=timezone_getter('Asia/Bangkok'), locale='th') == 'อา. 22:30 น.')
 
+    # fuzzy=True with no close match should raise KeyError with the original skeleton, not None
+    with pytest.raises(KeyError, match='G'):
+        dates.format_skeleton('G', datetime(2012, 1, 1, 14, 30, 59), locale='cs_CZ', fuzzy=True)
+
 
 @pytest.mark.parametrize(('skeleton', 'expected'), [
     ('Hmz', 'Hmv'),


### PR DESCRIPTION
When `format_skeleton` is called with `fuzzy=True` and `match_skeleton` finds no close match, it returns `None`. The subsequent `locale.datetime_skeletons[skeleton]` lookup then raises `KeyError: None`, which is confusing since it hides the skeleton that was actually requested.

This change falls back to the original skeleton when `match_skeleton` returns `None`, so the error is `KeyError: 'G'` instead of `KeyError: None`, consistent with the `fuzzy=False` behavior.

Fixes #1084.