### PR TITLE
Decode message context when reading MO files

### DIFF
--- a/babel/messages/mofile.py
+++ b/babel/messages/mofile.py
@@ -84,6 +84,7 @@ def read_mo(fileobj: SupportsRead[bytes]) -> Catalog:
 
         if b'\x04' in msg:  # context
             ctxt, msg = msg.split(b'\x04')
+            ctxt = ctxt.decode(catalog.charset)
         else:
             ctxt = None
 

--- a/tests/messages/test_mofile.py
+++ b/tests/messages/test_mofile.py
@@ -31,6 +31,19 @@ def test_basics():
         assert catalog['foobar'].string == ['Fuhstange', 'Fuhstangen']
 
 
+def test_context_is_decoded():
+    # The message context should be decoded to a string, just like the message
+    # id and string, so that a written catalog round-trips back to an equal one.
+    catalog = Catalog(locale='en_US')
+    catalog.add('foo', 'Voh', context='fooctxt')
+    buf = BytesIO()
+    mofile.write_mo(buf, catalog)
+    buf.seek(0)
+    catalog = mofile.read_mo(buf)
+    message = catalog.get('foo', context='fooctxt')
+    assert message is not None
+    assert message.context == 'fooctxt'
+
 
 def test_sorting():
     # Ensure the header is sorted to the first entry so that its charset


### PR DESCRIPTION
When reading an MO file, `read_mo` left the message context as raw bytes while the msgid and msgstr got decoded to `str` with the catalog charset. That made the context inconsistent with the rest of the message, and it differs from the standard library's gettext parser, which decodes the whole entry (context included).

The practical effect is a broken round-trip: a catalog written with `write_mo` (which `.encode()`s the context) reads back with the key stored as `(id, bytes)`, so `catalog.get('foo', context='fooctxt')` returns `None` and you can only look it up by passing the context as bytes.

The fix decodes the context with the catalog charset right after the `\x04` split, the same way the msgid/msgstr are handled a few lines down.

I added a test that writes a catalog with a context, reads it back, and checks that the context is a `str` and that the message is retrievable with a `str` context. It fails before the change and passes after. Full `tests/messages` suite stays green.

Fixes #1147.
