### PR TITLE
reject non-finite values in parse_decimal

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -1193,6 +1193,8 @@ def parse_decimal(
         parsed = decimal.Decimal(string.replace(group_symbol, '').replace(decimal_symbol, '.'))
     except decimal.InvalidOperation as exc:
         raise NumberFormatError(f"{string!r} is not a valid decimal number") from exc
+    if not parsed.is_finite():
+        raise NumberFormatError(f"{string!r} is not a valid decimal number")
     if strict and group_symbol in string:
         proper = format_decimal(
             parsed,

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -557,6 +557,12 @@ def test_parse_decimal():
         numbers.parse_decimal('2,109,998', locale='de')
 
 
+@pytest.mark.parametrize('string', ['nan', 'NaN', 'inf', '-inf', 'Infinity', 'sNaN'])
+def test_parse_decimal_rejects_non_finite(string):
+    with pytest.raises(numbers.NumberFormatError, match='is not a valid decimal number'):
+        numbers.parse_decimal(string, locale='en_US')
+
+
 @pytest.mark.parametrize('string', [
     '1 099,98',
     '1\xa0099,98',


### PR DESCRIPTION
1. `parse_decimal` builds the result straight from `decimal.Decimal(...)`, which happily accepts `nan`, `inf`, `Infinity` and `sNaN`, so those parse instead of being rejected.
2. a `NaN` result then slips past range checks (every comparison against NaN is False), and a signaling NaN throws `InvalidOperation` the first time anything does arithmetic with it.

Added an `is_finite()` check so non-finite input raises `NumberFormatError` like any other non-decimal string. What happens today if someone feeds `"inf"` from a form field straight into a `> limit` guard? It passes. Kept it in the parser since that's the layer that already promises to reject things that aren't localized decimals.
