### PR TITLE
Fix get_timezone_gmt hour for negative fractional offsets

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -461,11 +461,11 @@ def get_timezone_gmt(
 
     offset = datetime.tzinfo.utcoffset(datetime)
     seconds = offset.days * 24 * 60 * 60 + offset.seconds
+    if return_z and seconds == 0:
+        return 'Z'
     sign = '-' if seconds < 0 else '+'
     hours, seconds = divmod(abs(seconds), 3600)
-    if return_z and hours == 0 and seconds == 0:
-        return 'Z'
-    elif seconds == 0 and width == 'iso8601_short':
+    if seconds == 0 and width == 'iso8601_short':
         return '%s%02d' % (sign, hours)
     elif width == 'short' or width == 'iso8601_short':
         pattern = '%s%02d%02d'

--- a/babel/dates.py
+++ b/babel/dates.py
@@ -461,18 +461,19 @@ def get_timezone_gmt(
 
     offset = datetime.tzinfo.utcoffset(datetime)
     seconds = offset.days * 24 * 60 * 60 + offset.seconds
-    hours, seconds = divmod(seconds, 3600)
+    sign = '-' if seconds < 0 else '+'
+    hours, seconds = divmod(abs(seconds), 3600)
     if return_z and hours == 0 and seconds == 0:
         return 'Z'
     elif seconds == 0 and width == 'iso8601_short':
-        return '%+03d' % hours
+        return '%s%02d' % (sign, hours)
     elif width == 'short' or width == 'iso8601_short':
-        pattern = '%+03d%02d'
+        pattern = '%s%02d%02d'
     elif width == 'iso8601':
-        pattern = '%+03d:%02d'
+        pattern = '%s%02d:%02d'
     else:
-        pattern = locale.zone_formats['gmt'] % '%+03d:%02d'
-    return pattern % (hours, seconds // 60)
+        pattern = locale.zone_formats['gmt'] % '%s%02d:%02d'
+    return pattern % (sign, hours, seconds // 60)
 
 
 def get_timezone_location(

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -455,6 +455,13 @@ def test_get_timezone_gmt(timezone_getter):
     assert dates.get_timezone_gmt(dt, 'short', locale='en') == '-0700'
     assert dates.get_timezone_gmt(dt, locale='en', width='iso8601_short') == '-07'
     assert dates.get_timezone_gmt(dt, 'long', locale='fr_FR') == 'UTC-07:00'
+    # A negative offset with a non-zero minute part must keep the correct hour
+    # (Newfoundland Standard Time is UTC-03:30, not UTC-04:30).
+    tz = timezone_getter('America/St_Johns')
+    dt = _localize(tz, datetime(2007, 1, 1, 12, 0))
+    assert dates.get_timezone_gmt(dt, locale='en') == 'GMT-03:30'
+    assert dates.get_timezone_gmt(dt, 'short', locale='en') == '-0330'
+    assert dates.get_timezone_gmt(dt, locale='en', width='iso8601') == '-03:30'
 
 
 def test_get_timezone_location(timezone_getter):


### PR DESCRIPTION
## Summary

`get_timezone_gmt` renders the wrong hour for any timezone whose UTC offset has a non-zero minute part and is negative. For example, Newfoundland Standard Time (`America/St_Johns`, UTC-03:30):

```python
>>> from datetime import datetime
>>> from babel.dates import get_timezone, get_timezone_gmt
>>> tz = get_timezone('America/St_Johns')
>>> dt = datetime(2007, 1, 1, 12, 0, tzinfo=tz)
>>> get_timezone_gmt(dt, locale='en')
'GMT-04:30'          # should be 'GMT-03:30'
>>> get_timezone_gmt(dt, 'short', locale='en')
'-0430'              # should be '-0330'
```

`Pacific/Marquesas` (UTC-09:30) is likewise rendered as `GMT-10:30`. Positive fractional offsets (`Asia/Kolkata`, `+05:30`) and whole-hour negatives (`America/Los_Angeles`, `-08:00`) are correct, so this is specific to negative offsets with minutes. Newfoundland Time covers a real, populated region, so this is user-facing incorrect output.

## Root cause

`divmod()` on a negative value floors the quotient and returns a non-negative remainder:

```python
>>> divmod(-12600, 3600)   # -3:30 in seconds
(-4, 1800)
```

The code printed the floored hour (`-4`) via `%+03d` while taking the minutes from the positive remainder (`1800 // 60 == 30`), producing `-04:30` for a `-03:30` offset.

## Fix

Decompose the offset from its absolute value and track the sign separately (the same idiom the code already uses elsewhere):

```python
sign = '-' if seconds < 0 else '+'
hours, seconds = divmod(abs(seconds), 3600)
```

and emit the sign explicitly (`'%s%02d...'`) instead of relying on `'%+03d'`.

For every offset that already formatted correctly the output is unchanged: `'%s%02d'` with the explicit sign is byte-identical to `'%+03d'` whenever `0 <= hours < 100`. I verified this exhaustively across all offsets from -12:00 to +14:00 in 15-minute steps and all four widths (plus `return_z`): the new code differs from the old in exactly the negative-fractional cases and nowhere else.

## Tests

Added three assertions to the existing `test_get_timezone_gmt` (already parametrized over both the `pytz` and `zoneinfo` backends). They fail before the change (`AssertionError: assert 'GMT-04:30' == 'GMT-03:30'`) and pass after, on both backends.

Happy to add a `CHANGES.rst` bugfix entry if you would like one included in this PR rather than compiled at release time.