### PR TITLE
Don't crash on blank PO-Revision-Date/POT-Creation-Date headers

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import datetime
 import re
 from collections.abc import Iterable, Iterator
+from contextlib import suppress
 from copy import copy
 from difflib import SequenceMatcher
 from email import message_from_string
@@ -582,11 +583,19 @@ class Catalog:
                 self._num_plurals = int(params.get('nplurals', 2))
                 self._plural_expr = params.get('plural', '(n != 1)')
             elif name == 'pot-creation-date':
-                self.creation_date = _parse_datetime_header(value)
+                # Some tools (e.g. Poedit) may leave this header blank or
+                # otherwise malformed; rather than crashing, just ignore it
+                # and keep the existing value in that case.
+                with suppress(ValueError):
+                    self.creation_date = _parse_datetime_header(value)
             elif name == 'po-revision-date':
                 # Keep the value if it's not the default one
                 if 'YEAR' not in value:
-                    self.revision_date = _parse_datetime_header(value)
+                    # Some tools (e.g. Poedit) may leave this header blank or
+                    # otherwise malformed; rather than crashing, just ignore
+                    # it and keep the existing value in that case.
+                    with suppress(ValueError):
+                        self.revision_date = _parse_datetime_header(value)
 
     @property
     def mime_headers(self) -> list[tuple[str, str]]:

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -335,6 +335,22 @@ def test_catalog_update_po_keeps_po_revision_date():
     assert localized_catalog.revision_date == fake_rev_date
 
 
+def test_catalog_set_mime_headers_ignores_blank_dates():
+    # Some tools (e.g. Poedit) can leave the PO-Revision-Date and/or
+    # POT-Creation-Date headers blank instead of omitting them or using the
+    # "YEAR-MO-DA HO:MI+ZONE" placeholder. This used to raise a ValueError
+    # instead of being handled gracefully.
+    cat = catalog.Catalog()
+    original_creation_date = cat.creation_date
+    original_revision_date = cat.revision_date
+    cat._set_mime_headers([
+        ('POT-Creation-Date', ''),
+        ('PO-Revision-Date', ''),
+    ])
+    assert cat.creation_date == original_creation_date
+    assert cat.revision_date == original_revision_date
+
+
 def test_catalog_stores_datetime_correctly():
     localized = catalog.Catalog()
     localized.locale = 'de_DE'


### PR DESCRIPTION
## Bug

Closes #1219

Some tools (e.g. Poedit) leave `PO-Revision-Date` or `POT-Creation-Date` blank in a `.po` file's header, instead of using the `YEAR-MO-DA HO:MI+ZONE` placeholder or omitting the header entirely.

`Catalog._set_mime_headers()` passes that value straight to `_parse_datetime_header()`, which does:

```python
dt = datetime.datetime.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
```

With an empty string this raises:

```
ValueError: time data '' does not match format '%Y-%m-%d %H:%M'
```

which propagates all the way up and crashes `pybabel extract`/`update`/`compile` (see the traceback in #1219).

## Fix

Wrap both call sites (`pot-creation-date` and `po-revision-date`) in `contextlib.suppress(ValueError)`, so a blank or otherwise malformed date header is simply ignored (keeping whatever default/previous value the `Catalog` already had) instead of aborting the whole command. This matches the "ignore the blank date, or at least give a graceful message instead of crashing" request in the issue.

## Testing

- Added `test_catalog_set_mime_headers_ignores_blank_dates` in `tests/messages/test_catalog.py`, which reproduces the crash against the old code (fails with the reported `ValueError` before the fix) and passes after it.
- Ran the full test suite: `pytest tests/messages` — 353 passed.
- Ran `ruff check` on the changed files — no issues.