### PR TITLE
Report extra PO plural forms without changing parse

### DIFF
--- a/babel/messages/catalog.py
+++ b/babel/messages/catalog.py
@@ -192,6 +192,9 @@ class Message:
             self.previous_id = []
         self.lineno = lineno
         self.context = context
+        # msgstr[N] entries dropped while reading a PO file because
+        # N was >= catalog.num_plurals. Does not affect message.string.
+        self.discarded_plural_forms = 0
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__} {self.id!r} (flags: {list(self.flags)!r})>"
@@ -232,7 +235,7 @@ class Message:
         return self.__dict__ == other.__dict__
 
     def clone(self) -> Message:
-        return Message(
+        cloned = Message(
             id=copy(self.id),
             string=copy(self.string),
             locations=copy(self.locations),
@@ -243,6 +246,8 @@ class Message:
             lineno=self.lineno,  # immutable (str/None)
             context=self.context,  # immutable (str/None)
         )
+        cloned.discarded_plural_forms = self.discarded_plural_forms
+        return cloned
 
     def check(self, catalog: Catalog | None = None) -> list[TranslationError]:
         """Run various validation checks on the message.  Some validations
@@ -774,6 +779,10 @@ class Catalog:
             current.auto_comments = list(dict.fromkeys([*current.auto_comments, *message.auto_comments]))  # fmt:skip
             current.user_comments = list(dict.fromkeys([*current.user_comments, *message.user_comments]))  # fmt:skip
             current.flags |= message.flags
+            current.discarded_plural_forms = max(
+                current.discarded_plural_forms,
+                message.discarded_plural_forms,
+            )
         elif id == '':
             # special treatment for the header message
             self.mime_headers = message_from_string(message.string).items()
@@ -996,6 +1005,7 @@ class Catalog:
                 oldmsg = remaining.pop(oldkey, None)
                 assert oldmsg is not None
             message.string = oldmsg.string
+            message.discarded_plural_forms = oldmsg.discarded_plural_forms
 
             if keep_user_comments and oldmsg.user_comments:
                 message.user_comments = list(dict.fromkeys(oldmsg.user_comments))

--- a/babel/messages/checkers.py
+++ b/babel/messages/checkers.py
@@ -38,7 +38,8 @@ def num_plurals(catalog: Catalog | None, message: Message) -> None:
     msgstrs = message.string
     if not isinstance(msgstrs, (list, tuple)):
         msgstrs = (msgstrs,)
-    if len(msgstrs) != catalog.num_plurals:
+    n_forms = len(msgstrs) + message.discarded_plural_forms
+    if n_forms != catalog.num_plurals:
         raise TranslationError(
             f"Wrong number of plural forms (expected {catalog.num_plurals})",
         )

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -194,17 +194,19 @@ class PoFileParser:
         Add a message to the catalog based on the current parser state and
         clear the state ready to process the next message.
         """
+        discarded_plural_forms = 0
         if len(self.messages) > 1:
             msgid = tuple(m.denormalize() for m in self.messages)
             string = ['' for _ in range(self.catalog.num_plurals)]
             for idx, translation in sorted(self.translations):
-                if idx >= len(string):
+                if idx >= self.catalog.num_plurals:
                     self._invalid_pofile(
                         "",
                         self.offset,
                         "msg has more translations than num_plurals of catalog",
                     )
-                    string.extend([''] * (idx + 1 - len(string)))
+                    discarded_plural_forms += 1
+                    continue
                 string[idx] = translation.denormalize()
             string = tuple(string)
         else:
@@ -221,6 +223,7 @@ class PoFileParser:
             lineno=self.offset + 1,
             context=msgctxt,
         )
+        message.discarded_plural_forms = discarded_plural_forms
         if self.obsolete:
             if not self.ignore_obsolete:
                 self.catalog.obsolete[self.catalog._key_for(msgid, msgctxt)] = message

--- a/babel/messages/pofile.py
+++ b/babel/messages/pofile.py
@@ -198,13 +198,13 @@ class PoFileParser:
             msgid = tuple(m.denormalize() for m in self.messages)
             string = ['' for _ in range(self.catalog.num_plurals)]
             for idx, translation in sorted(self.translations):
-                if idx >= self.catalog.num_plurals:
+                if idx >= len(string):
                     self._invalid_pofile(
                         "",
                         self.offset,
                         "msg has more translations than num_plurals of catalog",
                     )
-                    continue
+                    string.extend([''] * (idx + 1 - len(string)))
                 string[idx] = translation.denormalize()
             string = tuple(string)
         else:

--- a/tests/messages/test_checkers.py
+++ b/tests/messages/test_checkers.py
@@ -79,8 +79,8 @@ msgstr[0] ""
 
 
 def test_2_num_plurals_checkers():
