### PR TITLE
Fix JS extractor line numbers being off on CRLF files

### DIFF
--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -42,8 +42,8 @@ class Token(NamedTuple):
 
 _rules: list[tuple[str | None, re.Pattern[str]]] = [
     (None, re.compile(r'\s+', re.UNICODE)),
-    (None, re.compile(r'<!--.*')),
-    ('linecomment', re.compile(r'//.*')),
+    (None, re.compile(r'<!--[^\r\n]*')),
+    ('linecomment', re.compile(r'//[^\r\n]*')),
     ('multilinecomment', re.compile(r'/\*.*?\*/', re.UNICODE | re.DOTALL)),
     ('dotted_name', dotted_name_re),
     ('name', name_re),

--- a/tests/messages/test_js_extract.py
+++ b/tests/messages/test_js_extract.py
@@ -191,3 +191,20 @@ def test_inside_nested_template_string():
     )
 
     assert messages == [(1, 'Greetings!', [], None), (1, 'This is a lovely evening.', [], None), (1, 'The day is really nice!', [], None)]
+
+
+@pytest.mark.parametrize('comment', ['// comment', '<!-- comment'])
+def test_line_numbers_are_the_same_for_lf_and_crlf(comment):
+    source = f"{comment}\n{comment}\n{comment}\nmsg = _('Bonjour')\n"
+
+    def line_numbers(newline):
+        buf = BytesIO(source.replace('\n', newline).encode('utf-8'))
+        return [lineno for lineno, _, _, _ in extract.extract('javascript', buf)]
+
+    assert line_numbers('\n') == line_numbers('\r\n') == [4]
+
+
+def test_translator_comment_has_no_trailing_carriage_return():
+    buf = BytesIO("// NOTE: hello\r\nmsg = _('Bonjour à tous')\r\n".encode())
+    messages = list(extract.extract_javascript(buf, ('_',), ['NOTE:'], {}))
+    assert messages[0][3] == ['NOTE: hello']

--- a/tests/messages/test_jslexer.py
+++ b/tests/messages/test_jslexer.py
@@ -123,3 +123,16 @@ def test_jsx():
         ('jsx_tag', '</comp2', 8),
         ('operator', '>', 8),
     ]
+
+
+def test_line_comment_does_not_eat_carriage_return():
+    # A `//` comment must not swallow the trailing `\r` of a CRLF line ending,
+    # otherwise the line count for the following code is off by one per comment.
+    source = "// comment\r\ngettext('foo')\r\n"
+    assert list(jslexer.tokenize(source)) == [
+        ('linecomment', '// comment', 1),
+        ('name', 'gettext', 2),
+        ('operator', '(', 2),
+        ('string', "'foo'", 2),
+        ('operator', ')', 2),
+    ]


### PR DESCRIPTION
Fixes #770.

The JS extractor reports different line numbers by line ending: a call after three comment lines shows on line 4 with LF but line 7 with CRLF.

It's the `//` and `<!--` comment rules in jslexer. They match with `.*`, and `.` eats the `\r` of a CRLF, so the comment token keeps a trailing `\r` that gets counted as a newline, then the `\n` is counted again, two lines per comment. Switching both to `[^\r\n]*` stops the comment before the newline so the `\r\n` counts once. Added tests that LF and CRLF line numbers match.

Left `CHANGES.rst` alone since that's filled in at release, happy to add an entry.