### PR TITLE
Extract template expressions after quoted attributes

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -909,13 +909,22 @@ def parse_template_string(
     level = 0
     inside_str = False
     expression_contents = ''
-    for character in template_string[1:-1]:
-        if not inside_str and character in ('"', "'", '`'):
-            inside_str = character
-        elif inside_str == character and prev_character != r'\\':
-            inside_str = False
+    template_contents = template_string[1:-1]
+    for index, character in enumerate(template_contents):
+        next_character = template_contents[index + 1] if index + 1 < len(template_contents) else None
+        if not level:
+            # A concatenated template fragment can start by closing a quoted
+            # HTML attribute before an expression, as in `">${_(...)}`.
+            if not inside_str and character in ('"', "'", '`') and next_character != '>':
+                inside_str = character
+            elif inside_str == character and prev_character != r'\\':
+                inside_str = False
         if level:
             expression_contents += character
+            if not inside_str and character in ('"', "'", '`'):
+                inside_str = character
+            elif inside_str == character and prev_character != r'\\':
+                inside_str = False
         if not inside_str:
             if character == '{' and prev_character == '$':
                 level += 1

--- a/tests/messages/test_js_extract.py
+++ b/tests/messages/test_js_extract.py
@@ -191,3 +191,25 @@ def test_inside_nested_template_string():
     )
 
     assert messages == [(1, 'Greetings!', [], None), (1, 'This is a lovely evening.', [], None), (1, 'The day is really nice!', [], None)]
+
+
+def test_inside_template_string_quoted_html_attributes():
+    buf = BytesIO(b"""\
+`<label>${_('AA0')}</label>
+<select data-placeholder="${_('AA1')}">${_('AA2')}</select>
+<select data-placeholder="` + _('AA3') + `">${_('AA4')}</select>
+<select data-placeholder="">${_('AA5')}</select>
+<select data-placeholder="">` + _('AA6') + `</select>`
+""")
+    messages = [
+        message
+        for _, message, _, _ in extract.extract(
+            'javascript',
+            buf,
+            {"_": None},
+            [],
+            {'parse_template_string': True},
+        )
+    ]
+
+    assert messages == ["AA0", "AA2", "AA3", "AA4", "AA5", "AA6"]


### PR DESCRIPTION
﻿## Summary
- keep template-string extraction from evaluating `${...}` inside quoted HTML attribute values, preserving the existing #329 behavior
- handle concatenated template fragments that start by closing a quoted attribute, such as `">${_(...)}`
- add a regression test for the #989 AA0-AA6 example, expecting AA1 to remain ignored and AA4/AA5 to be extracted again

Closes #989.

## Tests
- `py -3 -m ruff check babel/messages/extract.py tests/messages/test_js_extract.py`
- `py -3 -m pytest tests/messages/test_js_extract.py -q`
- `PYTHONUTF8=1 py -3 -m pytest tests/messages -q` (`352 passed`)
- `PYTHONUTF8=1 py -3 -m pytest -q` (`7481 passed, 8 skipped, 2 xfailed`)

Note: without `PYTHONUTF8=1`, the Windows full/messages run hits an unrelated `UnicodeDecodeError` in `tests/messages/frontend/test_extract.py::test_input_paths_is_treated_as_list` when reading a generated `.pot` file with the local `cp936` default encoding.