-    # in this testcase we add an extra msgstr[idx], we should be
-    # disregarding it
+    # Extra msgstr[idx] beyond catalog.num_plurals must still be visible
+    # to the checker (not discarded while reading the PO file).
     for _locale in [p for p in PLURALS if PLURALS[p][0] == 2]:
         if _locale in ['nn', 'no']:
             _locale = 'nn_NO'
@@ -132,12 +132,31 @@ msgstr[1] ""
 msgstr[2] ""
 
 """.encode('utf-8')
-        # we should be adding the missing msgstr[0]
-
-        # This test will fail for revisions <= 406 because so far
-        # catalog.num_plurals was neglected
         catalog = read_po(BytesIO(po_file), _locale)
         message = catalog['foobar']
+        # Extra msgstr[2] is kept so the checker can report it instead of
+        # silently shrinking the message back to catalog.num_plurals.
+        with pytest.raises(TranslationError, match="Wrong number of plural forms"):
+            checkers.num_plurals(catalog, message)
+
+
+def test_num_plurals_checker_on_parsed_extra_forms():
+    po_file = b'''\
+msgid ""
+msgstr ""
+"Language: en\\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+
+msgid "file"
+msgid_plural "files"
+msgstr[0] "file"
+msgstr[1] "files"
+msgstr[2] "too many"
+'''
+    catalog = read_po(BytesIO(po_file), 'en')
+    message = catalog['file']
+    assert len(message.string) == 3
+    with pytest.raises(TranslationError, match="Wrong number of plural forms"):
         checkers.num_plurals(catalog, message)
 
 

--- a/tests/messages/test_checkers.py
+++ b/tests/messages/test_checkers.py
@@ -79,8 +79,8 @@ msgstr[0] ""
 
 
 def test_2_num_plurals_checkers():
-    # Extra msgstr[idx] beyond catalog.num_plurals must still be visible
-    # to the checker (not discarded while reading the PO file).
+    # Extra msgstr[idx] is dropped from message.string, but the checker
+    # still reports the mismatch.
     for _locale in [p for p in PLURALS if PLURALS[p][0] == 2]:
         if _locale in ['nn', 'no']:
             _locale = 'nn_NO'
@@ -134,8 +134,7 @@ msgstr[2] ""
 """.encode('utf-8')
         catalog = read_po(BytesIO(po_file), _locale)
         message = catalog['foobar']
-        # Extra msgstr[2] is kept so the checker can report it instead of
-        # silently shrinking the message back to catalog.num_plurals.
+        assert len(message.string) == num_plurals
         with pytest.raises(TranslationError, match="Wrong number of plural forms"):
             checkers.num_plurals(catalog, message)
 
@@ -155,7 +154,8 @@ msgstr[2] "too many"
 '''
     catalog = read_po(BytesIO(po_file), 'en')
     message = catalog['file']
-    assert len(message.string) == 3
+    assert message.string == ('file', 'files')
+    assert message.discarded_plural_forms == 1
     with pytest.raises(TranslationError, match="Wrong number of plural forms"):
         checkers.num_plurals(catalog, message)
 

--- a/tests/messages/test_pofile_read.py
+++ b/tests/messages/test_pofile_read.py
@@ -514,7 +514,7 @@ msgstr[2] "Vohs [text]"
     assert message.string[2] == 'Vohs [text]'
 
 
-def test_plural_forms_beyond_nplurals_are_kept():
+def test_plural_forms_beyond_nplurals_are_discarded():
     buf = StringIO('''\
 msgid ""
 msgstr ""
@@ -529,7 +529,8 @@ msgstr[2] "extra"
     catalog = pofile.read_po(buf, locale='en')
     message = catalog['foo']
     assert catalog.num_plurals == 2
-    assert message.string == ('Voh', 'Vohs', 'extra')
+    assert message.string == ('Voh', 'Vohs')
+    assert message.discarded_plural_forms == 1
 
 
 def test_with_location():

--- a/tests/messages/test_pofile_read.py
+++ b/tests/messages/test_pofile_read.py
@@ -514,6 +514,24 @@ msgstr[2] "Vohs [text]"
     assert message.string[2] == 'Vohs [text]'
 
 
+def test_plural_forms_beyond_nplurals_are_kept():
+    buf = StringIO('''\
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+
+msgid "foo"
+msgid_plural "foos"
+msgstr[0] "Voh"
+msgstr[1] "Vohs"
+msgstr[2] "extra"
+''')
+    catalog = pofile.read_po(buf, locale='en')
+    message = catalog['foo']
+    assert catalog.num_plurals == 2
+    assert message.string == ('Voh', 'Vohs', 'extra')
+
+
 def test_with_location():
     buf = StringIO('''\
 #: main.py:1 \u2068filename with whitespace.py\u2069:123


### PR DESCRIPTION
Fixes #1323.

`read_po` still drops `msgstr[N]` entries where `N >= nplurals` and pads `message.string` to `catalog.num_plurals`, same as it has for a decade. Extra forms are counted on `message.discarded_plural_forms` so `num_plurals()` can fail on a parsed catalog instead of always seeing a matching length.