### PR TITLE
Fix JavaScript escaped line terminator extraction

### DIFF
--- a/babel/messages/jslexer.py
+++ b/babel/messages/jslexer.py
@@ -103,7 +103,7 @@ def unquote_string(string: str) -> str:
     assert string and string[0] == string[-1] and string[0] in '"\'`', (
         'string provided is not properly delimited'
     )
-    string = line_join_re.sub('\\1', string[1:-1])
+    string = line_join_re.sub('', string[1:-1])
     result: list[str] = []
     add = result.append
     pos = 0

--- a/tests/messages/test_js_extract.py
+++ b/tests/messages/test_js_extract.py
@@ -20,6 +20,12 @@ msg3 = ngettext('s', 'p', 42)
                         (3, ('s', 'p'), [], None)]
 
 
+def test_extract_string_with_escaped_line_terminator():
+    buf = BytesIO(b"_('hey\\\nlol')")
+    messages = list(extract.extract('javascript', buf, extract.DEFAULT_KEYWORDS, [], {}))
+    assert messages == [(1, 'heylol', [], None)]
+
+
 def test_various_calls():
     buf = BytesIO(b"""\
 msg1 = _(i18n_arg.replace(/"/, '"'))


### PR DESCRIPTION
Fixes #1056

## Summary
- remove escaped line terminators when unquoting JavaScript strings
- add extraction regression coverage for a string continued across a newline

## Tests
- .venv/bin/python -m pytest -q tests/messages/test_jslexer.py tests/messages/test_js_extract.py
- .venv/bin/pre-commit run --files babel/messages/jslexer.py tests/messages/test_js_extract.py