### PR TITLE
Fix Arabic plural rule to match CLDR (#816)

### DIFF
--- a/babel/messages/plurals.py
+++ b/babel/messages/plurals.py
@@ -34,7 +34,7 @@ PLURALS: dict[str, tuple[int, str]] = {
     # Aragonese
     # 'an': (),
     # Arabic - From Pootle's PO's
-    'ar': (6, '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5)'),
+    'ar': (6, '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5)'),
     # Assamese
     # 'as': (),
     # Avaric

--- a/tests/messages/test_plurals.py
+++ b/tests/messages/test_plurals.py
@@ -61,3 +61,34 @@ def test_get_plural():
     assert str(plural_pl_PL) == 'nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);'
     assert plural_pl_PL.num_plurals == 3
     assert plural_pl_PL.plural_expr == '(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+
+
+def test_get_plural_arabic():
+    # The hand-maintained Arabic rule previously had the "many" (4) and "other"
+    # (5) forms swapped relative to CLDR, so e.g. n=11 or n=100 selected the
+    # wrong form. See https://github.com/python-babel/babel/issues/816.
+    plural_ar = plurals.get_plural('ar')
+    assert plural_ar.num_plurals == 6
+    assert plural_ar.plural_expr == (
+        '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5)'
+    )
+
+    # It must agree with the CLDR-derived rule that Babel ships for Arabic.
+    cldr_form = Locale('ar').plural_form
+    category_index = {'zero': 0, 'one': 1, 'two': 2, 'few': 3, 'many': 4, 'other': 5}
+
+    def manual_form(n):
+        if n == 0:
+            return 0
+        if n == 1:
+            return 1
+        if n == 2:
+            return 2
+        if 3 <= n % 100 <= 10:
+            return 3
+        if 11 <= n % 100 <= 99:
+            return 4
+        return 5
+
+    for n in (0, 1, 2, 3, 10, 11, 50, 99, 100, 101, 102, 111, 999, 1000):
+        assert manual_form(n) == category_index[cldr_form(n)], n


### PR DESCRIPTION
Fixes #816.

## Problem

`babel/messages/plurals.py` keeps a hand-maintained table of gettext `Plural-Forms` rules. Its Arabic (`ar`) rule has the **"many" (form 4)** and **"other" (form 5)** categories swapped relative to Unicode CLDR:

```python
'ar': (6, '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5)'),
```

CLDR assigns **many** to `n % 100` in `11..99` and **other** to the rest, but the table assigns form 4 to `n % 100` in `0..2` instead. As a result, generated Arabic catalogs pick the wrong plural for any `n` whose `n % 100` is 11–99 (e.g. 11, 50, 99, 111, 999). This also disagrees with the CLDR-derived rule that Babel itself ships (`Locale('ar').plural_form`).

## Fix

One line — align the rule with CLDR:

```python
'ar': (6, '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5)'),
```

This matches the standard gettext Arabic `Plural-Forms` used by Weblate/Transifex.

## Testing

- Added `test_get_plural_arabic`, which asserts the corrected expression **and** cross-checks that the hand-maintained rule agrees with Babel's CLDR-derived `Locale('ar').plural_form` across a range of `n` (0, 1, 2, 3, 10, 11, 50, 99, 100, 101, 102, 111, 999, 1000). It fails on `master` and passes with this change.
- The plural, number, catalog, and message test suites pass (`6202 passed`). The only failure in a full run is the pre-existing, system-timezone-dependent `test_get_timezone_name_misc` (issue #935), which fails identically on `master` here and is unrelated to this change.
- `ruff` is clean on the changed files.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I verified the rule against Babel's own CLDR data, added and ran the regression test, ran the suites and linter, and take responsibility for the contribution and will respond to review feedback personally.*
