### PR TITLE
Ignore blank PO-Revision-Date/POT-Creation-Date header values

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -103,10 +103,18 @@ def _has_python_brace_format(string: str) -> bool:
     return field_name_seen
 
 
-def _parse_datetime_header(value: str) -> datetime.datetime:
+def _parse_datetime_header(value: str) -> datetime.datetime | None:
     match = re.match(r'^(?P<datetime>.*?)(?P<tzoffset>[+-]\d{4})?$', value)
 
-    dt = datetime.datetime.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
+    dt_str = match.group('datetime').strip()
+    if not dt_str:
+        # Some tools (e.g. Poedit) leave the PO-Revision-Date/POT-Creation-Date
+        # header value blank instead of using the conventional
+        # 'YEAR-MO-DA HO:MI+ZONE' placeholder or omitting the header
+        # altogether. There's nothing meaningful to parse in that case.
+        return None
+
+    dt = datetime.datetime.strptime(dt_str, '%Y-%m-%d %H:%M')
 
     # Separate the offset into a sign component, hours, and # minutes
     tzoffset = match.group('tzoffset')
@@ -591,11 +599,15 @@ class Catalog:
                 self._num_plurals = int(params.get('nplurals', 2))
                 self._plural_expr = params.get('plural', '(n != 1)')
             elif name == 'pot-creation-date':
-                self.creation_date = _parse_datetime_header(value)
+                parsed = _parse_datetime_header(value)
+                if parsed is not None:
+                    self.creation_date = parsed
             elif name == 'po-revision-date':
                 # Keep the value if it's not the default one
                 if 'YEAR' not in value:
-                    self.revision_date = _parse_datetime_header(value)
+                    parsed = _parse_datetime_header(value)
+                    if parsed is not None:
+                        self.revision_date = parsed
 
     @property
     def mime_headers(self) -> list[tuple[str, str]]:

--- a/tests/messages/test_catalog.py
+++ b/tests/messages/test_catalog.py
@@ -557,6 +557,29 @@ def test_datetime_parsing():
     assert val2.tzinfo is None
 
 
+def test_datetime_parsing_blank_value():
+    # Some tools (e.g. Poedit) leave the PO-Revision-Date/POT-Creation-Date
+    # header value blank instead of using the conventional
+    # 'YEAR-MO-DA HO:MI+ZONE' placeholder or omitting the header
+    # altogether; this used to raise a ValueError. See GH issue #1219.
+    assert catalog._parse_datetime_header('') is None
+    assert catalog._parse_datetime_header('   ') is None
+
+
+def test_set_mime_headers_ignores_blank_dates():
+    cat = catalog.Catalog()
+    default_creation_date = cat.creation_date
+    default_revision_date = cat.revision_date
+
+    cat._set_mime_headers([
+        ('POT-Creation-Date', ''),
+        ('PO-Revision-Date', ''),
+    ])
+
+    assert cat.creation_date == default_creation_date
+    assert cat.revision_date == default_revision_date
+
+
 def test_update_catalog_comments():
     # Based on https://web.archive.org/web/20100710131029/http://babel.edgewall.org/attachment/ticket/163/cat-update-comments.py
 


### PR DESCRIPTION
## Summary

`pybabel update`/`compile` crashes with an unhandled `ValueError` when a `.po` file has a blank `PO-Revision-Date` (or `POT-Creation-Date`) header value, as generated by some tools (e.g. Poedit) instead of the conventional `YEAR-MO-DA HO:MI+ZONE` placeholder or omitting the header entirely.

```
File ".../babel/messages/catalog.py", line 109, in _parse_datetime_header
    dt = datetime.datetime.strptime(match.group('datetime'), '%Y-%m-%d %H:%M')
ValueError: time data '' does not match format '%Y-%m-%d %H:%M'
```

## Root cause

`_parse_datetime_header()` unconditionally passes its input to `datetime.strptime()`. The `po-revision-date` call site already special-cases the literal `'YEAR-MO-DA HO:MI+ZONE'` placeholder to avoid parsing it, but doesn't handle a blank value, and the `pot-creation-date` call site has no such guard at all.

## Fix

`_parse_datetime_header()` now returns `None` for a blank (or whitespace-only) value instead of raising. Both call sites in `Catalog._set_mime_headers()` only assign `creation_date`/`revision_date` when the parse actually returns a value, so a blank header now falls back to the existing defaults instead of crashing -- the same behavior the `'YEAR-MO-DA HO:MI+ZONE'` placeholder already gets.

## Testing

- Added `test_datetime_parsing_blank_value` (unit test for `_parse_datetime_header`) and `test_set_mime_headers_ignores_blank_dates` (integration test through `Catalog._set_mime_headers`) to `tests/messages/test_catalog.py`.
- `tests/messages/test_catalog.py`: 46 passed.
- `tests/messages/` (full, with CLDR data built via `scripts/download_import_cldr.py`): 383 passed, 1 skipped (the 3 apparent failures without CLDR/cwd setup are pre-existing and unrelated -- they pass once run from the repo root).
- Reverting only `babel/messages/catalog.py` (keeping the new tests) reproduces the exact reported error: `ValueError: time data '' does not match format '%Y-%m-%d %H:%M'`.
- `ruff check` clean on both changed files.

Fixes #1219
