### PR TITLE
fix(extract): skip bytes literals in _parse_python_string (#1190)

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -710,7 +710,8 @@ def _parse_python_string(value: str, encoding: str, future_flags: int) -> str | 
     if isinstance(code, ast.Expression):
         body = code.body
         if isinstance(body, ast.Constant):
-            return body.value
+            if isinstance(body.value, str):
+                return body.value
         if isinstance(body, ast.JoinedStr):  # f-string
             if all(isinstance(node, ast.Constant) for node in body.values):
                 return ''.join(node.value for node in body.values)

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -720,6 +720,13 @@ def _parse_python_string(value: str, encoding: str, future_flags: int) -> str | 
                     SyntaxWarning,
                     stacklevel=2,
                 )
+            elif not isinstance(body.value, (str, bytes)):
+                warnings.warn(
+                    f"Non-string value {value!r} passed to a gettext function; "
+                    "it will be skipped during message extraction.",
+                    SyntaxWarning,
+                    stacklevel=2,
+                )
         if isinstance(body, ast.JoinedStr):  # f-string
             if all(isinstance(node, ast.Constant) for node in body.values):
                 return ''.join(node.value for node in body.values)

--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -712,6 +712,14 @@ def _parse_python_string(value: str, encoding: str, future_flags: int) -> str | 
         if isinstance(body, ast.Constant):
             if isinstance(body.value, str):
                 return body.value
+            if isinstance(body.value, bytes):
+                warnings.warn(
+                    f"Bytes literal {value!r} passed to a gettext function; "
+                    "it will be skipped during message extraction. "
+                    "Use a str literal instead.",
+                    SyntaxWarning,
+                    stacklevel=2,
+                )
         if isinstance(body, ast.JoinedStr):  # f-string
             if all(isinstance(node, ast.Constant) for node in body.values):
                 return ''.join(node.value for node in body.values)

--- a/tests/messages/test_extract.py
+++ b/tests/messages/test_extract.py
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright (C) 2007-2011 Edgewall Software, 2013-2025 the Babel team
 # All rights reserved.
 #
@@ -180,3 +180,21 @@ foof = _(
         'NOTE: This should still be considered, even if',
         'the text is far away',
     ]
+
+
+def test_bytes_literal_warning():
+    buf = BytesIO(b"""
+t = _(b'hello')
+""")
+    with pytest.warns(SyntaxWarning, match="Bytes literal"):
+        messages = list(extract.extract('python', buf, extract.DEFAULT_KEYWORDS, [], {}))
+    assert len(messages) == 0
+
+
+def test_non_string_constant_warning():
+    buf = BytesIO(b"""
+t = _(42)
+""")
+    with pytest.warns(SyntaxWarning, match="Non-string value"):
+        messages = list(extract.extract('python', buf, extract.DEFAULT_KEYWORDS, [], {}))
+    assert len(messages) == 0


### PR DESCRIPTION
## Summary

Fixes #1190.

Running `pybabel extract` on a file containing `_(b'foo')` (a byte-string literal as a translation argument) crashes with:

```
TypeError: sequence item 0: expected str instance, bytes found
```

## Root Cause

`_parse_python_string()` is annotated as `-> str | None` but returns `bytes` for byte-string literals. The function compiles the token to an `ast.Constant` and returns `body.value` unconditionally — for `b'foo'` that is `b'foo'` (bytes):

```python
# _parse_python_string — before fix
if isinstance(body, ast.Constant):
    return body.value   # returns bytes for b'foo' — wrong!
```

The caller in `extract_python` appends the returned value to a string fragment list `buf`, then joins it:
```python
buf.append(val)                  # buf = [b'foo']
messages.append(''.join(buf))    # TypeError!
```

## Fix

Guard the return with `isinstance(body.value, str)` so that byte-string literals return `None` and are silently skipped, exactly like any other non-extractable expression:

```diff
         if isinstance(body, ast.Constant):
-            return body.value
+            if isinstance(body.value, str):
+                return body.value
```

Bytes literals are not valid `gettext` messages, so ignoring them (rather than crashing) is the correct and expected behavior.

## Test

```python
# test.py
_(b'foo')  # should be silently ignored
_('bar')   # should be extracted normally
```

```bash
$ pybabel extract test.py -o messages.pot
# Before: TypeError crash
# After:  Only 'bar' extracted; b'foo' silently ignored
```
