### PR TITLE
Clamp rounded fractional seconds to the field width

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1646,7 +1646,10 @@ class DateTimeFormat:
         of digits passed in.
         """
         value = self.value.microsecond / 1000000
-        return self.format(round(value, num) * 10**num, num)
+        # Rounding can carry the value up to a whole second (for example 0.999
+        # rounds to 1.0), which would add a digit; clamp to the field width.
+        frac = min(int(round(value, num) * 10**num), 10**num - 1)
+        return self.format(frac, num)
 
     def format_milliseconds_in_day(self, num):
         msecs = (

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -177,6 +177,14 @@ class DateTimeFormatTestCase:
         t = time(15, 30, 0)
         assert dates.DateTimeFormat(t, locale='en_US')['SSSS'] == '0000'
 
+    def test_fractional_seconds_rounding_does_not_overflow_field(self):
+        t = time(1, 2, 3, 990000)
+        assert dates.DateTimeFormat(t, locale='en_US')['S'] == '9'
+        t = time(1, 2, 3, 999500)
+        assert dates.DateTimeFormat(t, locale='en_US')['SS'] == '99'
+        t = time(1, 2, 3, 999999)
+        assert dates.DateTimeFormat(t, locale='en_US')['SSSS'] == '9999'
+
     def test_milliseconds_in_day(self):
         t = time(15, 30, 12, 345000)
         assert dates.DateTimeFormat(t, locale='en_US')['AAAA'] == '55812345'


### PR DESCRIPTION
`DateTimeFormat.format_frac_seconds` can render a fractional-seconds field that is wider than its declared number of digits.

The method rounds the microseconds to the requested precision:

```python
value = self.value.microsecond / 1000000
return self.format(round(value, num) * 10**num, num)
```

`round(value, num)` can carry up to a whole second (for example `0.999` rounds to `1.0`). Then `1.0 * 10**num == 10**num`, which has `num + 1` digits, and `self.format` (`'%0*d' % (num, value)`) prints all of them. Babel intentionally does not carry into the seconds field, so the fractional field simply overflows its width.

```python
from datetime import time
from babel.dates import DateTimeFormat

DateTimeFormat(time(1, 2, 3, 990000), locale='en_US')['S']    # '10'  (expected '9')
DateTimeFormat(time(1, 2, 3, 999500), locale='en_US')['SS']   # '100' (expected '99')
```

A single `S` digit must be 0 to 9, but it can render `10`.

Fix: clamp the rounded value to the largest in-field value so it stays within the declared width:

```python
frac = min(int(round(value, num) * 10**num), 10**num - 1)
return self.format(frac, num)
```

This only changes the overflow case (the value is clamped to all nines, the closest representation without carrying into seconds). Every existing `test_fractional_seconds` expectation, including the deliberately rounded `['SSSS'] == '0346'`, is unchanged. Added a regression test covering the `S`, `SS`, and `SSSS` overflow inputs.
