### PR TITLE
Don't crash on blank PO-Revision-Date / POT-Creation-Date headers

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -582,10 +582,16 @@ class Catalog:
                 self._num_plurals = int(params.get('nplurals', 2))
                 self._plural_expr = params.get('plural', '(n != 1)')
             elif name == 'pot-creation-date':
-                self.creation_date = _parse_datetime_header(value)
+                # Some tools (e.g. Poedit) may leave this header blank.
+                # Keep the previous/default value rather than crashing.
+                if value.strip():
+                    self.creation_date = _parse_datetime_header(value)
             elif name == 'po-revision-date':
-                # Keep the value if it's not the default one
-                if 'YEAR' not in value:
+                # Keep the value if it's not the default one.
+                # Some tools (e.g. Poedit) may also leave this header
+                # blank; keep the previous/default value in that case
+                # too, rather than crashing.
+                if 'YEAR' not in value and value.strip():
                     self.revision_date = _parse_datetime_header(value)
 
     mime_headers = property(

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -346,6 +346,36 @@ def test_catalog_stores_datetime_correctly():
             assert value == '2009-03-09 15:47-0700'
 
 
+def test_catalog_handles_blank_revision_and_creation_date():
+    """Regression test for
+    https://github.com/python-babel/babel/issues/1219
+
+    Some tools (e.g. Poedit) can leave PO-Revision-Date and/or
+    POT-Creation-Date blank in the header. Parsing such a header must
+    not raise, and must not silently store an unparseable value that
+    would corrupt the header on write-out.
+    """
+    cat = catalog.Catalog()
+    default_creation_date = cat.creation_date
+    default_revision_date = cat.revision_date
+
+    cat[''] = catalog.Message(
+        '',
+        "POT-Creation-Date: \n"
+        "PO-Revision-Date: \n",
+    )
+
+    # The blank headers should not have overwritten the defaults with
+    # an unparseable value (e.g. the raw empty string) or crashed.
+    assert cat.creation_date == default_creation_date
+    assert cat.revision_date == default_revision_date
+
+    for key, value in cat.mime_headers:
+        if key in ('POT-Creation-Date', 'PO-Revision-Date'):
+            assert value is not None
+            assert 'None' not in str(value)
+
+
 def test_catalog_mime_headers_contain_same_information_as_attributes():
     cat = catalog.Catalog()
     cat[''] = catalog.Message('',


### PR DESCRIPTION
Fixes #1219.

Some tools (e.g. Poedit) can leave the `PO-Revision-Date` header blank in a generated `.po` file instead of omitting it or using the conventional `YEAR-MO-DA HO:MI+ZONE` placeholder. Parsing such a file crashes with:
```
ValueError: time data '' does not match format '%Y-%m-%d %H:%M'
```
because `_parse_datetime_header()` is called unconditionally with the blank value, as reported in the issue.

**Fix**: guard both call sites (`po-revision-date` and, for the same reason, `pot-creation-date`) to skip parsing when the header value is blank, keeping the previous/default value instead -- the same treatment already given to the `YEAR-MO-DA HO:MI+ZONE` placeholder value right above it, and to a blank `Language` header elsewhere in this same method (`self._set_locale(value or None)`).

**Testing**: added a regression test that parses a message block with both headers blank and asserts: no exception is raised, `creation_date`/`revision_date` fall back to their defaults rather than being corrupted, and no literal `None` leaks into the round-tripped `mime_headers` output. I confirmed the test fails with the original `ValueError` without the fix, and passes with it.

I also verified end-to-end with an actual `.po` file parse + write round-trip (using an installed release build with CLDR data, since a shallow clone here can't build that data on its own), confirming no `None` leaks into the output and that normal (non-blank) header values are completely unaffected. Ran the full existing `test_catalog.py` and `test_pofile.py` suites: all pass, no regressions.