### PR TITLE
Decode message contexts when reading MO files

### DIFF
--- a/babel/messages/mofile.py
+++ b/babel/messages/mofile.py
@@ -84,6 +84,7 @@ def read_mo(fileobj: SupportsRead[bytes]) -> Catalog:
 
         if b'\x04' in msg:  # context
             ctxt, msg = msg.split(b'\x04')
+            ctxt = ctxt.decode(catalog.charset)
         else:
             ctxt = None
 

--- a/tests/messages/test_mofile.py
+++ b/tests/messages/test_mofile.py
@@ -62,6 +62,31 @@ def test_more_plural_forms():
     mofile.write_mo(buf, catalog2)
 
 
+def test_read_mo_decodes_message_context():
+    catalog = Catalog(locale='de_DE')
+    catalog.add('', '''\
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n''')
+    catalog.add('Save', 'Speichern', context='Button')
+    catalog.add('Library', 'Bibliothek', context='Menü')
+
+    buf = BytesIO()
+    mofile.write_mo(buf, catalog)
+    buf.seek(0)
+
+    read_catalog = mofile.read_mo(buf)
+
+    button_message = read_catalog.get('Save', context='Button')
+    menu_message = read_catalog.get('Library', context='Menü')
+
+    assert button_message is not None
+    assert button_message.context == 'Button'
+    assert button_message.string == 'Speichern'
+    assert menu_message is not None
+    assert menu_message.context == 'Menü'
+    assert menu_message.string == 'Bibliothek'
+
+
 def test_empty_translation_with_fallback():
     catalog1 = Catalog(locale='fr_FR')
     catalog1.add('', '''\


### PR DESCRIPTION
## Summary

- Decode `msgctxt` values with the catalog charset when reading MO files.
- Add a regression test that round-trips ASCII and non-ASCII message contexts through `write_mo()` and `read_mo()`.
- Verify `Catalog.get(..., context=...)` works with string contexts after reading an MO file.

Fixes #1147

## Tests

- `python -m pytest tests/messages/test_mofile.py -q`
- `python -m pytest tests/messages/test_mofile.py tests/messages/test_pofile_read.py tests/messages/test_catalog.py -q`
- `python -m ruff check babel/messages/mofile.py tests/messages/test_mofile.py`