### PR TITLE
Fix JavaScript number tokenization

### DIFF
--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -24,8 +24,8 @@ operators: list[str] = sorted([
 
 escapes: dict[str, str] = {'b': '\b', 'f': '\f', 'n': '\n', 'r': '\r', 't': '\t'}
 
-name_re = re.compile(r'[\w$_][\w\d$_]*', re.UNICODE)
-dotted_name_re = re.compile(r'[\w$_][\w\d$_.]*[\w\d$_.]', re.UNICODE)
+name_re = re.compile(r'(?!\d)[\w$_][\w\d$_]*', re.UNICODE)
+dotted_name_re = re.compile(r'(?!\d)[\w$_][\w\d$_.]*[\w\d$_.]', re.UNICODE)
 division_re = re.compile(r'/=?')
 regex_re = re.compile(r'/(?:[^/\\]*(?:\\.[^/\\]*)*)/[a-zA-Z]*', re.DOTALL)
 line_re = re.compile(r'(\r\n|\n|\r)')
@@ -48,10 +48,10 @@ _rules: list[tuple[str | None, re.Pattern[str]]] = [
     ('dotted_name', dotted_name_re),
     ('name', name_re),
     ('number', re.compile(r'''(
+        (0x[a-fA-F0-9]+) |
         (?:0|[1-9]\d*)
         (\.\d+)?
-        ([eE][-+]?\d+)? |
-        (0x[a-fA-F0-9]+)
+        ([eE][-+]?\d+)?
     )''', re.VERBOSE)),
     ('jsx_tag', re.compile(r'(?:</?[^>\s]+|/>)', re.I)),  # May be mangled in `get_rules`
     ('operator', re.compile(r'(%s)' % '|'.join(re.escape(op) for op in operators))),

--- a/tests/messages/test_jslexer.py
+++ b/tests/messages/test_jslexer.py
@@ -12,6 +12,15 @@ def test_dollar_in_identifier():
     assert list(jslexer.tokenize('dollar$dollar')) == [('name', 'dollar$dollar', 1)]
 
 
+def test_number_literals():
+    assert list(jslexer.tokenize('42 3.14 1e3 0x2a')) == [
+        ('number', '42', 1),
+        ('number', '3.14', 1),
+        ('number', '1e3', 1),
+        ('number', '0x2a', 1),
+    ]
+
+
 def test_dotted_name():
     assert list(jslexer.tokenize("foo.bar(quux)", dotted=True)) == [
         ('name', 'foo.bar', 1),


### PR DESCRIPTION
Fixes #789

Prevent JavaScript identifier rules from matching tokens that start with a digit, allowing decimal, fractional, and exponent literals to reach the number rule. The number rule now checks hexadecimal literals before the shorter `0` alternative so their full token is preserved.

Adds focused regression coverage for all four supported number forms.

Tests:
- `python -m pytest -q` — 7736 passed, 7 skipped, 2 xfailed
- `pre-commit run --files babel/messages/jslexer.py tests/messages/test_jslexer.py`
- `python -m compileall -q babel/messages/jslexer.py tests/messages/test_jslexer.py`
