### PR TITLE
Fix short timezone fallback formatting

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -475,6 +475,53 @@ def get_timezone_gmt(
     return pattern % (hours, seconds // 60)
 
 
+def _get_timezone_gmt_short(
+    datetime: _Instant = None,
+    locale: Locale | str | None = None,
+) -> str:
+    datetime = _ensure_datetime_tzinfo(_get_datetime(datetime))
+    locale = Locale.parse(locale or LC_TIME)
+
+    offset = datetime.tzinfo.utcoffset(datetime)
+    seconds = offset.days * 24 * 60 * 60 + offset.seconds
+    sign = '-' if seconds < 0 else '+'
+    hours, seconds = divmod(abs(seconds), 3600)
+    minutes = seconds // 60
+    if minutes:
+        offset_string = f"{sign}{hours}:{minutes:02d}"
+    else:
+        offset_string = f"{sign}{hours}"
+    return locale.zone_formats['gmt'] % offset_string
+
+
+def _get_timezone_name_or_gmt_short(
+    dt_or_tzinfo: _DtOrTzinfo,
+    locale: Locale | str | None = None,
+) -> str:
+    dt, tzinfo = _get_dt_and_tzinfo(dt_or_tzinfo)
+    locale = Locale.parse(locale or LC_TIME)
+
+    dst = tzinfo.dst(dt)
+    zone_variant: Literal['daylight', 'standard'] = "daylight" if dst else "standard"
+
+    zone = _get_tz_name(dt_or_tzinfo)
+    zone = get_global('zone_aliases').get(zone, zone)
+
+    info = locale.time_zones.get(zone, {})
+    value = info.get('short', {}).get(zone_variant)
+    if value and value != NO_INHERITANCE_MARKER:
+        return value
+
+    metazone = get_global('meta_zones').get(zone)
+    if metazone:
+        metazone_info = locale.meta_zones.get(metazone, {})
+        name = metazone_info.get('short', {}).get(zone_variant)
+        if name and name != NO_INHERITANCE_MARKER:
+            return name
+
+    return _get_timezone_gmt_short(dt, locale=locale)
+
+
 def get_timezone_location(
     dt_or_tzinfo: _DtOrTzinfo = None,
     locale: Locale | str | None = None,
@@ -1668,6 +1715,8 @@ class DateTimeFormat:
             value = datetime.datetime.combine(self.reference_date, self.value)
 
         if char == 'z':
+            if width == 'short':
+                return _get_timezone_name_or_gmt_short(value, locale=self.locale)
             return get_timezone_name(value, width, locale=self.locale)
         elif char == 'Z':
             if num == 5:

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -773,7 +773,7 @@ def test_no_inherit_metazone_formatting(timezone_getter):
     tz = timezone_getter('America/Los_Angeles')
     t = _localize(tz, datetime(2016, 1, 6, 7))
     assert dates.format_time(t, format='long', locale='en_US') == "7:00:00\u202fAM PST"
-    assert dates.format_time(t, format='long', locale='en_GB') == "07:00:00 Pacific Standard Time"
+    assert dates.format_time(t, format='long', locale='en_GB') == "07:00:00 GMT-8"
     assert dates.get_timezone_name(t, width='short', locale='en_US') == "PST"
     assert dates.get_timezone_name(t, width='short', locale='en_GB') == "Pacific Standard Time"
 
@@ -1198,12 +1198,10 @@ def test_issue_1192():
     assert dates.get_timezone_name('Pacific/Honolulu', 'short', locale='en_GB') == "Hawaii-Aleutian Time"
 
 
-@pytest.mark.xfail
 def test_issue_1192_fmt(timezone_getter):
     """
     There is an issue in how we format the fallback for z/zz in the absence of data
     (esp. with the no inheritance marker present).
-    This test is marked xfail until that's fixed.
     """
     # env TEST_TIMEZONES=Pacific/Honolulu TEST_LOCALES=en_US,en_GB TEST_TIME_FORMAT="YYYY-MM-dd H:mm z" bin/icu4c_date_format
     # Defaulting TEST_TIME to 2025-03-04T13:53:00Z
@@ -1213,7 +1211,7 @@ def test_issue_1192_fmt(timezone_getter):
     # Pacific/Honolulu        en_US   2025-03-04 3:53 HST
     # Pacific/Honolulu        en_GB   2025-03-04 3:53 GMT-10
     tz = timezone_getter("Pacific/Honolulu")
-    dt = _localize(tz, datetime(2025, 3, 4, 13, 53, tzinfo=UTC))
+    dt = datetime(2025, 3, 4, 13, 53, tzinfo=UTC).astimezone(tz)
     assert dates.format_datetime(dt, "YYYY-MM-dd H:mm z", locale="en_US") == "2025-03-04 3:53 HST"
     assert dates.format_datetime(dt, "YYYY-MM-dd H:mm z", locale="en_GB") == "2025-03-04 3:53 GMT-10"
     assert dates.format_datetime(dt, "YYYY-MM-dd H:mm zz", locale="en_US") == "2025-03-04 3:53 HST"


### PR DESCRIPTION
## Summary
- format short `z`/`zz` timezone fallbacks as localized GMT offsets when CLDR marks the short metazone name as no-inheritance
- keep `get_timezone_name(..., width=short)` using its existing long-name fallback for direct API calls
- unxfail the `Pacific/Honolulu` regression and fix the test instant conversion for both `pytz` and `zoneinfo`

Closes #1201.

## Tests
- `py -3 -m ruff check babel/dates.py tests/test_dates.py`
- `py -3 -m pytest tests/test_dates.py -q`
- `PYTHONUTF8=1 py -3 -m pytest -q` (`7482 passed, 8 skipped`)

Note: without `PYTHONUTF8=1`, the full Windows run hits an unrelated `UnicodeDecodeError` in `tests/messages/frontend/test_extract.py::test_input_paths_is_treated_as_list` when reading a generated `.pot` file with the local `cp936` default encoding.