### PR TITLE
decode message context to str in read_mo

### DIFF
--- a/babel/messages/mofile.py
+++ b/babel/messages/mofile.py
@@ -84,6 +84,7 @@ def read_mo(fileobj: SupportsRead[bytes]) -> Catalog:
 
         if b'\x04' in msg:  # context
             ctxt, msg = msg.split(b'\x04')
+            ctxt = ctxt.decode(catalog.charset)
         else:
             ctxt = None
 

--- a/tests/messages/test_mofile.py
+++ b/tests/messages/test_mofile.py
@@ -55,6 +55,19 @@ def test_sorting():
     assert translations.ugettext('Fuzzes') == 'Fuzzes'
 
 
+def test_context_round_trip():
+    catalog = Catalog(locale='en_US')
+    catalog.add('foo', 'Voh', context='menu')
+    buf = BytesIO()
+    mofile.write_mo(buf, catalog)
+    buf.seek(0)
+    read = mofile.read_mo(buf)
+    message = read.get('foo', context='menu')
+    assert message is not None
+    assert message.context == 'menu'
+    assert not isinstance(message.context, bytes)
+
+
 def test_more_plural_forms():
     catalog2 = Catalog(locale='ru_RU')
     catalog2.add(('Fuzz', 'Fuzzes'), ('', '', ''))


### PR DESCRIPTION
`read_mo` splits the context off a message but never decodes it, so a `.mo` carrying a msgctxt yields a `Message.context` of `bytes` that mis-keys the entry and crashes re-export through `write_mo`; found by round-tripping a catalog with a context.