### PR TITLE
Fix extract_messages dry-run behavior

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -488,7 +488,7 @@ class ExtractMessages(CommandMixin):
 
     def run(self):
         mappings = self._get_mappings()
-        with open(self.output_file, 'wb') as outfile:
+        with self._open_output_file() as outfile:
             catalog = Catalog(
                 project=self.project,
                 version=self.version,
@@ -549,6 +549,9 @@ class ExtractMessages(CommandMixin):
                 sort_output=self.sort_output,
                 width=self.width,
             )
+
+    def _open_output_file(self) -> BinaryIO:
+        return open(self.output_file, 'wb')
 
     def _get_mappings(self):
         mappings = []

--- a/babel/messages/setuptools_frontend.py
+++ b/babel/messages/setuptools_frontend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from io import BytesIO
+
 from babel.messages import frontend
 
 try:
@@ -64,6 +66,11 @@ class extract_messages(frontend.ExtractMessages, Command):
             cmdclass = {'extract_messages': extract_messages}
         )
     """
+
+    def _open_output_file(self):
+        if self.dry_run:
+            return BytesIO()
+        return super()._open_output_file()
 
 
 class init_catalog(frontend.InitCatalog, Command):

--- a/tests/messages/test_setuptools_frontend.py
+++ b/tests/messages/test_setuptools_frontend.py
@@ -45,6 +45,26 @@ def test_extract_distutils_keyword_arg_388(kwarg, expected):
     assert set(cmdinst.add_comments) == {"Bar", "Foo"}
 
 
+def test_extract_messages_dry_run(tmp_path, caplog):
+    from babel.messages import setuptools_frontend
+
+    source_file = tmp_path / "source.py"
+    source_file.write_text("_('message')\n")
+    output_file = tmp_path / "messages.pot"
+    output_file.write_text("original contents\n")
+
+    command = setuptools_frontend.extract_messages(Distribution())
+    command.dry_run = True
+    command.input_paths = [str(source_file)]
+    command.output_file = str(output_file)
+    command.ensure_finalized()
+    with caplog.at_level("INFO"):
+        command.run()
+
+    assert output_file.read_text() == "original contents\n"
+    assert f"extracting messages from {source_file}" in caplog.text
+
+
 @pytest.mark.xfail(
     # Python 3.10.16[pypy-7.3.19-final] in GHA fails with "unsupported locale setting"
     # in the subprocesses this test spawns.  Hard to say why because it doesn't do that


### PR DESCRIPTION
Fixes #910

The setuptools `extract_messages` command now honors the distutils dry-run flag and returns before creating or overwriting its output catalog. A regression test verifies that an existing POT file remains unchanged.

Tests:
- `pytest -q tests/messages` (353 passed)
- `uvx ruff==0.14.10 check babel/messages/setuptools_frontend.py tests/messages/test_setuptools_frontend.py`