### PR TITLE
Fix: In babel/messages/catalog.py Catalog._set_mime_headers(), the...

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -579,8 +579,15 @@ class Catalog:
                     self.charset = params['charset'].lower()
             elif name == 'plural-forms':
                 params = parse_separated_header(f" ;{value}")
-                self._num_plurals = int(params.get('nplurals', 2))
-                self._plural_expr = params.get('plural', '(n != 1)')
+                # nplurals/plural values may be left as the untranslated
+                # xgettext placeholders (e.g. in a fresh POT template);
+                # fall back to the defaults in that case instead of
+                # crashing on int(), mirroring the po-revision-date guard
+                # for the analogous 'YEAR' placeholder below.
+                num_plurals = params.get('nplurals', 2)
+                self._num_plurals = 2 if num_plurals == 'INTEGER' else int(num_plurals)
+                plural_expr = params.get('plural', '(n != 1)')
+                self._plural_expr = '(n != 1)' if plural_expr == 'EXPRESSION' else plural_expr
             elif name == 'pot-creation-date':
                 self.creation_date = _parse_datetime_header(value)
             elif name == 'po-revision-date':

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -462,6 +462,22 @@ def test_catalog_mime_headers_set_locale():
     ]
 
 
+def test_catalog_mime_headers_xgettext_plural_forms_placeholder():
+    """
+    A freshly-generated POT template from xgettext may leave the
+    Plural-Forms header with unexpanded placeholder tokens
+    (``nplurals=INTEGER; plural=EXPRESSION;``) instead of real values.
+    Parsing such a header should not raise, and should fall back to the
+    same defaults used elsewhere in the catalog.
+    """
+    cat = catalog.Catalog()
+    cat.mime_headers = [
+        ('Plural-Forms', 'nplurals=INTEGER; plural=EXPRESSION;'),
+    ]
+    assert cat.num_plurals == 2
+    assert cat.plural_expr == '(n != 1)'
+
+
 def test_catalog_mime_headers_type_coercion():
     """
     Test that mime headers' keys and values are coerced to strings

--- a/tests/messages/test_pofile.py
+++ b/tests/messages/test_pofile.py
@@ -146,6 +146,20 @@ msgstr ""
     assert pofile.read_po(buf).locale is None
 
 
+def test_issue_1154():
+    # A freshly-generated POT template from xgettext may leave the
+    # Plural-Forms header with unexpanded placeholder tokens instead of
+    # real values; parsing it should not raise.
+    buf = StringIO(r'''
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+''')
+    cat = pofile.read_po(buf)
+    assert cat.num_plurals == 2
+    assert cat.plural_expr == '(n != 1)'
+
+
 @pytest.mark.parametrize("case", ['msgid "foo"', 'msgid "foo"\nmsgid_plural "foos"'])
 @pytest.mark.parametrize("abort_invalid", [False, True])
 def test_issue_1134(case: str, abort_invalid: bool):


### PR DESCRIPTION
## Summary
Added a fallback in the 'plural-forms' branch of _set_mime_headers(): if nplurals == 'INTEGER', use the default 2; if plural == 'EXPRESSION', use the default '(n != 1)' expression -- otherwise parse/use the real values as before. This work was already completed and committed in this worktree (commit 314ade9) prior to this session's verification pass.

## Problem
python-babel/babel issue reference: python-babel/babel#1154

## Root Cause
In babel/messages/catalog.py Catalog._set_mime_headers(), the 'plural-forms' branch did `int(params.get('nplurals', 2))` and used the raw 'plural' value unconditionally. When a POT template is freshly generated by xgettext but not yet localized, these fields retain the literal placeholder tokens 'INTEGER' and 'EXPRESSION' instead of real values, so int() crashes. This mirrors the pre-existing 'YEAR' placeholder issue already guarded for po-revision-date just below it.

## Testing
PASS - all 79 tests in test_pofile.py and test_catalog.py pass (after running `python setup.py import_cldr` to build required CLDR data files, which is a documented one-time environment setup step, not related to this fix); the new test_issue_1154 regression test passes on its own as well.

## Related Issue
python-babel/babel#1154
