### PR TITLE
Apply exponent grouping for scientific notation patterns

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -1424,10 +1424,14 @@ class NumberPattern:
         value = value * get_decimal_quantum(exp)
         assert value.adjusted() == 0
 
-        # Shift exponent and value by the minimum number of leading digits
-        # imposed by the rendering pattern. And always make that number
-        # greater or equal to 1.
-        lead_shift = max([1, min(self.int_prec)]) - 1
+        # Shift exponent and value by the number of leading digits imposed by
+        # the rendering pattern. If a maximum integer digit count is present
+        # and larger than the minimum, it specifies exponent grouping.
+        min_int, max_int = self.int_prec
+        if max_int > min_int and max_int > 1:
+            lead_shift = exp % max_int
+        else:
+            lead_shift = max([1, min_int]) - 1
         exp = exp - lead_shift
         value = value * get_decimal_quantum(-lead_shift)
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -474,12 +474,14 @@ def test_format_scientific():
     assert numbers.format_scientific(4234567, '#.#E0', locale='en_US') == '4.2E6'
     assert numbers.format_scientific(4234567, '0E0000', locale='en_US') == '4.234567E0006'
     assert numbers.format_scientific(4234567, '##0E00', locale='en_US') == '4.234567E06'
-    assert numbers.format_scientific(4234567, '##00E00', locale='en_US') == '42.34567E05'
+    assert numbers.format_scientific(4234567, '##00E00', locale='en_US') == '423.4567E04'
     assert numbers.format_scientific(4234567, '0,000E00', locale='en_US') == '4,234.567E03'
     assert numbers.format_scientific(4234567, '##0.#####E00', locale='en_US') == '4.23457E06'
     assert numbers.format_scientific(4234567, '##0.##E00', locale='en_US') == '4.23E06'
     assert numbers.format_scientific(42, '00000.000000E0000', locale='en_US') == '42000.000000E-0003'
     assert numbers.format_scientific(0.2, locale="ar_EG", numbering_system="default") == '2أس\u061c-1'
+    assert numbers.format_scientific(12345, '##0.####E0', locale='en_US') == '12.345E3'
+    assert numbers.format_scientific(12345, '##0E00', locale='en_US') == '12.345E03'
 
 
 def test_default_scientific_format():

--- a/tests/test_numbers_format_decimal.py
+++ b/tests/test_numbers_format_decimal.py
@@ -80,7 +80,7 @@ def test_scientific_notation():
     assert numbers.format_scientific(1234, '0.###E0', locale='en_US') == '1.234E3'
     assert numbers.format_scientific(1234, '0.#E0', locale='en_US') == '1.2E3'
     # Exponent grouping
-    assert numbers.format_scientific(12345, '##0.####E0', locale='en_US') == '1.2345E4'
+    assert numbers.format_scientific(12345, '##0.####E0', locale='en_US') == '12.345E3'
     # Minimum number of int digits
     assert numbers.format_scientific(12345, '00.###E0', locale='en_US') == '12.345E3'
     assert numbers.format_scientific(-12345.6, '00.###E0', locale='en_US') == '-12.346E3'


### PR DESCRIPTION
Fixes #1026.

LDML scientific notation treats the maximum number of integer digits in a scientific pattern as the exponent grouping size. Babel only shifted by the minimum integer digit count, so patterns such as `##0.####E0` formatted `12345` as `1.2345E4` instead of `12.345E3`.

This changes the scientific notation normalization to use the maximum integer digit count when it is larger than the minimum, while preserving the existing fixed-minimum behavior for patterns without exponent grouping.

Checks run locally:
- `python setup.py import_cldr`
- `python -m pytest tests\test_numbers.py tests\test_numbers_format_decimal.py -q` (140 passed)
- `python -m pre_commit run --files babel\numbers.py tests\test_numbers.py tests\test_numbers_format_decimal.py --show-diff-on-failure --color=never`
- `PYTHONUTF8=1 python -m pytest -q` (7478 passed, 8 skipped, 2 xfailed)